### PR TITLE
Specify available memory for MEGAHIT

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -911,9 +911,10 @@ process megahit {
 
     script:
     def input = params.single_end ? "-r \"${reads}\"" :  "-1 \"${reads[0]}\" -2 \"${reads[1]}\""
+    mem = task.memory.toBytes()
     if ( !params.megahit_fix_cpu_1 || task.cpus == 1 )
         """
-        megahit -t "${task.cpus}" $input -o MEGAHIT --out-prefix "${name}"
+        megahit -t "${task.cpus}" -m $mem $input -o MEGAHIT --out-prefix "${name}"
         gzip -c "MEGAHIT/${name}.contigs.fa" > "MEGAHIT/${name}.contigs.fa.gz"
         """
     else


### PR DESCRIPTION
Specify available memory for MEGAHIT using the `-m` option. Without this, on unix systems, it detects the available memory size automatically, but I guess that can differ from `task.memory`.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
