### PR TITLE
Replace zcat with `gunzip -c` to avoid errors on Mac OS X

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -526,8 +526,8 @@ process remove_host {
                 2> ${name}.bowtie2.log
 
         if [ ${save_ids} = "Y" ] ; then
-            zcat ${name}_host_mapped_1.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped_1.read_ids.txt
-            zcat ${name}_host_mapped_2.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped_2.read_ids.txt
+            gunzip -c ${name}_host_mapped_1.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped_1.read_ids.txt
+            gunzip -c ${name}_host_mapped_2.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped_2.read_ids.txt
         fi
         rm -f ${name}_host_mapped_*.fastq.gz
         """
@@ -543,7 +543,7 @@ process remove_host {
                 2> ${name}.bowtie2.log
 
         if [ ${save_ids} = "Y" ] ; then
-            zcat ${name}_host_mapped.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped.read_ids.txt
+            gunzip -c ${name}_host_mapped.fastq.gz | awk '{if(NR%4==1) print substr(\$0, 2)}' | LC_ALL=C sort > ${name}_host_mapped.read_ids.txt
         fi
         rm -f ${name}_host_mapped.fastq.gz
         """
@@ -591,15 +591,15 @@ if(!params.keep_phix) {
             """
             bowtie2 -p "${task.cpus}" -x ref -1 "${reads[0]}" -2 "${reads[1]}" --un-conc-gz ${name}_phix_unmapped_%.fastq.gz
             echo "Bowtie2 reference: ${genome}" >${name}_remove_phix_log.txt
-            zcat ${reads[0]} | echo "Read pairs before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            zcat ${name}_phix_unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            gunzip -c ${reads[0]} | echo "Read pairs before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            gunzip -c ${name}_phix_unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
             """
         } else {
             """
             bowtie2 -p "${task.cpus}" -x ref -U ${reads}  --un-gz ${name}_phix_unmapped.fastq.gz
             echo "Bowtie2 reference: ${genome}" >${name}_remove_phix_log.txt
-            zcat ${reads[0]} | echo "Reads before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            zcat ${name}_phix_unmapped.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            gunzip -c ${reads[0]} | echo "Reads before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            gunzip -c ${name}_phix_unmapped.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
             """
         }
 
@@ -697,7 +697,7 @@ if (!params.keep_lambda) {
 
         echo "NanoLyse reference: $params.lambda_reference" >${id}_nanolyse_log.txt
         cat ${lr} | echo "total reads before NanoLyse: \$((`wc -l`/4))" >>${id}_nanolyse_log.txt
-        zcat ${id}_nanolyse.fastq.gz | echo "total reads after NanoLyse: \$((`wc -l`/4))" >>${id}_nanolyse_log.txt
+        gunzip -c ${id}_nanolyse.fastq.gz | echo "total reads after NanoLyse: \$((`wc -l`/4))" >>${id}_nanolyse_log.txt
         """
     }
 } else {


### PR DESCRIPTION
I replaced `zcat` with `gunzip -c` to avoid errors on Mac OS X when using the Conda profile. 

For me this occurred when I wanted to test something. Even if users might typically not use MacOS for assembly, it would probably still be good if the implementation works on as many systems as possible, since from the docs it seems that the conda profile should work too. 

Although to be precise, there are remaining issues when running on MacOS: kraken2 conda build causes a segmentation fault (https://github.com/DerrickWood/kraken2/issues/222) and there is something wrong with MEGAHIT, but that's not within the scope of this PR.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
