### PR TITLE
Fix links in test profiles to testdata

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -18,8 +18,8 @@ params {
   // Input data
   single_end = false
   input_paths = [
-    ['test_minigut', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R1.fastq.gz', 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/test_minigut_R2.fastq.gz']],
-    ['test_minigut_sample2', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R1.fastq.gz', 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/test_minigut_sample2_R2.fastq.gz']]
+    ['test_minigut', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R2.fastq.gz']],
+    ['test_minigut_sample2', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R2.fastq.gz']]
   ]
   centrifuge_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_cf.tar.gz"
   kraken2_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_kraken.tgz"

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -18,8 +18,8 @@ params {
   // TODO nf-core: Give any required params for the test so that command line flags are not needed
   single_end = false
   input_paths = [
-    ['test_minigut', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R1.fastq.gz', 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/test_minigut_R2.fastq.gz']],
-    ['test_minigut_sample2', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R1.fastq.gz', 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/test_minigut_sample2_R2.fastq.gz']]
+    ['test_minigut', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_R2.fastq.gz']],
+    ['test_minigut_sample2', ['https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_R2.fastq.gz']]
   ]
   centrifuge_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_cf.tar.gz"
   kraken2_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_kraken.tgz"

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -17,7 +17,7 @@ params {
 
   // Input data
   single_end = false
-  params.manifest = 'https://github.com/HadrienG/test-datasets/raw/mag/test_data/manifest.txt'
+  params.manifest = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest.txt'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -10,7 +10,7 @@
 params {
   config_profile_name = 'Test profile'
   config_profile_description = 'Minimal test dataset to check pipeline function'
-  // Limit resources so that this can run on GitHub Actions
+  // Limit resources so that this can run on GitHub Actionss
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -10,7 +10,7 @@
 params {
   config_profile_name = 'Test profile'
   config_profile_description = 'Minimal test dataset to check pipeline function'
-  // Limit resources so that this can run on GitHub Actionss
+  // Limit resources so that this can run on GitHub Actions
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h


### PR DESCRIPTION
Replaced remaining links to testata in @HadrienG's repo with links to testdata in `nf-core/test-datasets`.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
