### PR TITLE
Adjusted test profiles

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -14,8 +14,8 @@ params {
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
-  params.outdir = "./tests"
-  params.temp_dir = "./tests/tmp_dir"
+
+  // Input data
   single_end = false
   input_paths = [
     ['test_minigut', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R1.fastq.gz', 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/test_minigut_R2.fastq.gz']],

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -14,6 +14,8 @@ params {
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
+
+  // Input data
   host_fasta = "https://github.com/nf-core/test-datasets/raw/mag/host_reference/genome.hg38.chr21_10000bp_region.fa"
   input_paths = [
     ['test_minigut_hg38host', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_hg38host_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_hg38host_R2.fastq.gz']],

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -8,11 +8,13 @@
  */
 
 params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on GitHub Actions
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
-  params.outdir = "./tests"
-  params.temp_dir = "./tests/tmp_dir"
+
   // Input data
   single_end = false
   params.manifest = 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/manifest.txt'

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -8,9 +8,13 @@
  */
 
 params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on GitHub Actions
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
+
   // Input data
   host_fasta = "https://github.com/nf-core/test-datasets/raw/mag/host_reference/genome.hg38.chr21_10000bp_region.fa"
   params.manifest = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest_hg38host.txt'


### PR DESCRIPTION
- Removed `outdir` parameter from the `test` profiles. It is unnecessary and, additionally, confusing, since currently by default the `tracedir` will be created in `"${params.outdir}/pipeline_info"` with `outdir=./results`. When `outdir` is changed (in the test config file)  to `./tests`, this causes the creation of two directories, i.e. `./tests` and `./results`. This should probably be changed in the template.

- Removed the remaining `temp_dir` parameters, since it is unused anyway.

- Added missing `config_profile_*` parameters

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
