### PR TITLE
Fix processing of input parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.2.0dev - [date]
 
+### `Fixed`
+
+- [#133](https://github.com/nf-core/mag/pull/133) - Fixed processing of `--input` parameter
+
 ## v1.1.1 - 2019/11/10
 
 ### `Added`

--- a/main.nf
+++ b/main.nf
@@ -280,8 +280,8 @@ if(params.manifest){
     }
  } else {
     Channel
-        .fromFilePairs(params.reads, size: params.single_end ? 1 : 2)
-        .ifEmpty { exit 1, "Cannot find any reads matching: ${params.reads}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --single_end on the command line." }
+        .fromFilePairs(params.input, size: params.single_end ? 1 : 2)
+        .ifEmpty { exit 1, "Cannot find any reads matching: ${params.input}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --single_end on the command line." }
         .into { read_files_fastqc; read_files_fastp }
     files_long_raw = Channel.from()
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,6 +66,9 @@ params {
   spadeshybrid_fix_cpus = false
   metabat_rng_seed = 1
 
+  // For testing
+  input_paths = false
+
   // Boilerplate options
   name = false
   multiqc_config = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,6 +22,11 @@
                     "description": "Manifest file, required for hybrid assembly with metaSPAdes. Alternative to `--input`.",
                     "help_text": "Has 4 headerless columns (tab separated): Sample_Id, Long_Reads, Short_Reads_1, Short_Reads_2\n"
                 },
+                "input_paths": {
+                    "type": "string",
+                    "description": "Paths to input FastQ files for tests.",
+                    "hidden": true
+                },
                 "single_end": {
                     "type": "boolean",
                     "description": "Specifies that the input is single-end reads.",


### PR DESCRIPTION
Fixed issue https://github.com/nf-core/mag/issues/131: internally still the deprecated `params.reads` where processed instead of `params.input` (sorry! must have overseen something when merging the template).

To avoid future confusions and avoid the warning 
"WARN: Access to undefined parameter `input_paths` -- Initialise it to a default value eg. `params.input_paths = some_value`" 
for users when not running test profiles, I also initialised the `input_paths` variable again (even though it was removed from the template).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
