### PR TITLE
Revert busco version to 3.0.2 (wait for release with fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add MetaBAT2 RNG seed parameter `--metabat_rng_seed` and set the default to 1 which ensures reproducible binning results
 - Add parameters `--megahit_fix_cpu_1`, `--spades_fix_cpus` and `--spadeshybrid_fix_cpus` to ensure reproducible results from assembly tools
 
-### `Changed`
-
-- Update BUSCO from version `3.0.2` to `4.0.6`
-
 ### `Fixed`
 
 - Fix links in README

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - bioconda::krona=2.7.1
   - conda-forge::r-markdown=1.0
   - conda-forge::r-ggplot2=3.2.0
-  - bioconda::busco=4.0.6
+  - bioconda::busco=3.0.2
   - bioconda::nanoplot=1.26.3
   - bioconda::filtlong=0.2.0
   - bioconda::porechop=0.2.3_seqan2.1.1


### PR DESCRIPTION
With BUSCO version 4.0.6 there are frequent, non-reproducible errors occurring, caused by a `replace("faa", "fna")` function corrupting nextflow filenames that contain the substring "faa" in their hash id. I prepared a PR for BUSCO (https://gitlab.com/ezlab/busco/-/issues/305).

For now I suggest we revert to the previous BUSCO version so we can continue with other PRs until we can include a new BUSCO release. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
