### PR TITLE
Add Zenodo DOI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ For further information or help, don't hesitate to get in touch on the [Slack `#
 
 ## Citation
 
-<!-- TODO nf-core: Add citation for pipeline after first release. Uncomment lines below and update Zenodo doi. -->
-<!-- If you use  nf-core/mag for your analysis, please cite it using the following doi: [10.5281/zenodo.XXXXXX](https://doi.org/10.5281/zenodo.XXXXXX) -->
+If you use nf-core/mag for your analysis, please cite it using the following doi: [10.5281/zenodo.4068515](https://doi.org/10.5281/zenodo.4068515)
 
 You can cite the `nf-core` publication as follows:
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/)
 [![Docker](https://img.shields.io/docker/automated/nfcore/mag.svg)](https://hub.docker.com/r/nfcore/mag)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4068515.svg)](https://doi.org/10.5281/zenodo.4068515)
 [![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23mag-4A154B?logo=slack)](https://nfcore.slack.com/channels/mag)
 
 ## Introduction


### PR DESCRIPTION
Add Zenodo DOI to README.

I could not commit against the master README as stated in https://nf-co.re/developers/release_checklist, thus I thought I try to directly make a PR against master. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
