### PR TITLE
Fixed metabat input channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added missing parameters to summary
 - Updated links to minikraken db
 - Fixed kraken2 dp preparation: allow different names for compressed archive file and contained folder as for some minikraken dbs
+- Fixed channel joining for multiple samples causing MetaBAT2 error [#32](https://github.com/nf-core/mag/issues/32)
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -1019,7 +1019,7 @@ process bowtie2 {
         """
 }
 
-assembly_mapping_for_metabat = assembly_mapping_for_metabat.groupTuple(by:[0,1]).join(assembly_all_to_metabat_copy)
+assembly_mapping_for_metabat = assembly_mapping_for_metabat.groupTuple(by:[0,1]).join(assembly_all_to_metabat_copy, by:[0,1])
 
 assembly_mapping_for_metabat = assembly_mapping_for_metabat.dump(tag:'assembly_mapping_for_metabat')
 
@@ -1029,7 +1029,7 @@ process metabat {
         saveAs: {filename -> (filename.indexOf(".bam") == -1 && filename.indexOf(".fastq.gz") == -1) ? "GenomeBinning/$filename" : null}
 
     input:
-    set val(assembler), val(sample), file(bam), file(index), val(sampleCopy), file(assembly) from assembly_mapping_for_metabat
+    set val(assembler), val(sample), file(bam), file(index), file(assembly) from assembly_mapping_for_metabat
     val(min_size) from params.min_contig_size
     val(max_unbinned) from params.max_unbinned_contigs
     val(min_length_unbinned) from params.min_length_unbinned_contigs


### PR DESCRIPTION
Fixed problem described in https://github.com/nf-core/mag/issues/32. There is a problem with the input channel for metabat, where assembly mappings and the assembly from wrong samples are joined. 

The input channel is created by joining the following two channels:

- `assembly_mapping_for_metabat.groupTuple(by:[0,1])`: 
   [MEGAHIT, SAMPLE_ID1, [MEGAHIT-SAMPLE_ID1-SAMPLE_ID1.bam, MEGAHIT-SAMPLE_ID1-SAMPL_ID2.bam], [MEGAHIT-SAMPLE_ID1-SAMPLE_ID1.bam.bai, MEGAHIT-SAMPLE_ID1-SAMPLE_ID2.bam.bai, MEGAHIT-SAMPLE_ID1-SAMPLE_ID1.bam.bai]]
   ...
- `assembly_all_to_metabat_copy`: 
   [MEGAHIT, SAMPLE_ID1, SAMPLE_ID1.contigs.fa]
   ...

Those two channels are currently joined with default parameters, thus by index 0 which is the assembler name and not the sample name. This did not cause a problem for single-sample analyses or when, by chance, the order of the emitted assemblies and assembly mappings was not changed during the run. However, this resulted in cases where assembly mappings and assembly from different samples are joined and caused the in PR #53 observed error, due to wrong contigs.

Fixed this by using `join`with parameter `by:[0,1]` to join by assembler name and sample name.


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
