### PR TITLE
Fixed missing input when --keep_phix is specified

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -511,7 +511,7 @@ if(!params.keep_phix) {
 
     }
 } else {
-    trimmed_reads.into {trimmed_reads_megahit; trimmed_reads_metabat; trimmed_reads_fastqc; trimmed_sr_spadeshybrid; trimmed_reads_spades; trimmed_reads_centrifuge}
+    trimmed_reads.into {trimmed_reads_megahit; trimmed_reads_metabat; trimmed_reads_fastqc; trimmed_sr_spadeshybrid; trimmed_reads_spades; trimmed_reads_centrifuge; trimmed_reads_kraken2; trimmed_reads_bowtie2}
 }
 
 


### PR DESCRIPTION
When `--keep_phix` is specified, reads were not redirected to channels `trimmed_reads_kraken2` and `trimmed_reads_bowtie2`, which causes errors (when the downstream processes using them are not explicitly turned off). Fixed that.

In case that was on purpose and the parameter `--keep_phix` should only be used with certain parameter combinations, this should be caught before.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
