### PR TITLE
Fixed problem with quast_bins output dir when copying files from scratch

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1193,7 +1193,7 @@ process quast_bins {
     set val(assembler), val(sample), file(assembly) from metabat_bins_quast_bins
 
     output:
-    file("QUAST/*/*")
+    path("QUAST/*") type('dir')
     file("QUAST/*-quast_summary.tsv") into quast_bin_summaries
 
     when:
@@ -1203,7 +1203,7 @@ process quast_bins {
     """
     ASSEMBLIES=\$(echo \"$assembly\" | sed 's/[][]//g')
     IFS=', ' read -r -a assemblies <<< \"\$ASSEMBLIES\"
-    
+
     for assembly in \"\${assemblies[@]}\"; do
         metaquast.py --threads "${task.cpus}" --max-ref-number 0 --rna-finding --gene-finding -l "\${assembly}" "\${assembly}" -o "QUAST/\${assembly}"
         if ! [ -f "QUAST/${assembler}-${sample}-quast_summary.tsv" ]; then 
@@ -1211,7 +1211,7 @@ process quast_bins {
         else
             tail -n +2 "QUAST/\${assembly}/transposed_report.tsv" >> "QUAST/${assembler}-${sample}-quast_summary.tsv"
         fi
-    done    
+    done
     """
 }
 


### PR DESCRIPTION
Another follow-up PR for #62. 

Specifying output files as "QUAST/\*/\*" doesn't work in combination with `scratch = true`, because during the unstaging of the output files (i.e. copying back from scratch to the work dir), a folder "QUAST/*" will be created and all results files for all assemblies will be copied into this.

To fix this I now used "QUAST/\*" in combination with `type('dir')` to ensure only subdirectories in "QUAST/" are specified, and thus to avoid publishing "QUAST/\*-quast_summary.tsv" twice.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
