### PR TITLE
Update busco to 4.1.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#88](https://github.com/nf-core/mag/pull/88) - Update to new nf-core 1.10.2 `TEMPLATE`
 - [#88](https://github.com/nf-core/mag/pull/88) - `--reads` is now removed, use `--input` instead
 - [#101](https://github.com/nf-core/mag/pull/101) - Prevented PhiX alignments from being stored in work directory [#97](https://github.com/nf-core/mag/issues/97)
-- [#104](https://github.com/nf-core/mag/pull/104) - Update `BUSCO` from `v3.0.2` to `v4.1.3`
+- [#104](https://github.com/nf-core/mag/pull/104), [#111](https://github.com/nf-core/mag/pull/111) - Update `BUSCO` from `v3.0.2` to `v4.1.4`
 
 ### `Fixed`
 

--- a/containers/busco/environment.yml
+++ b/containers/busco/environment.yml
@@ -18,4 +18,4 @@ dependencies:
   - conda-forge::fonts-conda-ecosystem=1          # to avoid missing fonts in R (https://github.com/conda-forge/r-base-feedstock/issues/91)
   - conda-forge::r-base=4.0.2                     # busco requires R >= 4
   - conda-forge::r-ggplot2=3.3.2
-  - bioconda::busco=4.1.3
+  - bioconda::busco=4.1.4


### PR DESCRIPTION
Update BUSCO to 4.1.4 due to bug in 4.1.3 affecting Augustus results (https://gitlab.com/ezlab/busco/-/issues/327).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md
