### PR TITLE
Fix process 'fastqc_trimmed' to also handle read files that were not preprocessed with host or phix removal

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -621,10 +621,10 @@ process fastqc_trimmed {
     if ( !params.single_end ) {
         """
         fastqc -t "${task.cpus}" -q ${reads}
-        mv *_1_fastqc.html "${name}_R1.trimmed_fastqc.html"
-        mv *_2_fastqc.html "${name}_R2.trimmed_fastqc.html"
-        mv *_1_fastqc.zip "${name}_R1.trimmed_fastqc.zip"
-        mv *_2_fastqc.zip "${name}_R2.trimmed_fastqc.zip"
+        mv *1_fastqc.html "${name}_R1.trimmed_fastqc.html"
+        mv *2_fastqc.html "${name}_R2.trimmed_fastqc.html"
+        mv *1_fastqc.zip "${name}_R1.trimmed_fastqc.zip"
+        mv *2_fastqc.zip "${name}_R2.trimmed_fastqc.zip"
         """
     } else {
         """


### PR DESCRIPTION
Output read filenames from the processes `remove_host` and `remove_phix` end with "_1.fastq.gz", while from `fastp` filenames end with "_R1/2.fastq.gz". The output files of `fastqc` are named accordingly.
 
Changed `fastqc_trimmed` process to be able to handle both cases.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
