### PR TITLE
Spades finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed channel joining for multiple samples causing MetaBAT2 error [#32](https://github.com/nf-core/mag/issues/32)
 - Update MetaBAT2 from v2.13 to v2.15
 - Fix number of threads used by MetaBAT2 program `jgi_summarize_bam_contig_depths`
+- No more ignoring errors in SPAdes assembly
 
 ### `Deprecated`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -91,13 +91,15 @@ process {
     cpus = { check_spades_cpus (10, task.attempt) }
     memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
+    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'finish' }
+    maxRetries = 5
   }
   withName: spadeshybrid {
     cpus = { check_spadeshybrid_cpus (10, task.attempt) }
     memory = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
     time = { check_max (24.h * (2**(task.attempt-1)), 'time' ) }
-    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'ignore' }
+    errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'finish' }
+    maxRetries = 5
   }
   withName: bowtie2 {
     cpus = { check_max (2 * task.attempt, 'cpus' ) }


### PR DESCRIPTION
Finish `process spades` and `spadeshybrid` instead of ignoring errors. Additionally, increase retries to 5 for these 2 processes to allow higher RAM allocation.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
