### PR TITLE
Removed deprecated option --fastq-input for kraken2

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -843,7 +843,6 @@ process kraken2 {
         --report-zero-counts \
         --threads "${task.cpus}" \
         --db database \
-        --fastq-input \
         --report kraken2_report.txt \
         $input \
         > kraken2.kraken


### PR DESCRIPTION
I removed the parameter `--fastq-input`, which was from kraken1 and is not used by kraken2 anymore. Caused warning `Unknown option: fastq-input`.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
