### PR TITLE
WIP: Add Illumina / Nanopore Hybrid Assembly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ script:
   - nf-core lint ${TRAVIS_BUILD_DIR}
   # Run the pipeline with the test profile
   - nextflow run main.nf -profile test,docker
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_hybrid,docker

--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ The nf-core/mag pipeline comes with documentation about the pipeline, found in t
 
 ### Credits
 
-This pipeline was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se).
+This pipeline was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se) and Daniel Straub ([@d4straub](https://github.com/d4straub)).
+
+Long read processing was inspired by [caspargross/HybridAssembly](https://github.com/caspargross/HybridAssembly) written by Caspar Gross [@caspargross](https://github.com/caspargross)

--- a/bin/combine_tables.py
+++ b/bin/combine_tables.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+#USAGE: ./combine_tables.py <BUSCO_table> <QUAST_table>
+
+import pandas as pd
+from sys import stdout
+from sys import argv
+
+# Read files
+file1 = pd.read_csv(argv[1], sep="\t")
+file2 = pd.read_csv(argv[2], sep="\t")
+
+# Merge files
+result = pd.merge(file1, file2, left_on="GenomeBin", right_on="Assembly", how='outer')
+
+# Print to stdout
+result.to_csv(stdout, sep='\t')

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -11,8 +11,15 @@ regexes = {
     'fastp': ['v_fastp.txt', r"fastp (\S+)"],
     'megahit': ['v_megahit.txt', r"MEGAHIT v(\S+)"],
     'metabat': ['v_metabat.txt', r"version (\S+)"],
-    'checkm': ['v_checkm.txt', r"CheckM v(\S+)"],
-    'refinem': ['v_refinem.txt', r"RefineM v(\S+)"]
+    #'checkm': ['v_checkm.txt', r"CheckM v(\S+)"],
+    #'refinem': ['v_refinem.txt', r"RefineM v(\S+)"],
+    'NanoPlot': ['v_nanoplot.txt', r"NanoPlot (\S+)"],
+    'Filtlong': ['v_filtlong.txt', r"Filtlong v(\S+)"],
+    'porechop': ['v_porechop.txt', r"(\S+)"],
+    'NanoLyse': ['v_nanolyse.txt', r"NanoLyse (\S+)"],
+    'SPAdes': ['v_spades.txt', r"SPAdes v(\S+)"],
+    'BUSCO': ['v_busco.txt', r"BUSCO (\S+)"],
+    'Bandage': ['v_bandage.txt', r"Version: (\S+)"]
 }
 results = OrderedDict()
 results['nf-core/mag'] = '<span style="color:#999999;\">N/A</span>'
@@ -22,8 +29,15 @@ results['fastqc'] = '<span style="color:#999999;\">N/A</span>'
 results['fastp'] = '<span style="color:#999999;\">N/A</span>'
 results['megahit'] = '<span style="color:#999999;\">N/A</span>'
 results['metabat'] = '<span style="color:#999999;\">N/A</span>'
-results['checkm'] = '<span style="color:#999999;\">N/A</span>'
-results['refinem'] = '<span style="color:#999999;\">N/A</span>'
+#results['checkm'] = '<span style="color:#999999;\">N/A</span>'
+#results['refinem'] = '<span style="color:#999999;\">N/A</span>'
+results['NanoPlot'] = '<span style="color:#999999;\">N/A</span>'
+results['Filtlong'] = '<span style="color:#999999;\">N/A</span>'
+results['porechop'] = '<span style="color:#999999;\">N/A</span>'
+results['NanoLyse'] = '<span style="color:#999999;\">N/A</span>'
+results['SPAdes'] = '<span style="color:#999999;\">N/A</span>'
+results['BUSCO'] = '<span style="color:#999999;\">N/A</span>'
+results['Bandage'] = '<span style="color:#999999;\">N/A</span>'
 
 # Search each file using its regex
 for k, v in regexes.items():

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -11,8 +11,6 @@ regexes = {
     'fastp': ['v_fastp.txt', r"fastp (\S+)"],
     'megahit': ['v_megahit.txt', r"MEGAHIT v(\S+)"],
     'metabat': ['v_metabat.txt', r"version (\S+)"],
-    #'checkm': ['v_checkm.txt', r"CheckM v(\S+)"],
-    #'refinem': ['v_refinem.txt', r"RefineM v(\S+)"],
     'NanoPlot': ['v_nanoplot.txt', r"NanoPlot (\S+)"],
     'Filtlong': ['v_filtlong.txt', r"Filtlong v(\S+)"],
     'porechop': ['v_porechop.txt', r"(\S+)"],
@@ -29,8 +27,6 @@ results['fastqc'] = '<span style="color:#999999;\">N/A</span>'
 results['fastp'] = '<span style="color:#999999;\">N/A</span>'
 results['megahit'] = '<span style="color:#999999;\">N/A</span>'
 results['metabat'] = '<span style="color:#999999;\">N/A</span>'
-#results['checkm'] = '<span style="color:#999999;\">N/A</span>'
-#results['refinem'] = '<span style="color:#999999;\">N/A</span>'
 results['NanoPlot'] = '<span style="color:#999999;\">N/A</span>'
 results['Filtlong'] = '<span style="color:#999999;\">N/A</span>'
 results['porechop'] = '<span style="color:#999999;\">N/A</span>'

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -17,7 +17,6 @@ regexes = {
     'NanoLyse': ['v_nanolyse.txt', r"NanoLyse (\S+)"],
     'SPAdes': ['v_spades.txt', r"SPAdes v(\S+)"],
     'BUSCO': ['v_busco.txt', r"BUSCO (\S+)"],
-    'Bandage': ['v_bandage.txt', r"Version: (\S+)"]
 }
 results = OrderedDict()
 results['nf-core/mag'] = '<span style="color:#999999;\">N/A</span>'

--- a/bin/summary_busco.py
+++ b/bin/summary_busco.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+#USAGE: ./summary.busco.py *.txt
+
+import re
+from sys import argv
+
+#"# Summarized benchmarking in BUSCO notation for file MEGAHIT-testset1.contigs.fa"
+#"	C:0.0%[S:0.0%,D:0.0%],F:0.0%,M:100.0%,n:148"
+
+regexes = {
+    'nf-core/mag': ['v_pipeline.txt', r"(\S+)"],
+    'Nextflow': ['v_nextflow.txt', r"(\S+)"],
+    'MultiQC': ['v_multiqc.txt', r"multiqc, version (\S+)"],
+    'fastqc': ['v_fastqc.txt', r"FastQC v(\S+)"],
+    'fastp': ['v_fastp.txt', r"fastp (\S+)"],
+    'megahit': ['v_megahit.txt', r"MEGAHIT v(\S+)"],
+    'metabat': ['v_metabat.txt', r"version (\S+)"],
+    'NanoPlot': ['v_nanoplot.txt', r"NanoPlot (\S+)"],
+    'Filtlong': ['v_filtlong.txt', r"Filtlong v(\S+)"],
+    'porechop': ['v_porechop.txt', r"(\S+)"],
+    'NanoLyse': ['v_nanolyse.txt', r"NanoLyse (\S+)"],
+    'SPAdes': ['v_spades.txt', r"SPAdes v(\S+)"],
+    'BUSCO': ['v_busco.txt', r"BUSCO (\S+)"],
+}
+
+regexes = [r"# Summarized benchmarking in BUSCO notation for file (\S+)", r"	C:(\S+)%\[S:", r"%\[S:(\S+)%,D:", r"%,D:(\S+)%\],F:", r"%\],F:(\S+)%,M:", r"%,M:(\S+)%,n:", r"%,n:(\S+)"]
+columns = ["GenomeBin","%Complete","%Complete and single-copy","%Complete and duplicated","%Fragmented","%Missing","Total number"]
+
+# Search each file using its regex
+print("\t".join(columns))
+for FILE in argv[1:]:
+    with open(FILE) as x:
+        results = []
+        TEXT = x.read()
+        for REGEX in regexes:
+            match = re.search(REGEX, TEXT)
+            if match:
+                results.append( match.group(1) )
+        print("\t".join(results))

--- a/conf/base.config
+++ b/conf/base.config
@@ -17,95 +17,61 @@ process {
   memory = { check_max( 8.GB * task.attempt, 'memory' ) }
   time = { check_max( 2.h * task.attempt, 'time' ) }
 
-  errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'finish' }
-  maxRetries = 3
+  errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  maxRetries = 4
   maxErrors = '-1'
 
   // Process-specific resource requirements
-  withName: fastqc_raw {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
-  withName: fastqc_trimmed {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
-  withName: multiqc {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
   withName: busco_download_db {
+    time = 4.h
+  }
+  withName: phix_download_db {
     time = 4.h
   }
   withName: porechop {
     cpus = { check_max (4 * task.attempt, 'cpus' ) }
     memory = { check_max (30.GB * task.attempt, 'memory' ) }
     time = { check_max (4.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: nanolyse {
     cpus = { check_max (2 * task.attempt, 'cpus' ) }
     memory = { check_max (10.GB * task.attempt, 'memory' ) }
     time = { check_max (3.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   //filtlong: exponential increase of memory and time with attempts
-  //64 GB starting memory might be sufficient
   withName: filtlong {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (256.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (48.h * (2**(task.attempt-1)), 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
   }
   withName: remove_phix {
     cpus = { check_max (4 * task.attempt, 'cpus' ) }
     memory = { check_max (8.GB * task.attempt, 'memory' ) }
     time = { check_max (6.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: megahit {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (40.GB * task.attempt, 'memory' ) }
-    time = { check_max (8.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+    time = { check_max (16.h * task.attempt, 'time' ) }
   }
   //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
-  //exponential increase of memory with attempts
-  //spades: 40 GB memory / 16 h is sufficient for low complexity Illumina-only metagenome
-  //320 GB is not sufficient for complex dataset, also >50h!
+  //exponential increase of memory and time with attempts
   withName: spades {
-    cpus = { check_max (20 * task.attempt, 'cpus' ) }
-    memory = { check_max (512.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (120.h * task.attempt, 'time' ) }
+    cpus = { check_max (10 * task.attempt, 'cpus' ) }
+    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
-  //spadeshybrid: 64 GB / 16 h starting memory might be sufficient
   withName: spadeshybrid {
-    cpus = { check_max (20 * task.attempt, 'cpus' ) }
-    memory = { check_max (512.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (120.h * task.attempt, 'time' ) }
+    cpus = { check_max (10 * task.attempt, 'cpus' ) }
+    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
-  }
-  withName: quast {
-    cpus = { check_max (2 * task.attempt, 'cpus' ) }
-    memory = { check_max (10.GB * task.attempt, 'memory' ) }
-    time = { check_max (2.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: metabat {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (20.GB * task.attempt, 'memory' ) }
     time = { check_max (8.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
-  withName: busco {
-    cpus = { check_max (4 * task.attempt, 'cpus' ) }
-    memory = { check_max (10.GB * task.attempt, 'memory' ) }
-    time = { check_max (4.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
-  withName: busco_plot {
-    cpus = { check_max (1 * task.attempt, 'cpus' ) }
-    memory = { check_max (10.GB * task.attempt, 'memory' ) }
-    time = { check_max (4.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
 }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -64,6 +64,12 @@ process {
     time = { check_max (8.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
+  withName: spadeshybrid {
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    memory = { check_max (20.GB * task.attempt, 'memory' ) }
+    time = { check_max (8.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
   withName: quast {
     cpus = { check_max (2 * task.attempt, 'cpus' ) }
     memory = { check_max (10.GB * task.attempt, 'memory' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -34,7 +34,7 @@ process {
   withName: busco_download_db {
     time = 4.h
   }
-  withName: porcechop {
+  withName: porechop {
     cpus = { check_max (2 * task.attempt, 'cpus' ) }
     memory = { check_max (10.GB * task.attempt, 'memory' ) }
     time = { check_max (3.h * task.attempt, 'time' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -31,10 +31,7 @@ process {
   withName: multiqc {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
-  withName: checkm_download_db {
-    time = 4.h
-  }
-  withName: refinem_download_db {
+  withName: busco_download_db {
     time = 4.h
   }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -67,19 +67,20 @@ process {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
-  //exponential increase of memory and time with attempts
+  //exponential increase of memory with attempts
   //spades: 40 GB memory / 16 h is sufficient for low complexity Illumina-only metagenome
+  //320 GB is not sufficient for complex dataset, also >50h!
   withName: spades {
-    cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (40.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (16.h * (2**(task.attempt-1)), 'time' ) }
+    cpus = { check_max (20 * task.attempt, 'cpus' ) }
+    memory = { check_max (512.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (120.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   //spadeshybrid: 64 GB / 16 h starting memory might be sufficient
   withName: spadeshybrid {
-    cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (256.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (48.h * (2**(task.attempt-1)), 'time' ) }
+    cpus = { check_max (20 * task.attempt, 'cpus' ) }
+    memory = { check_max (512.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (120.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: quast {

--- a/conf/base.config
+++ b/conf/base.config
@@ -46,11 +46,12 @@ process {
     time = { check_max (3.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
-  //filtlong: exponential increase of memory with attempts
+  //filtlong: exponential increase of memory and time with attempts
+  //64 GB starting memory might be sufficient
   withName: filtlong {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (24.h * task.attempt, 'time' ) }
+    memory = { check_max (256.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (48.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: remove_phix {
@@ -66,18 +67,19 @@ process {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
-  //exponential increase of memory with attempts
-  //40 GB memory is sufficient for low complexity Illumina-only metagenome
+  //exponential increase of memory and time with attempts
+  //spades: 40 GB memory / 16 h is sufficient for low complexity Illumina-only metagenome
   withName: spades {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (40.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (16.h * task.attempt, 'time' ) }
+    time = { check_max (16.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
+  //spadeshybrid: 64 GB / 16 h starting memory might be sufficient
   withName: spadeshybrid {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
-    time = { check_max (16.h * task.attempt, 'time' ) }
+    memory = { check_max (256.GB * (2**(task.attempt-1)), 'memory' ) }
+    time = { check_max (48.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: quast {

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,9 +47,9 @@ process {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: filtlong {
-    cpus = { check_max (4 * task.attempt, 'cpus' ) }
-    memory = { check_max (50.GB * task.attempt, 'memory' ) }
-    time = { check_max (6.h * task.attempt, 'time' ) }
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    memory = { check_max (64.GB * task.attempt, 'memory' ) }
+    time = { check_max (24.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: remove_phix {
@@ -68,13 +68,13 @@ process {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (40.GB * task.attempt, 'memory' ) }
     time = { check_max (16.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: spadeshybrid {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (40.GB * task.attempt, 'memory' ) }
     time = { check_max (16.h * task.attempt, 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: quast {
     cpus = { check_max (2 * task.attempt, 'cpus' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -18,7 +18,7 @@ process {
   time = { check_max( 2.h * task.attempt, 'time' ) }
 
   errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'finish' }
-  maxRetries = 1
+  maxRetries = 3
   maxErrors = '-1'
 
   // Process-specific resource requirements
@@ -33,6 +33,60 @@ process {
   }
   withName: busco_download_db {
     time = 4.h
+  }
+  withName: porcechop {
+    cpus = { check_max (2 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (3.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: nanolyse {
+    cpus = { check_max (2 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (3.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: filtlong {
+    cpus = { check_max (2 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (3.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: megahit {
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    memory = { check_max (20.GB * task.attempt, 'memory' ) }
+    time = { check_max (8.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: spades {
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    memory = { check_max (20.GB * task.attempt, 'memory' ) }
+    time = { check_max (8.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: quast {
+    cpus = { check_max (2 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (2.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: metabat {
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    memory = { check_max (20.GB * task.attempt, 'memory' ) }
+    time = { check_max (8.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: busco {
+    cpus = { check_max (4 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (4.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: busco_plot {
+    cpus = { check_max (1 * task.attempt, 'cpus' ) }
+    memory = { check_max (10.GB * task.attempt, 'memory' ) }
+    time = { check_max (4.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
 }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -35,9 +35,9 @@ process {
     time = 4.h
   }
   withName: porechop {
-    cpus = { check_max (2 * task.attempt, 'cpus' ) }
-    memory = { check_max (10.GB * task.attempt, 'memory' ) }
-    time = { check_max (3.h * task.attempt, 'time' ) }
+    cpus = { check_max (4 * task.attempt, 'cpus' ) }
+    memory = { check_max (30.GB * task.attempt, 'memory' ) }
+    time = { check_max (4.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: nanolyse {
@@ -47,27 +47,33 @@ process {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: filtlong {
-    cpus = { check_max (2 * task.attempt, 'cpus' ) }
-    memory = { check_max (10.GB * task.attempt, 'memory' ) }
-    time = { check_max (3.h * task.attempt, 'time' ) }
+    cpus = { check_max (4 * task.attempt, 'cpus' ) }
+    memory = { check_max (50.GB * task.attempt, 'memory' ) }
+    time = { check_max (6.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+  withName: remove_phix {
+    cpus = { check_max (4 * task.attempt, 'cpus' ) }
+    memory = { check_max (8.GB * task.attempt, 'memory' ) }
+    time = { check_max (6.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: megahit {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (20.GB * task.attempt, 'memory' ) }
+    memory = { check_max (40.GB * task.attempt, 'memory' ) }
     time = { check_max (8.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: spades {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (20.GB * task.attempt, 'memory' ) }
-    time = { check_max (8.h * task.attempt, 'time' ) }
+    memory = { check_max (40.GB * task.attempt, 'memory' ) }
+    time = { check_max (16.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: spadeshybrid {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (20.GB * task.attempt, 'memory' ) }
-    time = { check_max (8.h * task.attempt, 'time' ) }
+    memory = { check_max (40.GB * task.attempt, 'memory' ) }
+    time = { check_max (16.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   withName: quast {

--- a/conf/base.config
+++ b/conf/base.config
@@ -46,9 +46,10 @@ process {
     time = { check_max (3.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
+  //filtlong: exponential increase of memory with attempts
   withName: filtlong {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (64.GB * task.attempt, 'memory' ) }
+    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (24.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
@@ -64,15 +65,18 @@ process {
     time = { check_max (8.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
+  //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
+  //exponential increase of memory with attempts
+  //40 GB memory is sufficient for low complexity Illumina-only metagenome
   withName: spades {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (40.GB * task.attempt, 'memory' ) }
+    memory = { check_max (40.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (16.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: spadeshybrid {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
-    memory = { check_max (40.GB * task.attempt, 'memory' ) }
+    memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (16.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }

--- a/conf/binac_smp.config
+++ b/conf/binac_smp.config
@@ -1,0 +1,23 @@
+//Profile config names for nf-core/configs
+params {
+  config_profile_description = 'BINAC cluster profile for jobs requiring >128 GB memory provided by nf-core/configs.'
+  config_profile_contact = 'just a test right now'
+  config_profile_url = 'https://www.bwhpc-c5.de/wiki/index.php/Category:BwForCluster_BinAC'
+}
+
+singularity {
+  enabled = true
+}
+
+process {
+  beforeScript = 'module load devel/singularity/3.0.1'
+  executor = 'pbs'
+  queue = 'smp'
+}
+
+params {
+  igenomes_base = '/nfsmounts/igenomes'
+  max_memory = 1024.GB
+  max_cpus = 40
+  max_time = 730.h
+}

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -1,0 +1,19 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/methylseq -profile test
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 7.GB
+  max_time = 48.h
+  params.outdir = "./tests"
+  params.temp_dir = "./tests/tmp_dir"
+  // Input data
+  singleEnd = false
+  params.manifest = 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/manifest.txt'
+}

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,9 @@ dependencies:
   - conda-forge::r-markdown=0.8
   - checkm-genome=1.0.12
   - refinem=0.0.24
+  #long read specific:
+  #- nanoplot=1.20.0 #python >=3.5 -->incompatible! alternative is pauvre
+  - pauvre=0.1.86=py_1
+  - filtlong=0.2.0=he941832_2
+  #- porechop=0.2.3_seqan2.1.1 #python >=3.5,<3.6.0a0 -->incompatible! alternative is fastp
+  - spades=3.13.0=0

--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,3 @@ dependencies:
   - porechop=0.2.3_seqan2.1.1=py36h2d50403_3
   - nanolyse=1.1.0=py36_1
   - spades=3.13.0=0
-  - bandage=0.8.1=hb59a952_0

--- a/environment.yml
+++ b/environment.yml
@@ -5,27 +5,27 @@ channels:
   - defaults
 dependencies:
   - fastqc=0.11.8
-  - multiqc=1.6
+  - multiqc=1.6=py36h24bf2e0_0
   - fastp=0.19.5
-  - megahit=1.1.3
+  - megahit=1.1.3=py36_0
   - metabat2=2.12.1
   - samtools=1.9
-  - bowtie2=2.3.4.3
-  - quast=5.0.2
+  - bowtie2=2.3.4.3=py36he860b03_1
+  - quast=5.0.2=py36pl526ha92aebf_0
   - hmmer=3.2.1
   - prodigal=2.6.3
   - pplacer=1.1.alpha19
-  - diamond=0.9.22
-  - python=2.7.15
+  - diamond=0.9.24=ha87ae23_0
+  - python=3.6.7=hd21baee_1002
   - r=3.5.1
-  - biopython=1.72
+  - biopython=1.72=py36h04863e7_0
   - krona=2.7
   - conda-forge::r-markdown=0.8
-  - checkm-genome=1.0.12
-  - refinem=0.0.24
-  #long read specific:
-  #- nanoplot=1.20.0 #python >=3.5 -->incompatible! alternative is pauvre
-  - pauvre=0.1.86=py_1
+  - r-ggplot2=3.1.0
+  - busco=3.0.2=py36_10
+  - nanoplot=1.20.0=py36_0
   - filtlong=0.2.0=he941832_2
-  #- porechop=0.2.3_seqan2.1.1 #python >=3.5,<3.6.0a0 -->incompatible! alternative is fastp
+  - porechop=0.2.3_seqan2.1.1=py36h2d50403_3
+  - nanolyse=1.1.0=py36_1
   - spades=3.13.0=0
+  - bandage=0.8.1=hb59a952_0

--- a/main.nf
+++ b/main.nf
@@ -898,10 +898,10 @@ process quast_bins {
     
     for assembly in \"\${assemblies[@]}\"; do
         metaquast.py --threads "${task.cpus}" --max-ref-number 0 --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
-        if ! [ -f "QUAST/${assembler}-quast_summary.tsv" ]; then 
-            cp "QUAST/\${assembly}/transposed_report.tsv" "QUAST/${assembler}-quast_summary.tsv"
+        if ! [ -f "QUAST/${assembler}-${sample}-quast_summary.tsv" ]; then 
+            cp "QUAST/\${assembly}/transposed_report.tsv" "QUAST/${assembler}-${sample}-quast_summary.tsv"
         else
-            tail -n +2 "QUAST/\${assembly}/transposed_report.tsv" >> "QUAST/${assembler}-quast_summary.tsv"
+            tail -n +2 "QUAST/\${assembly}/transposed_report.tsv" >> "QUAST/${assembler}-${sample}-quast_summary.tsv"
         fi
     done    
     """

--- a/main.nf
+++ b/main.nf
@@ -769,6 +769,8 @@ process busco {
     file("short_summary_${assembly}.txt") into (busco_summary_to_multiqc, busco_summary_to_plot)
     val("$assembler-$sample") into busco_assembler_sample_to_plot
     file("${assembly}_busco_log.txt")
+    file("${assembly}_buscos.faa")
+    file("${assembly}_buscos.fna")
 
     script:
     if( workflow.profile.toString().indexOf("conda") == -1) {
@@ -785,6 +787,8 @@ process busco {
             --out ${assembly} \
             >${assembly}_busco_log.txt
         cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+        cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa 2>/dev/null
+        cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna 2>/dev/null
         """
     } else {
         """
@@ -797,6 +801,8 @@ process busco {
             --out ${assembly} \
             >${assembly}_busco_log.txt
         cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+        cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa 2>/dev/null
+        cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna 2>/dev/null
         """
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -387,7 +387,6 @@ if (!params.no_nanolyse) {
 
 /*
  * Quality filter long reads focus on length instead of quality to improve assembly size
- * TODO: Should illumina reads be trimmed/processed before using them here?
  */
 process filtlong {
     tag "$id"
@@ -492,7 +491,6 @@ process fastp {
 
 /*
  * Remove PhiX contamination from Illumina reads
- * TODO: function downloaddb that also makes index
  * TODO: PhiX into/from iGenomes.conf?
  */
 if(!params.keep_phix) {

--- a/main.nf
+++ b/main.nf
@@ -175,11 +175,7 @@ if(!params.keep_phix) {
 
 def returnFile(it) {
 // Return file if it exists
-    if (workflow.profile in ['test', 'localtest'] ) {
-        inputFile = file("$workflow.projectDir/" + it)
-    } else {
-        inputFile = file(it)
-    }
+    inputFile = file(it)
     if (!file(inputFile).exists()) exit 1, "Missing file in TSV file: ${inputFile}, see --help for more information"
     return inputFile
 }

--- a/main.nf
+++ b/main.nf
@@ -149,7 +149,6 @@ params.skip_megahit = false
 params.keep_lambda = false
 params.longreads_min_length = 1000
 params.longreads_keep_percent = 90
-params.filtlong_split = 1000
 params.longreads_length_weight = 10
 params.lambda_reference = "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/viral/Escherichia_virus_Lambda/all_assembly_versions/GCA_000840245.1_ViralProj14204/GCA_000840245.1_ViralProj14204_genomic.fna.gz"
 

--- a/main.nf
+++ b/main.nf
@@ -787,8 +787,15 @@ process busco {
             --out ${assembly} \
             >${assembly}_busco_log.txt
         cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
-        cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa 2>/dev/null
-        cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna 2>/dev/null
+
+        for f in run_${assembly}/single_copy_busco_sequences/*faa; do 
+            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa || touch ${assembly}_buscos.faa
+            break
+        done
+        for f in run_${assembly}/single_copy_busco_sequences/*fna; do 
+            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna || touch ${assembly}_buscos.fna
+            break
+        done
         """
     } else {
         """
@@ -801,8 +808,15 @@ process busco {
             --out ${assembly} \
             >${assembly}_busco_log.txt
         cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
-        cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa 2>/dev/null
-        cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna 2>/dev/null
+
+        for f in run_${assembly}/single_copy_busco_sequences/*faa; do 
+            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa || touch ${assembly}_buscos.faa
+            break
+        done
+        for f in run_${assembly}/single_copy_busco_sequences/*fna; do 
+            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna || touch ${assembly}_buscos.fna
+            break
+        done
         """
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -471,6 +471,7 @@ process fastp {
 /*
  * Remove PhiX contamination from Illumina reads
  * TODO: function downloaddb that also makes index
+ * TODO: PhiX into/from iGenomes.conf?
  */
 if(!params.keep_phix) {
     phix_reference = "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/viral/Enterobacteria_phage_phiX174_sensu_lato/all_assembly_versions/GCA_002596845.1_ASM259684v1/GCA_002596845.1_ASM259684v1_genomic.fna.gz"
@@ -494,20 +495,20 @@ if(!params.keep_phix) {
         if ( !params.singleEnd ) {
             """
             bowtie2-build --threads "${task.cpus}" "${genome}" ref
-            bowtie2 -p "${task.cpus}" -x ref -1 "${reads[0]}" -2 "${reads[1]}" --un-conc-gz unmapped_%.fastq.gz
+            bowtie2 -p "${task.cpus}" -x ref -1 "${reads[0]}" -2 "${reads[1]}" --un-conc-gz ${name}_unmapped_%.fastq.gz
 
             echo "Bowtie2 reference: ${genome}" >${name}_remove_phix_log.txt
             zcat ${reads[0]} | echo "Read pairs before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            zcat unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            zcat ${name}_unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
             """
         } else {
             """
             bowtie2-build --threads "${task.cpus}" "${genome}" ref
-            bowtie2 -p "${task.cpus}" -x ref -U ${reads}  --un-gz unmapped.fastq.gz
+            bowtie2 -p "${task.cpus}" -x ref -U ${reads}  --un-gz ${name}_unmapped.fastq.gz
 
             echo "Bowtie2 reference: $ref" >${name}_remove_phix_log.txt
             zcat ${reads[0]} | echo "Reads before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            zcat unmapped_1.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            zcat ${name}_unmapped.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
             """
         }
 

--- a/main.nf
+++ b/main.nf
@@ -691,7 +691,7 @@ process quast {
 process metabat {
     tag "$assembler-$sample"
     publishDir "${params.outdir}/", mode: 'copy',
-        saveAs: {filename -> filename.indexOf(".bam") == -1 ? "GenomeBinning/$filename" : null}
+        saveAs: {filename -> (filename.indexOf(".bam") == -1 && filename.indexOf(".fastq.gz") == -1) ? "GenomeBinning/$filename" : null}
 
     input:
     set val(assembler), val(sample), file(assembly), file(reads) from assembly_spades_to_metabat.mix(assembly_megahit_to_metabat).mix(assembly_spadeshybrid_to_metabat)

--- a/main.nf
+++ b/main.nf
@@ -679,7 +679,7 @@ process quast {
 
     script:
     """
-    metaquast.py --threads "${task.cpus}" --rna-finding -l "${assembler}-${sample}" "${assembly}" -o "${sample}_QC"
+    metaquast.py --threads "${task.cpus}" --rna-finding --max-ref-number 0 -l "${assembler}-${sample}" "${assembly}" -o "${sample}_QC"
     """
 }
 
@@ -885,7 +885,7 @@ process quast_bins {
         IFS=', ' read -r -a assemblies <<< \"\$ASSEMBLIES\"
     
         for assembly in \"\${assemblies[@]}\"; do
-            metaquast.py --threads "${task.cpus}" --pe1 "${reads[0]}" --pe2 "${reads[1]}" --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
+            metaquast.py --threads "${task.cpus}" --max-ref-number 0 --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
         done    
         """
     } else {
@@ -894,7 +894,7 @@ process quast_bins {
         IFS=', ' read -r -a assemblies <<< \"\$ASSEMBLIES\"
     
         for assembly in \"\${assemblies[@]}\"; do
-            metaquast.py --threads "${task.cpus}" --single "${reads}" --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
+            metaquast.py --threads "${task.cpus}" --max-ref-number 0 --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
         done
         """        
     }

--- a/main.nf
+++ b/main.nf
@@ -772,17 +772,34 @@ process busco {
     file("${assembly}_busco_log.txt")
 
     script:
-    """
-    run_BUSCO.py \
-        --in ${assembly} \
-        --lineage_path $db_name \
-        --cpu "${task.cpus}" \
-        --blast_single_core \
-        --mode genome \
-        --out ${assembly} \
-        >${assembly}_busco_log.txt
-    cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
-    """
+    if( workflow.profile.toString().indexOf("conda") == -1) {
+        """
+        cp -r /opt/conda/pkgs/augustus-3.3-pl526hcfae127_4/config augustus_config/
+        export AUGUSTUS_CONFIG_PATH=augustus_config
+
+        run_BUSCO.py \
+            --in ${assembly} \
+            --lineage_path $db_name \
+            --cpu "${task.cpus}" \
+            --blast_single_core \
+            --mode genome \
+            --out ${assembly} \
+            >${assembly}_busco_log.txt
+        cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+        """
+    } else {
+        """
+        run_BUSCO.py \
+            --in ${assembly} \
+            --lineage_path $db_name \
+            --cpu "${task.cpus}" \
+            --blast_single_core \
+            --mode genome \
+            --out ${assembly} \
+            >${assembly}_busco_log.txt
+        cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+        """
+    }
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -873,7 +873,7 @@ process quast_bins {
     set val(assembler), val(sample), file(assembly), file(reads) from metabat_bins_quast_bins
 
     output:
-    file("QUAST/${assembler}/${sample}/*")
+    file("QUAST/*")
 
     when:
     !params.skip_quast
@@ -881,11 +881,21 @@ process quast_bins {
     script:
     if ( !params.singleEnd ) {
         """
-        metaquast.py --threads "${task.cpus}" --pe1 "${reads[0]}" --pe2 "${reads[1]}" --rna-finding --gene-finding -l "${assembler}-${sample}" "${assembly}" -o "QUAST/${assembler}/${sample}"
+        ASSEMBLIES=\$(echo \"$assembly\" | sed 's/[][]//g')
+        IFS=', ' read -r -a assemblies <<< \"\$ASSEMBLIES\"
+    
+        for assembly in \"\${assemblies[@]}\"; do
+            metaquast.py --threads "${task.cpus}" --pe1 "${reads[0]}" --pe2 "${reads[1]}" --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
+        done    
         """
     } else {
         """
-        metaquast.py --threads "${task.cpus}" --single "${reads}" --rna-finding --gene-finding -l "${assembler}-${sample}" "${assembly}" -o "QUAST/${assembler}/${sample}"
+        ASSEMBLIES=\$(echo \"$assembly\" | sed 's/[][]//g')
+        IFS=', ' read -r -a assemblies <<< \"\$ASSEMBLIES\"
+    
+        for assembly in \"\${assemblies[@]}\"; do
+            metaquast.py --threads "${task.cpus}" --single "${reads}" --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
+        done
         """        
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -831,11 +831,13 @@ process busco_plot {
 
     output:
     file("*busco_figure.png")
-    file("*busco_figure.R")
+    file("raw/*busco_figure.R")
+    file("*busco_summary.txt")
 
     script:
     def assemblersampleunique = assemblersample.unique()
     """
+    #for each assembler and sample:
     assemblersample=\$(echo \"$assemblersampleunique\" | sed 's/[][]//g')
     IFS=', ' read -r -a assemblersamples <<< \"\$assemblersample\"
 
@@ -843,9 +845,17 @@ process busco_plot {
         mkdir \${name}
         cp short_summary_\${name}* \${name}/
         generate_plot.py --working_directory \${name}
+        
         cp \${name}/busco_figure.png \${name}-busco_figure.png
         cp \${name}/busco_figure.R \${name}-busco_figure.R
+
+        summary_busco.py \${name}/short_summary_*.txt >\${name}-busco_summary.txt
     done
+
+    mkdir raw
+    cp *-busco_figure.R raw/
+
+    summary_busco.py short_summary_*.txt >busco_summary.txt
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -118,13 +118,13 @@ if( !(workflow.runName ==~ /[a-z]+_[a-z]+/) ){
 }
 
 /*
- * trimming options
+ * short read preprocessing options
  */
 params.adapter_forward = "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA"
 params.adapter_reverse = "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
 params.mean_quality = 15
 params.trimming_quality = 15
-params.keep_phix
+params.keep_phix = false
 
 /*
  * binning options
@@ -299,9 +299,16 @@ process get_software_versions {
     #printf "\$chd\\n\$chd\\n" | checkm data setRoot
 
     #checkm -h > v_checkm.txt
-    echo unknown > v_checkm.txt
     #refinem -h > v_refinem.txt
-    echo unknown > v_refinem.txt
+
+    NanoPlot --version > v_nanoplot.txt
+    filtlong --version > v_filtlong.txt
+    porechop --version > v_porechop.txt
+    NanoLyse --version > v_nanolyse.txt
+    spades.py --version > v_spades.txt
+    run_BUSCO.py --version > v_busco.txt
+    Bandage --version > v_bandage.txt
+
     scrape_software_versions.py > software_versions_mqc.yaml
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -319,11 +319,11 @@ if (!params.skip_adapter_trimming) {
         tag "$id"
             
         input:
-        set id, lr, sr1, sr2 from files_all_raw
+        set id, file(lr), sr1, sr2 from files_all_raw
         
         output:
         set id, file("${id}_porechop.fastq"), sr1, sr2 into files_porechop
-        set id, lr, val("raw") into files_nanoplot_raw
+        set id, file(lr), val("raw") into files_nanoplot_raw
         
         script:
         """
@@ -353,10 +353,10 @@ if (!params.keep_lambda) {
             saveAs: {filename -> filename.indexOf(".fastq.gz") == -1 ? "QC_longreads/NanoLyse/$filename" : null}
             
         input:
-        set id, file(lr), sr1, sr2, file(nanolyse_db) from files_porechop.combine(file_nanolyse_db)
+        set id, file(lr), file(sr1), file(sr2), file(nanolyse_db) from files_porechop.combine(file_nanolyse_db)
 
         output:
-        set id, file("${id}_nanolyse.fastq.gz"), sr1, sr2 into files_nanolyse
+        set id, file("${id}_nanolyse.fastq.gz"), file(sr1), file(sr2) into files_nanolyse
         file("${id}_nanolyse_log.txt")
     
         script:
@@ -381,7 +381,7 @@ process filtlong {
     tag "$id"
 
     input: 
-    set id, lr, sr1, sr2 from files_nanolyse
+    set id, file(lr), file(sr1), file(sr2) from files_nanolyse
     
     output:
     set id, file("${id}_lr_filtlong.fastq.gz") into files_lr_filtered 
@@ -409,7 +409,7 @@ process nanoplot {
     publishDir "${params.outdir}/QC_longreads/NanoPlot_${id}", mode: 'copy'
     
     input:
-    set id, lr, type from files_nanoplot_raw.mix(files_nanoplot_filtered)
+    set id, file(lr), type from files_nanoplot_raw.mix(files_nanoplot_filtered)
 
     output:
     file '*.png'

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,12 +28,6 @@ params {
 includeConfig 'conf/base.config'
 
 // Load nf-core custom profiles from different Institutions
-includeConfig "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}/nfcore_custom.config"
-
-// Load base.config by default for all pipelines
-includeConfig 'conf/base.config'
-
-// Load nf-core custom profiles from different Institutions
 try {
   includeConfig "${params.custom_config_base}/nfcore_custom.config"
 } catch (Exception e) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
   clusterOptions = false
   tracedir = "${params.outdir}/pipeline_info"
   custom_config_version = 'master'
+  custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 }
 
 // load base config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,9 @@ profiles {
   test {
     includeConfig 'conf/test.config'
   }
+  binac_smp {
+    includeConfig 'conf/binac_smp.config'
+  }
   none {
     // Don't load any config (for use with custom home configs)
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,9 @@ profiles {
   test {
     includeConfig 'conf/test.config'
   }
+  test_hybrid {
+    includeConfig 'conf/test_hybrid.config'
+  }
   binac_smp {
     includeConfig 'conf/binac_smp.config'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,16 @@ includeConfig 'conf/base.config'
 // Load nf-core custom profiles from different Institutions
 includeConfig "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}/nfcore_custom.config"
 
+// Load base.config by default for all pipelines
+includeConfig 'conf/base.config'
+
+// Load nf-core custom profiles from different Institutions
+try {
+  includeConfig "${params.custom_config_base}/nfcore_custom.config"
+} catch (Exception e) {
+  System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
+}
+
 profiles {
   conda { process.conda = "$baseDir/environment.yml" }
   docker {


### PR DESCRIPTION
This is still work in progress and needs polishing, also documentation isn't updated yet, however core functions work.

### Additions:
- Input via manifest file to allow Illumina & Nanopore files for multiple samples
- Illumina reads: PhiX removal
- Nanopore reads quality plots: https://github.com/wdecoster/NanoPlot
- Nanopore reads quality filtering: https://github.com/rrwick/Filtlong
- Nanopore reads removing adapters: https://github.com/rrwick/Porechop
- Nanopore reads: Lambda removal: https://github.com/wdecoster/nanolyse
- Hybrid assembly: https://github.com/ablab/spades
- ~~Assembly graph visualization: https://github.com/rrwick/Bandage~~
- Bin quality check: https://gitlab.com/ezlab/busco & http://quast.sourceforge.net/metaquast

### Problems:
Most of the above mentioned additions require python 3, therefore I upgraded from python 2 to 3, this means:
- replace CheckM with BUSCO for quantitative measures for the assessment of genome assembly
- loose CheckM merge genome bins
- loose RefineM

Solution might be to either come up with alternative programs or add a second environment with python 2.7 and CheckM/RefineM as done in https://github.com/nf-core/rnafusion/blob/dev/download-singularity-img.nf

### Ideas for further improvement:
- Assembly: allow assembly of multiple samples instead/ in addition to treating them individually
- Binning: improve binning by using depth information from several samples when available with `jgi_summarize_bam_contig_depths --outputDepth depth.txt *.bam` as decribed in https://bitbucket.org/berkeleylab/metabat