### PR TITLE
Update to BUSCO 4.0.6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - No more ignoring errors in SPAdes assembly
 - No more ignoring of BUSCO errors
 - Improved output documentation
+- Fixed grouping of BUSCO summaries for BUSCO plot
 
 ### `Deprecated`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -20,7 +20,7 @@ process {
   maxErrors = '-1'
 
   // Process-specific resource requirements
-  withName: busco_download_db {
+  withName: busco_db_preparation {
     time = 4.h
   }
   withName: busco {

--- a/main.nf
+++ b/main.nf
@@ -84,7 +84,7 @@ def helpMessage() {
     Bin quality check:
       --skip_busco [bool]                   Disable bin QC with BUSCO (default: false)
       --busco_reference [file]              Download path for BUSCO database, available databases are listed here: https://busco.ezlab.org/
-                                            (default: https://busco-archive.ezlab.org/v3/datasets/bacteria_odb9.tar.gz)
+                                            (default: https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2019-06-26.tar.gz)
 
     Reproducibility options:
       --megahit_fix_cpu_1 [bool]            Fix number of CPUs for MEGAHIT to 1. Not increased with retries (default: false)
@@ -154,9 +154,9 @@ if (params.megahit_fix_cpu_1 || params.spades_fix_cpus || params.spadeshybrid_fi
 if(!params.skip_busco){
     Channel
         .fromPath( "${params.busco_reference}", checkIfExists: true )
-        .set { file_busco_db }
+        .set { ch_file_busco_db }
 } else {
-    file_busco_db = Channel.from()
+    ch_file_busco_db = Channel.from()
 }
 
 if(params.centrifuge_db){
@@ -402,7 +402,7 @@ process get_software_versions {
     porechop --version > v_porechop.txt
     NanoLyse --version > v_nanolyse.txt
     spades.py --version > v_spades.txt
-    run_BUSCO.py --version > v_busco.txt
+    busco --version > v_busco.txt
     centrifuge --version > v_centrifuge.txt
     kraken2 -v > v_kraken2.txt
     CAT -v > v_cat.txt
@@ -1117,10 +1117,10 @@ process busco_download_db {
     tag "${database.baseName}"
 
     input:
-    file(database) from file_busco_db
+    file(database) from ch_file_busco_db
 
     output:
-    set val("${database.toString().replace(".tar.gz", "")}"), file("buscodb/*") into busco_db
+    set val("${database.toString().replace(".tar.gz", "")}"), file("buscodb/*") into ch_busco_db
 
     script:
     """
@@ -1131,112 +1131,119 @@ process busco_download_db {
 
 metabat_bins
     .transpose()
-    .combine(busco_db)
-    .set { metabat_db_busco }
+    .combine(ch_busco_db)
+    .set { ch_metabat_db_busco }
 
 /*
  * BUSCO: Quantitative measures for the assessment of genome assembly
  */
 process busco {
-    tag "${assembly}"
+    tag "${bin}"
     publishDir "${params.outdir}/GenomeBinning/QC/BUSCO/", mode: 'copy'
 
     input:
-    set val(assembler), val(sample), file(assembly), val(db_name), file(db) from metabat_db_busco
-
+    set val(assembler), val(sample), file(bin), val(db_name), file(db) from ch_metabat_db_busco
+ 
     output:
-    file("short_summary_${assembly}.txt") into (busco_summary_to_multiqc, busco_summary_to_plot)
-    val("$assembler-$sample") into busco_assembler_sample_to_plot
-    file("${assembly}_busco_log.txt")
-    file("${assembly}_buscos.faa")
-    file("${assembly}_buscos.fna")
+    set val(assembler), val(sample), file("short_summary.specific.${db}.${bin}.txt") into (ch_busco_multiqc, ch_busco_to_summary, ch_busco_plot)
+    file("${bin}_busco.log")
+    file("${bin}_buscos.faa") optional true
+    file("${bin}_buscos.fna") optional true
 
     script:
-    if( workflow.profile.toString().indexOf("conda") == -1) {
-        """
+    if( workflow.profile.toString().indexOf("conda") == -1)
+        cp_augustus_config = "Y"
+    else
+        cp_augustus_config = "N"
+
+    """
+    # get path to custom config file for busco (already configured during installation)
+    busco_path=\$(which busco)
+    config_file="\${busco_path%bin/busco}config/config.ini"
+
+    if [ ${cp_augustus_config} = "Y" ] ; then
         cp -r /opt/conda/pkgs/augustus*/config augustus_config/
         export AUGUSTUS_CONFIG_PATH=augustus_config
+    fi
 
-        run_BUSCO.py \
-            --in ${assembly} \
-            --lineage_path $db_name \
-            --cpu "${task.cpus}" \
-            --blast_single_core \
-            --mode genome \
-            --out ${assembly} \
-            >${assembly}_busco_log.txt
-        cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+    # place db in extra folder to ensure BUSCO recognizes it as path (instead of downloading it)
+    mkdir dataset
+    mv ${db} dataset/
 
-        for f in run_${assembly}/single_copy_busco_sequences/*faa; do 
-            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa || touch ${assembly}_buscos.faa
-            break
-        done
-        for f in run_${assembly}/single_copy_busco_sequences/*fna; do 
-            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna || touch ${assembly}_buscos.fna
-            break
-        done
-        """
-    } else {
-        """
-        run_BUSCO.py \
-            --in ${assembly} \
-            --lineage_path $db_name \
-            --cpu "${task.cpus}" \
-            --blast_single_core \
-            --mode genome \
-            --out ${assembly} \
-            >${assembly}_busco_log.txt
-        cp run_${assembly}/short_summary_${assembly}.txt short_summary_${assembly}.txt
+    busco \
+        --mode genome \
+        --in ${bin} \
+        --lineage_dataset dataset/${db} \
+        --config \${config_file} \
+        --cpu "${task.cpus}" \
+        --out "BUSCO" > ${bin}_busco.log
 
-        for f in run_${assembly}/single_copy_busco_sequences/*faa; do 
-            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*faa >${assembly}_buscos.faa || touch ${assembly}_buscos.faa
-            break
-        done
-        for f in run_${assembly}/single_copy_busco_sequences/*fna; do 
-            [ -e "\$f" ] && cat run_${assembly}/single_copy_busco_sequences/*fna >${assembly}_buscos.fna || touch ${assembly}_buscos.fna
-            break
-        done
-        """
-    }
+    cp BUSCO/short_summary.specific.${db}.BUSCO.txt short_summary.specific.${db}.${bin}.txt
+
+    for f in BUSCO/run_${db}/busco_sequences/single_copy_busco_sequences/*faa; do
+        [ -e "\$f" ] && cat BUSCO/run_${db}/busco_sequences/single_copy_busco_sequences/*faa >${bin}_buscos.faa
+        break
+    done
+    for f in BUSCO/run_${db}/busco_sequences/single_copy_busco_sequences/*fna; do
+        [ -e "\$f" ] && cat BUSCO/run_${db}/busco_sequences/single_copy_busco_sequences/*fna >${bin}_buscos.fna
+        break
+    done
+    """
 }
 
+// preprare channels for downstream processes
+ch_busco_multiqc = ch_busco_multiqc.map{it[2]}
+ch_busco_to_summary = ch_busco_to_summary.map{it[2]}
 
-process busco_plot { 
+// group by assembler and sample for plotting
+ch_busco_plot = ch_busco_plot.groupTuple(by: [0,1])
+
+process busco_plot {
+    tag "$assembler-$sample"
+    publishDir "${params.outdir}/GenomeBinning/QC/BUSCO/", mode: 'copy'
+
+    input:
+    set val(assembler), val(sample), file(summaries) from ch_busco_plot
+
+    output:
+    file("${assembler}-${sample}-busco_figure.png")
+    file("${assembler}-${sample}-busco_figure.R")
+    file("${assembler}-${sample}-busco_summary.txt")
+
+    script:
+    def name = "${assembler}-${sample}"
+    """
+    # replace dots in bin names within summary file names with underscores
+    # (currently, v4.1.2, generate_plot.py does not allow further dots)
+    for sum in ${summaries}; do
+        [[ \${sum} =~ short_summary.(.*).${name}.(.*).txt ]];
+        db_info=\${BASH_REMATCH[1]}
+        bin="${name}.\${BASH_REMATCH[2]}"
+        bin_new="\${bin//./_}"
+        mv \${sum} short_summary.\${db_info}.\${bin_new}.txt
+    done
+
+    generate_plot.py --working_directory .
+
+    mv busco_figure.png ${assembler}-${sample}-busco_figure.png
+    mv busco_figure.R ${assembler}-${sample}-busco_figure.R
+
+    summary_busco.py short_summary.*.txt > ${assembler}-${sample}-busco_summary.txt
+    """
+}
+
+process busco_summary {
     publishDir "${params.outdir}/GenomeBinning/QC/", mode: 'copy'
 
     input:
-    file(summaries) from busco_summary_to_plot.collect()
-    val(assemblersample) from busco_assembler_sample_to_plot.collect()
+    file("short_summary.*.txt") from ch_busco_to_summary.collect()
 
     output:
-    file("*busco_figure.png")
-    file("BUSCO/*busco_figure.R")
-    file("BUSCO/*busco_summary.txt")
     file("busco_summary.txt") into busco_summary
 
     script:
-    def assemblersampleunique = assemblersample.unique()
     """
-    #for each assembler and sample:
-    assemblersample=\$(echo \"$assemblersampleunique\" | sed 's/[][]//g')
-    IFS=', ' read -r -a assemblersamples <<< \"\$assemblersample\"
-
-    mkdir BUSCO
-
-    for name in \"\${assemblersamples[@]}\"; do
-        mkdir \${name}
-        cp short_summary_\${name}* \${name}/
-        generate_plot.py --working_directory \${name}
-        
-        cp \${name}/busco_figure.png \${name}-busco_figure.png
-        cp \${name}/busco_figure.R \${name}-busco_figure.R
-
-        summary_busco.py \${name}/short_summary_*.txt >BUSCO/\${name}-busco_summary.txt
-    done
-
-    cp *-busco_figure.R BUSCO/
-
-    summary_busco.py short_summary_*.txt >busco_summary.txt
+    summary_busco.py short_summary.*.txt > busco_summary.txt
     """
 }
 
@@ -1285,7 +1292,7 @@ process merge_quast_and_busco {
     """
     QUAST_BIN=\$(echo \"$quast_bin_sum\" | sed 's/[][]//g')
     IFS=', ' read -r -a quast_bin <<< \"\$QUAST_BIN\"
-    
+
     for quast_file in \"\${quast_bin[@]}\"; do
         if ! [ -f "quast_summary.tsv" ]; then 
             cp "\${quast_file}" "quast_summary.tsv"
@@ -1366,7 +1373,7 @@ process multiqc {
     file (fastqc_trimmed:'fastqc/*') from fastqc_results_trimmed.collect().ifEmpty([])
     file (host_removal) from ch_host_removed_log.collect().ifEmpty([])
     file ('quast*/*') from quast_results.collect().ifEmpty([])
-    file ('short_summary_*.txt') from busco_summary_to_multiqc.collect().ifEmpty([])
+    file ('short_summary.*.txt') from ch_busco_multiqc.collect().ifEmpty([])
     file ('software_versions/*') from ch_software_versions_yaml.collect()
     file workflow_summary from ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")
 

--- a/main.nf
+++ b/main.nf
@@ -1113,7 +1113,7 @@ process metabat {
     """
 }
 
-process busco_download_db {
+process busco_db_preparation {
     tag "${database.baseName}"
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
   readPaths = false
   single_end = false
   outdir = './results'
-  busco_reference = "https://busco-archive.ezlab.org/v3/datasets/bacteria_odb9.tar.gz"
+  busco_reference = "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2019-06-26.tar.gz"
 
   // short read preprocessing options
   adapter_forward = "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA"


### PR DESCRIPTION
Here is an update to BUSCO 4.0.6 (v4.1.2 is in conflict with the MAG python version 3.6.7). It contains only the basic functionality so far, without the automatic lineage selection and without automatic DB download which is provided since BUSCO 4 (which would require extra error handling among among others with the current BUSCO version).

I renamed the variable ${assembly} to ${bin} within the busco processes.

Additionally I changed the `busco_plot` process and the channel logic, so that the process now runs on each `assembler`-`sample` combination (instead of calling the busco script `generate_plot.py` for each combination within the process). This also fixes the grouping of BUSCO summaries for the plot, which was wrong in case one sample name was the prefix of another one. 

For the final busco summary for all bins I created an extra process.

Since current versions of the BUSCO `generate_plot.py` (v4.0.6-4.1.2) can not handle additional dots within the summary file names, I unfortunately had to replace also dots with underscores in the bin names, which will also appear as such in the BUSCO plots.



## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
