### PR TITLE
Changed 'manifest' format and merged into 'input' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.2.0dev - [date]
 
+### `Changed`
+
+- [#143](https://github.com/nf-core/mag/pull/143) - Changed format of manifest file, has to be handed over via `--input` parameter as well now
+
+### `Deprecated`
+
+- [#143](https://github.com/nf-core/mag/pull/143) - Change depreciated parameters: `--manifest` -> `--input`
+
 ## v1.1.2 - 2020/11/24
 
 ### `Changed`

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -14,7 +14,7 @@ params {
   // Input data for full size test
   // hg19 reference with highly conserved and low-complexity regions masked by Brian Bushnell
   host_fasta = "s3://nf-core-awsmegatests/mag/input_data/hg19_main_mask_ribo_animal_allplant_allfungus.fa.gz"
-  manifest = "s3://nf-core-awsmegatests/mag/input_data/manifest.full.txt"
+  input = "s3://nf-core-awsmegatests/mag/input_data/manifest.full.tsv"
 
   centrifuge_db = "s3://nf-core-awsmegatests/mag/input_data/p_compressed+h+v.tar.gz"
   kraken2_db = "s3://nf-core-awsmegatests/mag/input_data/minikraken_8GB_202003.tgz"

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -16,7 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  manifest = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest.txt'
+  input = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest.tsv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -17,7 +17,7 @@ params {
 
   // Input data
   host_fasta = "https://github.com/nf-core/test-datasets/raw/mag/host_reference/genome.hg38.chr21_10000bp_region.fa"
-  manifest = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest_hg38host.txt'
+  input = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/manifest_hg38host.tsv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -79,7 +79,7 @@ The pipeline uses Nanolyse to map the reads against the Lambda phage and removes
 
 ### Filtlong and porechop
 
-The pipeline uses filtlong and porechop to perform quality control of the long reads that are eventually provided with the `--manifest` option.
+The pipeline uses filtlong and porechop to perform quality control of the long reads that are eventually provided with the TSV input file.
 
 No direct host read removal is performed for long reads.
 However, since within this pipeline filtlong uses a read quality based on k-mer matches to the already filtered short reads, reads not overlapping those short reads might be discarded.

--- a/main.nf
+++ b/main.nf
@@ -135,6 +135,9 @@ ch_output_docs_images = file("$projectDir/docs/images/", checkIfExists: true)
 /*
  * Create a channel for input read files
  */
+
+if (params.manifest) exit 1, "The parameter `--manifest` is deprecated.\n\tPlease use the `--input` parameter instead and mind the new format specifications."
+
 hybrid = false
 if(hasExtension(params.input, "tsv")){
     // extracts read files from TSV and distribute into channels

--- a/main.nf
+++ b/main.nf
@@ -22,17 +22,13 @@ def helpMessage() {
     The typical command for running the pipeline is as follows:
 
     nextflow run nf-core/mag --input '*_R{1,2}.fastq.gz' -profile docker
-    nextflow run nf-core/mag --manifest 'manifest.tsv' -profile docker
+    nextflow run nf-core/mag --input 'manifest.tsv' -profile docker
 
     Mandatory arguments:
-      --input [file]                  Path to input data (must be surrounded with quotes)
-      -profile [str]                  Configuration profile to use. Can use multiple (comma separated)
-                                      Available: conda, docker, singularity, test, awsbatch, <institute> and more
-
-    Hybrid assembly:
-      --manifest [file]                     Path to manifest file (must be surrounded with quotes), required for hybrid assembly with metaSPAdes
-                                            Has 4 headerless columns (tab separated): Sample_Id, Long_Reads, Short_Reads_1, Short_Reads_2
-                                            Only one file path per entry allowed
+      --input [file]                        Path to short reads input data (must be surrounded with quotes). Alternatively, path to TSV manifest file required for hybrid assembly with metaSPAdes. 
+                                            Has 4 or 5 headerless columns (tab separated): Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]
+      -profile [str]                        Configuration profile to use. Can use multiple (comma separated)
+                                            Available: conda, docker, singularity, test, awsbatch, <institute> and more
 
     Options:
       --genome [str]                        Name of iGenomes reference
@@ -66,7 +62,7 @@ def helpMessage() {
 
     Assembly:
       --skip_spades [bool]                  Skip Illumina-only SPAdes assembly
-      --skip_spadeshybrid [bool]            Skip SPAdes hybrid assembly (only available when using manifest input)
+      --skip_spadeshybrid [bool]            Skip SPAdes hybrid assembly
       --skip_megahit [bool]                 Skip MEGAHIT assembly
       --skip_quast [bool]                   Skip metaQUAST
 
@@ -136,6 +132,67 @@ ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multi
 ch_output_docs = file("$projectDir/docs/output.md", checkIfExists: true)
 ch_output_docs_images = file("$projectDir/docs/images/", checkIfExists: true)
 
+/*
+ * Create a channel for input read files
+ */
+hybrid = false
+if(hasExtension(params.input, "tsv")){
+    // extracts read files from TSV and distribute into channels
+    Channel
+        .from(file(params.input))
+        .ifEmpty {exit 1, log.info "Cannot find path file ${tsvFile}"}
+        .splitCsv(sep:'\t')
+        .map { row ->
+                if (row.size() == 5) {
+                    def name = row[0]
+                    def grp = row[1]
+                    def sr1 = file(row[2], checkIfExists: true)
+                    def sr2 = file(row[3], checkIfExists: true)
+                    def lr = file(row[4], checkIfExists: true)
+                    hybrid = true
+                    return [ name, grp, sr1, sr2, lr ]}
+                else if (row.size() == 4) {
+                    def name = row[0]
+                    def grp = row[1]
+                    def sr1 = file(row[2], checkIfExists: true)
+                    def sr2 = file(row[3], checkIfExists: true)
+                    return [ name, grp, sr1, sr2 ]}
+                else {
+                    exit 1, "Input TSV file contains row with ${row.size()} column(s). Expects 4 or 5."
+                }
+            }
+        .into { ch_all_files_sr; ch_all_files_lr }
+    // prepare input for preprocessing
+    ch_all_files_sr
+        .map { row -> [ row[0], [ row[2], row[3] ] ] }
+        .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
+    ch_all_files_lr
+        .map { row -> if (row.size() == 5) [ row[0], row[4] ] }
+        .set { ch_raw_long_reads }
+} else if(params.input_paths){
+    if(params.single_end){
+        Channel
+            .from(params.input_paths)
+            .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true) ] ] }
+            .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
+            .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
+        ch_raw_long_reads = Channel.from()
+    } else {
+        Channel
+            .from(params.input_paths)
+            .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true), file(row[1][1], checkIfExists: true) ] ] }
+            .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
+            .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
+        ch_raw_long_reads = Channel.from()
+    }
+ } else {
+    Channel
+        .fromFilePairs(params.input, size: params.single_end ? 1 : 2)
+        .ifEmpty { exit 1, "Cannot find any reads matching: ${params.input}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --single_end on the command line." }
+        .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
+    ch_raw_long_reads = Channel.from()
+}
+
 // Check if specified cpus for SPAdes are available
 if ( params.spades_fix_cpus && params.spades_fix_cpus > params.max_cpus )
     exit 1, "Invalid parameter '--spades_fix_cpus ${params.spades_fix_cpus}', max cpus are '${params.max_cpus}'."
