### PR TITLE
Added parameters to ensure reproducible results from tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add separate MultiQC section for FastQC after preprocessing
 - Add social preview image
 - Add MetaBAT2 RNG seed parameter `--metabat_rng_seed` and set the default to 1 which ensures reproducible binning results
+- Add parameters `--megahit_fix_cpu_1`, `--spades_fix_cpus` and `--spadeshybrid_fix_cpus` to ensure reproducible results from assembly tools
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add host read removal with Bowtie 2 and according custom section to MultiQC
 - Add separate MultiQC section for FastQC after preprocessing
 - Add social preview image
+- Add MetaBAT2 RNG seed parameter `--metabat_rng_seed` and set the default to 1 which ensures reproducible binning results
 
 ### `Fixed`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -81,20 +81,20 @@ process {
     time = { check_max (12.h * task.attempt, 'time' ) }
   }
   withName: megahit {
-    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+    cpus = { check_megahit_cpus (8, task.attempt ) }
     memory = { check_max (40.GB * task.attempt, 'memory' ) }
     time = { check_max (16.h * task.attempt, 'time' ) }
   }
   //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
-  //exponential increase of memory and time with attempts
+  //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
   withName: spades {
-    cpus = { check_max (10 * task.attempt, 'cpus' ) }
+    cpus = { check_spades_cpus (10, task.attempt) }
     memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
   }
   withName: spadeshybrid {
-    cpus = { check_max (10 * task.attempt, 'cpus' ) }
+    cpus = { check_spadeshybrid_cpus (10, task.attempt) }
     memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
     errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,6 +86,13 @@ First, go to the [nf-core/mag releases page](https://github.com/nf-core/mag/rele
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
 
+Additionally, to ensure reproducible results from the individual tools there are a few aspects to be aware of.
+SPAdes is designed to be deterministic for a given number of threads. Thus to reproduce the results, just make sure to use the same number of threads when re-running the pipeline.
+To ensure reproducible results from MEGAHIT, run MEGAHIT single threaded by specifying `cpus = 1` for this process.
+
+MetaBAT2 is run by default with a fixed seed within this pipeline.
+
+
 ## Main arguments
 
 ### `-profile`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,12 +86,10 @@ First, go to the [nf-core/mag releases page](https://github.com/nf-core/mag/rele
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
 
-Additionally, to ensure reproducible results from the individual tools there are a few aspects to be aware of.
-SPAdes is designed to be deterministic for a given number of threads. Thus to reproduce the results, just make sure to use the same number of threads when re-running the pipeline.
-To ensure reproducible results from MEGAHIT, run MEGAHIT single threaded by specifying `cpus = 1` for this process.
+Additionally, to enable also reproducible results from the individual assembly tools this pipeline provides extra parameters. SPAdes is designed to be deterministic for a given number of threads. To generate reproducible results set the number of cpus with `--spades_fix_cpus` or `--spadeshybrid_fix_cpus`. This will overwrite the number of cpus specified in the `base.config` file and additionally ensure that it is not increased in case of retries for individual samples. MEGAHIT only generates reproducible results when run single-threaded.
+You can fix this by using the prameter `--megahit_fix_cpu_1`. In both cases, do not specify the number of cpus for these processes in additional custom config files, this would result in an error.
 
-MetaBAT2 is run by default with a fixed seed within this pipeline.
-
+MetaBAT2 is run by default with a fixed seed within this pipeline, thus producing reproducible results.
 
 ## Main arguments
 
@@ -242,6 +240,20 @@ Database for taxonomic binning with kraken2 (default: none). E.g. "<ftp://ftp.cc
 Database for taxonomic classification of metagenome assembled genomes (default: none). E.g. "<tbb.bio.uu.nl/bastiaan/CAT*prepare/CAT_prepare_20190108.tar.gz>"
 The zipped file needs to contain a folder named "\_taxonomy*" and "_CAT_database_" that hold the respective files.
 
+## Assembly options
+
+### `--megahit_fix_cpu_1`
+
+Fix number of CPUs for MEGAHIT to 1. Not increased with retries (default: false). See also [Reproducibility](#reproducibility).
+
+### `--spades_fix_cpus`
+
+Fixed number of CPUs used by SPAdes. Not increased with retries (default: none).
+
+### `--spadeshybrid_fix_cpus`
+
+Fixed number of CPUs used by SPAdes hybrid. Not increased with retries (default: none).
+
 ## Binning options
 
 ### `--min_contig_size`
@@ -266,7 +278,7 @@ Contigs that do not fulfill the thresholds of `--min_length_unbinned_contigs` an
 ### `--metabat_rng_seed`
 
 RNG seed for MetaBAT2. Use postive integer to ensure reproducibility (default: 1).
-Set to 0 to use random seed. 
+Set to 0 to use random seed.
 
 ## Job resources
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -256,6 +256,11 @@ Contigs that do not fulfill the thresholds of `--min_length_unbinned_contigs` an
 Maximal number of contigs that are not part of any bin but treated as individual genome (default: 100)
 Contigs that do not fulfill the thresholds of `--min_length_unbinned_contigs` and `--max_unbinned_contigs` are pooled for downstream analysis and reporting, except contigs that also do not fullfill `--min_contig_size` are not considered further.
 
+### `--metabat_rng_seed`
+
+RNG seed for MetaBAT2. Use postive integer to ensure reproducibility (default: 1).
+Set to 0 to use random seed. 
+
 ## Job resources
 
 ### Automatic resubmission

--- a/main.nf
+++ b/main.nf
@@ -80,6 +80,7 @@ def helpMessage() {
       --min_contig_size [int]               Minimum contig size to be considered for binning and for bin quality check (default: 1500)
       --min_length_unbinned_contigs [int]   Minimal length of contigs that are not part of any bin but treated as individual genome (default: 1000000)
       --max_unbinned_contigs [int]          Maximal number of contigs that are not part of any bin but treated as individual genome (default: 100)
+      --metabat_rng_seed [int]              RNG seed for MetaBAT2. Use postive integer to ensure reproducibility (default: 1). Set to 0 to use random seed.
 
     Bin quality check:
       --skip_busco [bool]                   Disable bin QC with BUSCO (default: false)
@@ -294,6 +295,7 @@ if (!params.skip_binning) {
     summary['Min contig size']              = params.min_contig_size
     summary['Min length unbinned contigs']  = params.min_length_unbinned_contigs
     summary['Max unbinned contigs']         = params.max_unbinned_contigs
+    summary['MetaBAT2 RNG seed']            = params.metabat_rng_seed
 }
 summary['Skip busco']           = params.skip_busco ? 'Yes' : 'No'
 if(!params.skip_busco) summary['Busco Reference']   = params.busco_reference
@@ -1042,7 +1044,7 @@ process metabat {
     def name = "${assembler}-${sample}"
     """
     OMP_NUM_THREADS=${task.cpus} jgi_summarize_bam_contig_depths --outputDepth depth.txt ${bam}
-    metabat2 -t "${task.cpus}" -i "${assembly}" -a depth.txt -o "MetaBAT2/${name}" -m ${min_size} --unbinned
+    metabat2 -t "${task.cpus}" -i "${assembly}" -a depth.txt -o "MetaBAT2/${name}" -m ${min_size} --unbinned --seed ${params.metabat_rng_seed}
 
     #save unbinned contigs above thresholds into individual files, dump others in one file
     split_fasta.py MetaBAT2/${name}.unbinned.fa ${min_length_unbinned} ${max_unbinned} ${min_size}

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,7 @@ params {
   min_contig_size = 1500
   min_length_unbinned_contigs = 1000000
   max_unbinned_contigs = 100
+  metabat_rng_seed = 1
 
   // assembly options
   skip_spades = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,6 @@ params {
   min_contig_size = 1500
   min_length_unbinned_contigs = 1000000
   max_unbinned_contigs = 100
-  metabat_rng_seed = 1
 
   // assembly options
   skip_spades = false
@@ -57,6 +56,12 @@ params {
   longreads_length_weight = 10
   // lambda_reference = "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/viral/Escherichia_virus_Lambda/all_assembly_versions/GCA_000840245.1_ViralProj14204/GCA_000840245.1_ViralProj14204_genomic.fna.gz"
   lambda_reference = "$baseDir/assets/data/GCA_000840245.1_ViralProj14204_genomic.fna.gz"
+
+  // Reproducibility options
+  megahit_fix_cpu_1 = false
+  spades_fix_cpus = false
+  spadeshybrid_fix_cpus = false
+  metabat_rng_seed = 1
 
   // Boilerplate options
   name = false
@@ -190,4 +195,19 @@ def check_max(obj, type) {
       return obj
     }
   }
+}
+
+// Funktions to fix number of cpus to allow reproducibility for MEGAHIT and SPAdes
+// if corresponding parameters are specified, number of cpus is not increased with retries
+def check_megahit_cpus (x, attempt ) {
+  if (params.megahit_fix_cpu_1) return 1
+  else return check_max (x * attempt, 'cpus' )
+}
+def check_spades_cpus (x, attempt ) {
+  if (params.spades_fix_cpus) return check_max (params.spades_fix_cpus, 'cpus' )
+  else return check_max (x * attempt, 'cpus' )
+}
+def check_spadeshybrid_cpus (x, attempt ) {
+  if (params.spadeshybrid_fix_cpus) return check_max (params.spadeshybrid_fix_cpus, 'cpus' )
+  else return check_max (x * attempt, 'cpus' )
 }


### PR DESCRIPTION
So far it was not possible to generate reproducible results with the tools MEGAHIT, SPAdes and MetaBAT2 within this pipeline. For MetaBAT2 this could be simply changed by using its seed parameter. I set it to 1 by default and added this as a pipeline parameter `--metabat_rng_seed`.

For MEGAHIT and SPAdes there is unfortunately no seed option. MEGAHIT can only ensure reproducible results when run single-threaded (https://github.com/voutcn/megahit/issues/170). SPAdes on the other hand was designed to generate reproducible results for a given number of threads (https://github.com/ablab/spades/issues/111). 

For this reason I added parameters to fix the number of cpus for those processes, for MEGAHIT to 1 (`--megahit_fix_cpu_1`) and for SPAdes to some fixed number (`--spades_fix_cpus`, `--spadeshybrid_fix_cpus`). For the sake of runtime efficiency, by default those parameters are not set in order to allow MEGAHIT running multi-threaded.

When these parameters are used, it is also ensured that the number of cpus will not be increased for retries. This is important for reproducing previous results but also to generate reproducible results, because otherwise a different number of cpus could be used for different samples. 

I wrote new functions (defined in `nextflow.config`) to set the cpus accordingly for those processes, which are called in the `base.config` file. In theory, those settings can be overwritten by the user with an additional custom config file (`-c`), changing the cpus of the corresponding processes. (I did not find any way how to check for this)  To make sure that only with, for example,  `--spades_fix_cpus` specified cpus are used, this is checked in the actual process script. If the `task.cpus` does not fit to the parameters, an error is returned.

It is also additionally checked at the beginning of the pipeline if the number of cpus is available, i.e. if `--spades_fix_cpus`, `--spadeshybrid_fix_cpus` <= `max_cpus` (instead of allowing that the number of cpus is reduced to `max_cpus`in `check_max()`).

The parameters are added to the summary.

Any feedback welcome :)







## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
