### PR TITLE
Fix CAT db link in help message

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,7 @@ def helpMessage() {
       --centrifuge_db [file]                Database for taxonomic binning with centrifuge (default: none). E.g. "ftp://ftp.ccb.jhu.edu/pub/infphilo/centrifuge/data/p_compressed+h+v.tar.gz"
       --kraken2_db [file]                   Database for taxonomic binning with kraken2 (default: none). E.g. "ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz"
       --skip_krona [bool]                   Skip creating a krona plot for taxonomic binning
-      --cat_db [file]                       Database for taxonomic classification of metagenome assembled genomes (default: none). E.g. "http://tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20200618.tar.gz"
+      --cat_db [file]                       Database for taxonomic classification of metagenome assembled genomes (default: none). E.g. "http://tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20200304.tar.gz"
                                             The zipped file needs to contain a folder named "*taxonomy*" and "*CAT_database*" that hold the respective files.
 
     Binning options:


### PR DESCRIPTION
Fix CAT db link in help message to version build with compatible diamond version.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