@@ -145,7 +202,7 @@ if ( params.spadeshybrid_fix_cpus && params.spadeshybrid_fix_cpus > params.max_c
 if (params.megahit_fix_cpu_1 || params.spades_fix_cpus || params.spadeshybrid_fix_cpus){
     if (!params.skip_spades && !params.spades_fix_cpus)
         log.warn "At least one assembly process is run with a parameter to ensure reproducible results, but SPAdes not. Consider using the parameter '--spades_fix_cpus'."
-    if (params.manifest && !params.skip_spadeshybrid && !params.spadeshybrid_fix_cpus)
+    if (hybrid && !params.skip_spadeshybrid && !params.spadeshybrid_fix_cpus)
         log.warn "At least one assembly process is run with a parameter to ensure reproducible results, but SPAdes hybrid not. Consider using the parameter '--spadeshybrid_fix_cpus'."
     if (!params.skip_megahit && !params.megahit_fix_cpu_1)
         log.warn "At least one assembly process is run with a parameter to ensure reproducible results, but MEGAHIT not. Consider using the parameter '--megahit_fix_cpu_1'."
@@ -200,7 +257,7 @@ if(!params.keep_phix) {
 if ( params.host_fasta && params.host_genome) {
     exit 1, "Both host fasta reference and iGenomes genome are specififed to remove host contamination! Invalid combination, please specify either --host_fasta or --host_genome."
 }
-if ( params.manifest && (params.host_fasta || params.host_genome) ) {
+if ( hybrid && (params.host_fasta || params.host_genome) ) {
     log.warn "Host read removal is only applied to short reads. Long reads might be filtered indirectly by Filtlong, which is set to use read qualities estimated based on k-mer matches to the short, already filtered reads."
     if ( params.longreads_length_weight > 1 ) {
         log.warn "The parameter --longreads_length_weight is ${params.longreads_length_weight}, causing the read length being more important for long read filtering than the read quality. Set --longreads_length_weight to 1 in order to assign equal weights."
@@ -236,66 +293,7 @@ if ( params.host_genome ) {
     ch_host_fasta = Channel.empty()
 }
 
-/*
- * Create a channel for input read files
- */
 
-if(params.manifest){
-    manifestFile = file(params.manifest)
-    // extracts read files from TSV and distribute into channels
-    Channel
-        .from(manifestFile)
-        .ifEmpty {exit 1, log.info "Cannot find path file ${tsvFile}"}
-        .splitCsv(sep:'\t')
-        .map { row ->
-                if (row.size() == 5) {
-                    def name = row[0]
-                    def grp = row[1]
-                    def sr1 = file(row[2], checkIfExists: true)
-                    def sr2 = file(row[3], checkIfExists: true)
-                    def lr = file(row[4], checkIfExists: true)
-                    return [ name, grp, sr1, sr2, lr ]}
-                else if (row.size() == 4) {
-                    def name = row[0]
-                    def grp = row[1]
-                    def sr1 = file(row[2], checkIfExists: true)
-                    def sr2 = file(row[3], checkIfExists: true)
-                    return [ name, grp, sr1, sr2 ]}
-                else {
-                    exit 1, "Input manifest contains row with ${row.size()} column(s). Expects 4 or 5."
-                }
-            }
-        .into { ch_all_files_sr; ch_all_files_lr }
-    // prepare input for preprocessing
-    ch_all_files_sr
-        .map { row -> [ row[0], [ row[2], row[3] ] ] }
-        .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
-    ch_all_files_lr
-        .map { row -> if (row.size() == 5) [ row[0], row[4] ] }
-        .set { ch_raw_long_reads }
-} else if(params.input_paths){
-    if(params.single_end){
-        Channel
-            .from(params.input_paths)
-            .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true) ] ] }
-            .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
-            .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
-        ch_raw_long_reads = Channel.from()
-    } else {
-        Channel
-            .from(params.input_paths)
-            .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true), file(row[1][1], checkIfExists: true) ] ] }
-            .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
-            .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
-        ch_raw_long_reads = Channel.from()
-    }
- } else {
-    Channel
-        .fromFilePairs(params.input, size: params.single_end ? 1 : 2)
-        .ifEmpty { exit 1, "Cannot find any reads matching: ${params.input}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --single_end on the command line." }
-        .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
-    ch_raw_long_reads = Channel.from()
-}
 
 // Header log info
 log.info nfcoreHeader()
