### PR TITLE
Removed bowtie2 alignments from .command.out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update to new nf-core 1.10.2 `TEMPLATE` [#88](https://github.com/nf-core/mag/pull/88)
 - `--reads` is now removed, use `--input` instead [#88](https://github.com/nf-core/mag/pull/88)
+- Prevented PhiX alignments from being stored in work directory [#101](https://github.com/nf-core/mag/pull/101)
 
 ### `Fixed`
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -48,7 +48,7 @@ The pipeline uses bowtie2 to map the reads against PhiX and removes mapped reads
 
 **Output directory: `QC_shortreads/remove_phix`**
 
-* `[sample]_remove_phix_log.txt`: Contains a brief log file indicating how many reads have been retained.
+* `[sample]_remove_phix.log`: Contains a brief log file indicating how many reads have been retained.
 
 ### Host read removal
 

--- a/main.nf
+++ b/main.nf
@@ -584,22 +584,33 @@ if(!params.keep_phix) {
 
         output:
         set val(name), file("*.fastq.gz") into (trimmed_reads_megahit, trimmed_reads_metabat, trimmed_reads_fastqc, trimmed_sr_spadeshybrid, trimmed_reads_spades, trimmed_reads_centrifuge, trimmed_reads_kraken2, trimmed_reads_bowtie2, trimmed_reads_filtlong)
-        file("${name}_remove_phix_log.txt")
+        file("${name}_remove_phix.log")
 
         script:
         if ( !params.single_end ) {
             """
-            bowtie2 -p "${task.cpus}" -x ref -1 "${reads[0]}" -2 "${reads[1]}" --un-conc-gz ${name}_phix_unmapped_%.fastq.gz
-            echo "Bowtie2 reference: ${genome}" >${name}_remove_phix_log.txt
-            gunzip -c ${reads[0]} | echo "Read pairs before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            gunzip -c ${name}_phix_unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            bowtie2 -p "${task.cpus}" \
+                    -x ref \
+                    -1 "${reads[0]}" \
+                    -2 "${reads[1]}" \
+                    --un-conc-gz ${name}_phix_unmapped_%.fastq.gz \
+                    1> /dev/null \
+                    2> ${name}.bowtie2.log
+            echo "Bowtie2 reference: ${genome}" >${name}_remove_phix.log
+            gunzip -c ${reads[0]} | echo "Read pairs before removal: \$((`wc -l`/4))" >>${name}_remove_phix.log
+            gunzip -c ${name}_phix_unmapped_1.fastq.gz | echo "Read pairs after removal: \$((`wc -l`/4))" >>${name}_remove_phix.log
             """
         } else {
             """
-            bowtie2 -p "${task.cpus}" -x ref -U ${reads}  --un-gz ${name}_phix_unmapped.fastq.gz
-            echo "Bowtie2 reference: ${genome}" >${name}_remove_phix_log.txt
-            gunzip -c ${reads[0]} | echo "Reads before removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
-            gunzip -c ${name}_phix_unmapped.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix_log.txt
+            bowtie2 -p "${task.cpus}" \
+                    -x ref \
+                    -U ${reads} \
+                    --un-gz ${name}_phix_unmapped.fastq.gz \
+                    1> /dev/null \
+                    2> ${name}.bowtie2.log
+            echo "Bowtie2 reference: ${genome}" >${name}_remove_phix.log
+            gunzip -c ${reads[0]} | echo "Reads before removal: \$((`wc -l`/4))" >>${name}_remove_phix.log
+            gunzip -c ${name}_phix_unmapped.fastq.gz | echo "Reads after removal: \$((`wc -l`/4))" >>${name}_remove_phix.log
             """
         }
 


### PR DESCRIPTION
Addresses https://github.com/nf-core/mag/issues/97.

Redirected `bowtie2 stdout`, i.e. alignments, to `/dev/null` and `bowtie2 stderr` to `log` file.  The `log` file is not written to `results` as `${name}_remove_phix.log` covers already the important stats.

Also I couldn't resist to rename `${name}_remove_phix_log.txt`to `${name}_remove_phix.log`. I saw there more such named files, but I would rename them in a separate PR, if you don't mind :)

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
