### PR TITLE
Fixed missing MultiQC when quast or busco is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix links in README
 - Fix MetaBAT2 binning discards unbinned contigs [#27](https://github.com/nf-core/mag/issues/27)
+- Fix missing MultiQC when `--skip_quast` or `--skip_busco` was specified
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -1106,8 +1106,8 @@ process multiqc {
     file (mqc_custom_config) from ch_multiqc_custom_config.collect().ifEmpty([])
     file (fastqc_raw:'fastqc/*') from fastqc_results.collect().ifEmpty([])
     file (fastqc_trimmed:'fastqc/*') from fastqc_results_trimmed.collect().ifEmpty([])
-    file ('quast*/*') from quast_results.collect()
-    file ('short_summary_*.txt') from busco_summary_to_multiqc.collect()
+    file ('quast*/*') from quast_results.collect().ifEmpty([])
+    file ('short_summary_*.txt') from busco_summary_to_multiqc.collect().ifEmpty([])
     file ('software_versions/*') from ch_software_versions_yaml.collect()
     file workflow_summary from ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")
 


### PR DESCRIPTION
The `multiqc` process required as input the output from quast and busco, i.e. no MultiQC report was generated when `--skip_quast` or `--skip_busco` was specified. Added `.ifEmpty([])` to fix this. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