@@ -303,7 +301,6 @@ def summary = [:]
 if (workflow.revision) summary['Pipeline Release'] = workflow.revision
 summary['Run Name'] = custom_runName ?: workflow.runName
 if (params.input_paths) summary['Input paths']     = params.input_paths
-else if (params.manifest) summary['Manifest']   = params.manifest
 else summary['Input']                           = params.input
 summary['Data Type']                  = params.single_end ? 'Single-End' : 'Paired-End'
 
@@ -317,7 +314,7 @@ if (params.host_genome) summary['Host Genome']               = params.host_genom
 else if(params.host_fasta) summary['Host Fasta Reference']   = params.host_fasta
 if (params.host_genome || params.host_fasta) summary['Host removal setting'] = params.host_removal_verysensitive ? 'very-sensitive' : 'sensitive'
 
-if (params.manifest) {
+if (hybrid) {
     summary['Skip adapter trimming']     = params.skip_adapter_trimming ? 'Yes' : 'No'
     summary['Keep lambda reads']         = params.keep_lambda ? 'Yes' : 'No'
     if (!params.keep_lambda) summary['Lambda reference']               = params.lambda_reference
@@ -345,7 +342,7 @@ summary['Skip quast']           = params.skip_quast ? 'Yes' : 'No'
 
 if (!params.skip_megahit)                                               summary['MEGAHIT fix cpus']         = params.megahit_fix_cpu_1 ? '1' : 'No'
 if (!params.single_end && !params.skip_spades)                          summary['SPAdes fix cpus']          = params.spades_fix_cpus ? params.spades_fix_cpus : 'No'
-if (params.manifest && !params.single_end && !params.skip_spadeshybrid) summary['SPAdes hybrid fix cpus']   = params.spadeshybrid_fix_cpus ? params.spadeshybrid_fix_cpus : 'No'
+if (hybrid && !params.single_end && !params.skip_spadeshybrid) summary['SPAdes hybrid fix cpus']   = params.spadeshybrid_fix_cpus ? params.spadeshybrid_fix_cpus : 'No'
 if (!params.skip_binning)                                               summary['MetaBAT2 RNG seed']        = params.metabat_rng_seed
 
 summary['Max Resources']    = "$params.max_memory memory, $params.max_cpus cpus, $params.max_time time per job"
@@ -984,7 +981,7 @@ process spadeshybrid {
     file("${name}_graph.gfa.gz")
 
     when:
-    params.manifest && !params.single_end && !params.skip_spadeshybrid
+    hybrid && !params.single_end && !params.skip_spadeshybrid
      
     script:
     maxmem = task.memory.toGiga()
@@ -1638,4 +1635,9 @@ def checkHostname() {
             }
         }
     }
+}
+
+// Check file extension
+def hasExtension(it, extension) {
+    it.toString().toLowerCase().endsWith(extension.toLowerCase())
 }

