### PR TITLE
Change paths for full-size test data to s3

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -13,12 +13,14 @@ params {
 
   // Input data for full size test
   // hg19 reference with highly conserved and low-complexity regions masked by Brian Bushnell
-  host_fasta = "https://zenodo.org/record/1208052/files/hg19_main_mask_ribo_animal_allplant_allfungus.fa.gz"
-  manifest = "https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest.full.txt"
+  host_fasta = "s3://nf-core-awsmegatests/mag/input_data/hg19_main_mask_ribo_animal_allplant_allfungus.fa.gz"
+  manifest = "s3://nf-core-awsmegatests/mag/input_data/manifest.full.txt"
 
-  centrifuge_db = "ftp://ftp.ccb.jhu.edu/pub/infphilo/centrifuge/data/p_compressed+h+v.tar.gz"
-  kraken2_db = "ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz"
-  cat_db = "http://tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20200304.tar.gz"
+  centrifuge_db = "s3://nf-core-awsmegatests/mag/input_data/p_compressed+h+v.tar.gz"
+  kraken2_db = "s3://nf-core-awsmegatests/mag/input_data/minikraken_8GB_202003.tgz"
+  cat_db = "s3://nf-core-awsmegatests/mag/input_data/CAT_prepare_20200304.tar.gz"
+
+  busco_reference = "s3://nf-core-awsmegatests/mag/input_data/bacteria_odb10.2020-03-06.tar.gz"
 
   // reproducibility options for megahit and spades not turned on
 }


### PR DESCRIPTION
Change paths for full-size test data to s3, to avoid problems when downloading data from SRA.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
