### PR TITLE
Adjusted handling of compressed tar archive containing kraken2 database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix missing MultiQC when `--skip_quast` or `--skip_busco` was specified
 - Fix missing channels when `--keep_phix` is specified
 - Added missing parameters to summary
+- Updated links to minikraken db
+- Fixed kraken2 dp preparation: allow different names for compressed archive file and contained folder as for some minikraken dbs
 
 ### `Deprecated`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -228,7 +228,7 @@ Database for taxonomic binning with centrifuge (default: none). E.g. "<ftp://ftp
 
 ### `--kraken2_db`
 
-Database for taxonomic binning with kraken2 (default: none). E.g. "<ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken2_v2_8GB_201904_UPDATE.tgz>"
+Database for taxonomic binning with kraken2 (default: none). E.g. "<ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz>"
 
 ### `--cat_db`
 

--- a/main.nf
+++ b/main.nf
@@ -70,7 +70,7 @@ def helpMessage() {
 
     Taxonomy:
       --centrifuge_db [file]                Database for taxonomic binning with centrifuge (default: none). E.g. "ftp://ftp.ccb.jhu.edu/pub/infphilo/centrifuge/data/p_compressed+h+v.tar.gz"
-      --kraken2_db [file]                   Database for taxonomic binning with kraken2 (default: none). E.g. "ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken2_v2_8GB_201904_UPDATE.tgz"
+      --kraken2_db [file]                   Database for taxonomic binning with kraken2 (default: none). E.g. "ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz"
       --skip_krona [bool]                   Skip creating a krona plot for taxonomic binning
       --cat_db [file]                       Database for taxonomic classification of metagenome assembled genomes (default: none). E.g. "tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20190108.tar.gz"
                                             The zipped file needs to contain a folder named "*taxonomy*" and "*CAT_database*" that hold the respective files.
@@ -777,7 +777,7 @@ process kraken2_db_preparation {
     file(db) from file_kraken2_db
 
     output:
-    set val("${db.baseName}"), file("${db.baseName}/*.k2d") into kraken2_database
+    set val("${db.baseName}"), file("*/*.k2d") into kraken2_database
 
     script:
     """


### PR DESCRIPTION
Adjusted handling of the compressed tar archive file containing the kraken2 database in the process `kraken2_db_preparation`. So far it was assumed that the name of the contained folder within the tar archive equals the base name of the compressed tar archive file. For the provided MiniKraken2 database this is not always the case, i.e. sometimes only a prefix matches but without a consistent pattern (see also https://ccb.jhu.edu/software/kraken2/index.shtml?t=downloads). 
Since I did not want to make any further assumptions on the folder name, I changed this to use all *.k2d in any contained folder, assuming each provided db file contains exactly one folder with *.k2d files. 

Additionally I updated the links in the help and documentation to the minikraken2 database, which was recently updated.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
