### PR TITLE
Fix seaborn version to avoid error with nanoplot

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - conda-forge::r-markdown=1.0
   - conda-forge::r-ggplot2=3.2.0
   - bioconda::nanoplot=1.26.3
+  - conda-forge::seaborn=0.10.1 # 0.11.0 causes AttributeError with nanoplot (https://github.com/wdecoster/NanoPlot/issues/201)
   - bioconda::filtlong=0.2.0
   - bioconda::porechop=0.2.3_seqan2.1.1
   - bioconda::nanolyse=1.1.0


### PR DESCRIPTION
On some long read data, I got a `NanoPlot` error:

```
raise AttributeError(f"{type(self).__name__!r} object "
AttributeError: 'PathCollection' object has no property 'stat_func'
```
See alos https://github.com/wdecoster/NanoPlot/issues/201.

Seems there was recently a new `seaborn` version 0.11.0 released, which can cause problems with `NanoPlot`. They fixed the seaborn version in the current bioconda recipe. But since we use an older NanoPlot version, we need to fix this manually within the `environment.yml`.
 



## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
