### PR TITLE
Fix number of threads used by MetaBAT2 program jgi_summarize_bam_contig_depths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added missing parameters to summary
 - Updated links to minikraken db
 - Fixed kraken2 dp preparation: allow different names for compressed archive file and contained folder as for some minikraken dbs
+- Fix number of threads used by MetaBAT2 program `jgi_summarize_bam_contig_depths`
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -1046,7 +1046,7 @@ process metabat {
     script:
     def name = "${assembler}-${sample}"
     """
-    jgi_summarize_bam_contig_depths --outputDepth depth.txt ${bam}
+    OMP_NUM_THREADS=${task.cpus} jgi_summarize_bam_contig_depths --outputDepth depth.txt ${bam}
     metabat2 -t "${task.cpus}" -i "${assembly}" -a depth.txt -o "MetaBAT2/${name}" -m ${min_size} --unbinned
 
     #save unbinned contigs above thresholds into individual files, dump others in one file


### PR DESCRIPTION
The `jgi_summarize_bam_contig_depths` program of MetaBAT2 uses by default all available threads (max. the number of samples).
Fixed the number of threads used with OpenMP OMP_NUM_THREADS environment variable. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
