### PR TITLE
Fix missing bin names for MultiQC BUSCO section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No more ignoring errors in SPAdes assembly
 - No more ignoring of BUSCO errors
 - Improved output documentation
+- Fix missing bin names in MultiQC BUSCO section [#96](https://github.com/nf-core/mag/pull/96)
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -1372,7 +1372,7 @@ process multiqc {
     file (fastqc_trimmed:'fastqc/*') from fastqc_results_trimmed.collect().ifEmpty([])
     file (host_removal) from ch_host_removed_log.collect().ifEmpty([])
     file ('quast*/*') from quast_results.collect().ifEmpty([])
-    file ('short_summary_*.txt') from busco_summary_to_multiqc.collect().ifEmpty([])
+    file (short_summary) from busco_summary_to_multiqc.collect().ifEmpty([])
     file ('software_versions/*') from ch_software_versions_yaml.collect()
     file workflow_summary from ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")
 


### PR DESCRIPTION
The bin names for the BUSCO section within the MultiQC report were missing (https://github.com/nf-core/mag/issues/78).

When using input: `file ('short_summary_*.txt')` the files will be enumerated and the numbers interpreted as sample names by MultiQC. To keep the original filenames including the bin names, I changed this to `file (short_summary)`.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
