### PR TITLE
Adjusted handling of MetaBAT2 output files

### DIFF
--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -51,5 +51,5 @@ for index, row in df.iterrows():
 
 print("write "+out_base+".pooled.fa")
 SeqIO.write(pooled, out_base+".pooled.fa", "fasta")
-print("write "+out_base+".fa.remaining")
-SeqIO.write(remaining, out_base+".fa.remaining", "fasta")
+print("write "+out_base+".remaining.fa")
+SeqIO.write(remaining, out_base+".remaining.fa", "fasta")

--- a/main.nf
+++ b/main.nf
@@ -1051,6 +1051,13 @@ process metabat {
 
     #save unbinned contigs above thresholds into individual files, dump others in one file
     split_fasta.py MetaBAT2/${name}.unbinned.fa ${min_length_unbinned} ${max_unbinned} ${min_size}
+
+    mkdir MetaBAT2/discarded
+    mv MetaBAT2/${name}.lowDepth.fa MetaBAT2/discarded/
+    mv MetaBAT2/${name}.tooShort.fa MetaBAT2/discarded/
+    mv MetaBAT2/${name}.unbinned.pooled.fa MetaBAT2/discarded/
+    mv MetaBAT2/${name}.unbinned.remaining.fa MetaBAT2/discarded/
+
     #rename splitted file so that it doesnt end up in following processes
     mv MetaBAT2/${name}.unbinned.fa ${name}.unbinned.fa
     """


### PR DESCRIPTION
I introduced a bug by updating Metabat2 to v2.15 in PR #56: this version of MetaBAT2 outputs additional files "\*.lowDepth.fa" and "\*.tooShort.fa", which might be empty and cause problems when passed forward to the process `quast_bins`.

To fix this, and since those files should anyway not be processed further, I moved all the unbinned FASTA files that are smaller than `--min_length_unbinned_contigs` (i.e. \*.tooShort.fa, \*.lowDepth.fa, \*.unbinned.pooled.fa, \*.unbinned.remaining.fa) to a folder `discarded`. However, those files will still be published. Additionally I renamed the file "\*.unbinned.fa.remaining" to "\*.unbinned.remaining.fa" for the sake of consistency.

@d4straub do you think that's OK in this way and the naming of the files ending up in the results folder should stay like this? If yes, some information about this could be added to the `output.md`

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
