### PR TITLE
Enable conda again

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -107,13 +107,27 @@ process {
   }
   withName: busco {
     container = 'nfcore/magbusco:dev'
+    profiles {
+      conda {
+        conda = "$baseDir/containers/busco/environment.yml"
+      }
+    }
   }
   withName: busco_plot {
     container = 'nfcore/magbusco:dev'
+    profiles {
+      conda {
+        conda = "$baseDir/containers/busco/environment.yml"
+      }
+    }
   }
   withName: get_busco_version {
     container = 'nfcore/magbusco:dev'
-    cache = false
+    profiles {
+      conda {
+        conda = "$baseDir/containers/busco/environment.yml"
+      }
+    }
   }
   withName: get_software_versions {
     cache = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -107,7 +107,12 @@ try {
 }
 
 profiles {
-  conda { process.conda = "$baseDir/environment.yml" }
+  conda {
+    process.conda = "$baseDir/environment.yml"
+    // Increase time available to build conda environment
+    conda.createTimeout = '1 h'
+  }
+
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker {
     docker.enabled = true


### PR DESCRIPTION
To enable running the pipeline with the `conda` profile again, I added the conda directives for the busco processes, but only for `profile` `conda` to make sure it is not used when running with the `docker` or `singularity` profile. 

I wasn't sure in which order the `conda` directives are taken. But it works, for the corresponding busco processes, the in `base.config` specified directives `conda = "$baseDir/containers/busco/environment.yml"` overwrite the in `nextflow.config` specified `conda = "$baseDir/environment.yml"` (although the main  `conda = "$baseDir/environment.yml"` is specified last).


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