--- a/main.nf
+++ b/main.nf
@@ -25,8 +25,8 @@ def helpMessage() {
     nextflow run nf-core/mag --input 'manifest.tsv' -profile docker
 
     Mandatory arguments:
-      --input [file]                        Path to short reads input data (must be surrounded with quotes). Alternatively, path to TSV manifest file required for hybrid assembly with metaSPAdes. 
-                                            Has 4 or 5 headerless columns (tab separated): Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]
+      --input [file]                        Path to short reads input data (must be surrounded with quotes). Alternatively, path to TSV manifest file required for hybrid assembly with metaSPAdes.
+                                            Has 4 or 5 headerless columns (tab separated): Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]. The latter requires a '.tsv' suffix.
       -profile [str]                        Configuration profile to use. Can use multiple (comma separated)
                                             Available: conda, docker, singularity, test, awsbatch, <institute> and more
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,6 @@ params {
 
   // Workflow flags
   input = "data/*{1,2}.fastq.gz"
-  manifest = false
   single_end = false
   outdir = './results'
   publish_dir_mode = 'copy'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -15,7 +15,7 @@
                     "type": "string",
                     "fa_icon": "fas fa-dna",
                     "description": "Input FastQ files or TSV file.",
-                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq'\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The path must have at least one `*` wildcard character\n3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.\n\nIf left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`. \n\nA TSV input file is required for hybrid assembly with metaSPAdes. Has 4 or 5 headerless columns: Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]."
+                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq'\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The path must have at least one `*` wildcard character\n3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.\n\nIf left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`. \n\nA TSV input file is required for hybrid assembly with metaSPAdes. Has 4 or 5 headerless columns: Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]. This requires a '.tsv' suffix."
                 },
                 "input_paths": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -14,13 +14,8 @@
                 "input": {
                     "type": "string",
                     "fa_icon": "fas fa-dna",
-                    "description": "Input FastQ files. Either this or the `--manifest` parameter is required.",
-                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq'\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The path must have at least one `*` wildcard character\n3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.\n\nIf left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`"
-                },
-                "manifest": {
-                    "type": "string",
-                    "description": "Manifest file, required for hybrid assembly with metaSPAdes. Alternative to `--input`.",
-                    "help_text": "Has 4 headerless columns (tab separated): Sample_Id, Long_Reads, Short_Reads_1, Short_Reads_2\n"
+                    "description": "Input FastQ files or TSV file.",
+                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq'\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The path must have at least one `*` wildcard character\n3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.\n\nIf left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`. \n\nA TSV input file is required for hybrid assembly with metaSPAdes. Has 4 or 5 headerless columns: Sample_Id, Group_Id, Short_Reads_1, Short_Reads_2 [, Long_Reads]."
                 },
                 "input_paths": {
                     "type": "string",
@@ -396,7 +391,7 @@
                 },
                 "skip_spadeshybrid": {
                     "type": "boolean",
-                    "description": "Skip SPAdes hybrid assembly (only available when using manifest input)."
+                    "description": "Skip SPAdes hybrid assembly."
                 },
                 "skip_megahit": {
                     "type": "boolean",


### PR DESCRIPTION
Changed manifest input format:
- `sampleId, lr, sr1, sr2` -> `sampleId, groupId, sr1, sr2 [, lr]`
- added groupId (not used yet)
- lr: long read file optional!

Needs to be TSV format now and has to be handed over also via `--input` parameter now.

I made a PR for the testate s well https://github.com/nf-core/test-datasets/pull/208. The current CI tests will fail.

If you agree to this, the `S3` manifest file needs to be updated as well.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
