### PR TITLE
Compress assembly files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add host read removal with Bowtie 2 and according custom section to MultiQC
 - Add separate MultiQC section for FastQC after preprocessing
 - Add social preview image
-- Compress asseembly files
+- Compress assembly files
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add host read removal with Bowtie 2 and according custom section to MultiQC
 - Add separate MultiQC section for FastQC after preprocessing
 - Add social preview image
+- Compress asseembly files
 
 ### `Fixed`
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -123,7 +123,7 @@ Trimmed (short) reads are assembled with both megahit and SPAdes. Hybrid assembl
 
 **Output directory: `results/MEGAHIT`**
 
-- `${sample}.contigs.fasta.gz`: compressed metagenome assembly in fasta format
+- `${sample}.contigs.fa.gz`: compressed metagenome assembly in fasta format
 - `${sample}_QC/`: directory containing QUAST files
 
 ### SPAdes

--- a/docs/output.md
+++ b/docs/output.md
@@ -123,7 +123,7 @@ Trimmed (short) reads are assembled with both megahit and SPAdes. Hybrid assembl
 
 **Output directory: `results/MEGAHIT`**
 
-- `${sample}.contigs.fasta`: metagenome assembly in fasta format
+- `${sample}.contigs.fasta.gz`: compressed metagenome assembly in fasta format
 - `${sample}_QC/`: directory containing QUAST files
 
 ### SPAdes
@@ -132,7 +132,9 @@ Trimmed (short) reads are assembled with both megahit and SPAdes. Hybrid assembl
 
 **Output directory: `results/SPAdes`**
 
-- `${sample}_contigs.fasta`: metagenome assembly in fasta format
+- `${sample}_scaffolds.fasta.gz`: compressed assembled scaffolds in fasta format
+- `${sample}_graph.gfa.gz`: compressed assembly graph in gfa format
+- `${sample}_contigs.fasta.gz`: compressed assembled contigs in fasta format
 - `${sample}_QC/`: directory containing QUAST files
 
 ### SPAdesHybrid
@@ -141,7 +143,9 @@ SPAdesHybrid is a part of the SPAdes software and is used when the user provides
 
 **Output directory: `results/SPAdesHybrid`**
 
-- `${sample}_contigs.fasta`: metagenome assembly in fasta format
+- `${sample}_scaffolds.fasta.gz`: compressed assembled scaffolds in fasta format
+- `${sample}_graph.gfa.gz`: compressed assembly graph in gfa format
+- `${sample}_contigs.fasta.gz`: compressed assembled contigs in fasta format
 - `${sample}_QC/`: directory containing QUAST files
 
 ### Quast

--- a/main.nf
+++ b/main.nf
@@ -860,8 +860,7 @@ process megahit {
     tag "$name"
     publishDir "${params.outdir}/", mode: 'copy',
         saveAs: {filename -> 
-          if (filename.indexOf(".gz") == -1 && filename.indexOf(".contigs.fa") == -1 ) "Assembly/$filename"
-          else if (filename.indexOf(".contigs.fa.gz") >0) "Assembly/$filename"
+          if (filename.indexOf(".log") > 0 || filename.indexOf(".contigs.fa.gz") > 0 ) "Assembly/$filename"
           else null}
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -895,8 +895,7 @@ process spadeshybrid {
     tag "$id"
     publishDir "${params.outdir}/", mode: 'copy', pattern: "${id}*",
         saveAs: {filename -> 
-          if (filename.indexOf(".fastq.gz") == -1  && filename.indexOf("_scaffolds.fasta") == -1) "Assembly/SPAdesHybrid/$filename"
-          else if (filename.indexOf("_scaffolds.fasta.gz") > 0) "Assembly/SPAdesHybrid/$filename"
+          if (filename.indexOf(".log") > 0 || filename.indexOf("_scaffolds.fasta.gz") > 0 || filename.indexOf("_graph.gfa.gz") > 0 || filename.indexOf("_contigs.fasta.gz") > 0 ) "Assembly/SPAdesHybrid/$filename"
           else null}
 
     input:
@@ -937,8 +936,7 @@ process spades {
     tag "$id"
     publishDir "${params.outdir}/", mode: 'copy', pattern: "${id}*",
         saveAs: {filename -> 
-          if (filename.indexOf(".fastq.gz") == -1  && filename.indexOf("_scaffolds.fasta") == -1) "Assembly/SPAdes/$filename"
-          else if (filename.indexOf("_scaffolds.fasta.gz") > 0) "Assembly/SPAdes/$filename"
+          if (filename.indexOf(".log") > 0 || filename.indexOf("_scaffolds.fasta.gz") > 0 || filename.indexOf("_graph.gfa.gz") > 0 || filename.indexOf("_contigs.fasta.gz") > 0 ) "Assembly/SPAdes/$filename"
           else null}
     input:
     set id, file(sr) from trimmed_reads_spades  

--- a/main.nf
+++ b/main.nf
@@ -927,8 +927,8 @@ process spadeshybrid {
     mv spades/scaffolds.fasta ${id}_scaffolds.fasta
     mv spades/contigs.fasta ${id}_contigs.fasta
     mv spades/spades.log ${id}_log.txt
-    gzip "${id}_contigs.fasta" > "${id}_contigs.fasta.gz"
-    gzip "${id}_graph.gfa" > "${id}_graph.gfa.gz"
+    gzip "${id}_contigs.fasta"
+    gzip "${id}_graph.gfa"
     gzip -c "${id}_scaffolds.fasta" > "${id}_scaffolds.fasta.gz"
     """
 }
@@ -967,8 +967,8 @@ process spades {
     mv spades/scaffolds.fasta ${id}_scaffolds.fasta
     mv spades/contigs.fasta ${id}_contigs.fasta
     mv spades/spades.log ${id}_log.txt
-    gzip "${id}_contigs.fasta" > "${id}_contigs.fasta.gz"
-    gzip "${id}_graph.gfa" > "${id}_graph.gfa.gz"
+    gzip "${id}_contigs.fasta"
+    gzip "${id}_graph.gfa"
     gzip -c "${id}_scaffolds.fasta" > "${id}_scaffolds.fasta.gz"
     """
 }


### PR DESCRIPTION
Large assembly files are compressed and exported to the reulst folder. This can reduce the result folder by several GB. This is the first bullet point in #34.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated