### PR TITLE
Rename FASTQ files and check sample ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#143](https://github.com/nf-core/mag/pull/143) - Changed format of manifest file, has to be handed over via `--input` parameter as well now
+- [#145](https://github.com/nf-core/mag/pull/145) - When using TSV input files, uses sample IDs now for `FastQC` instead of basenames of original read files. Allows non-unique file basenames.
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -164,11 +164,11 @@ if(hasExtension(params.input, "tsv")){
                     exit 1, "Input TSV file contains row with ${row.size()} column(s). Expects 4 or 5."
                 }
             }
-        .into { ch_all_files_sr; ch_all_files_lr }
+        .into { ch_sample_validate; ch_all_files_sr; ch_all_files_lr }
     // prepare input for preprocessing
     ch_all_files_sr
         .map { row -> [ row[0], [ row[2], row[3] ] ] }
-        .into { ch_raw_short_reads }
+        .set { ch_raw_short_reads }
     ch_all_files_lr
         .map { row -> if (row.size() == 5) [ row[0], row[4] ] }
         .set { ch_raw_long_reads }
@@ -178,14 +178,14 @@ if(hasExtension(params.input, "tsv")){
             .from(params.input_paths)
             .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true) ] ] }
             .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
-            .into { ch_raw_short_reads }
+            .into { ch_sample_validate; ch_raw_short_reads }
         ch_raw_long_reads = Channel.from()
     } else {
         Channel
             .from(params.input_paths)
             .map { row -> [ row[0], [ file(row[1][0], checkIfExists: true), file(row[1][1], checkIfExists: true) ] ] }
             .ifEmpty { exit 1, "params.input_paths was empty - no input files supplied" }
-            .into { ch_raw_short_reads }
+            .into { ch_sample_validate; ch_raw_short_reads }
         ch_raw_long_reads = Channel.from()
     }
  } else {
@@ -195,6 +195,12 @@ if(hasExtension(params.input, "tsv")){
         .into { ch_raw_short_reads_fastqc; ch_raw_short_reads_fastp }
     ch_raw_long_reads = Channel.from()
 }
+
+// Ensure sample IDs are unique
+ch_sample_validate
+    .map { row -> row[0] }
+    .toList()
+    .map{ ids -> if( ids.size() != ids.unique().size() ) {exit 1, "ERROR: input contains duplicated sample IDs!" } }
 
 // Check if specified cpus for SPAdes are available
 if ( params.spades_fix_cpus && params.spades_fix_cpus > params.max_cpus )

--- a/main.nf
+++ b/main.nf
@@ -458,17 +458,23 @@ process rename_short_read_fastqs {
     set val(name), file(reads) from ch_raw_short_reads
 
     output:
-    set val(name), path("*.fastq.gz", includeInputs: true) into (ch_raw_short_reads_fastqc, ch_raw_short_reads_fastp)
+    set val(name), path("${name}{_R1,_R2,}.fastq.gz", includeInputs: true) into (ch_raw_short_reads_fastqc, ch_raw_short_reads_fastp)
 
     script:
     if ( !params.single_end )
         """
-        [ -f "${name}_R1.fastq.gz" ] || ln -s "${reads[0]}" "${name}_R1.fastq.gz"
-        [ -f "${name}_R2.fastq.gz" ] || ln -s "${reads[1]}" "${name}_R2.fastq.gz"
+        if ! [ -f "${name}_R1.fastq.gz" ]; then
+            ln -s "${reads[0]}" "${name}_R1.fastq.gz"
+        fi
+        if ! [ -f "${name}_R2.fastq.gz" ]; then
+            ln -s "${reads[1]}" "${name}_R2.fastq.gz"
+        fi
         """
     else
         """
-        [ -f "${name}.fastq.gz" ] || ln -s "${reads}" "${name}.fastq.gz"
+        if ! [ -f "${name}.fastq.gz" ]; then
+            ln -s "${reads}" "${name}.fastq.gz"
+        fi
         """
 }
 


### PR DESCRIPTION
- rename all short read FASTQ files to ensure consistent names in reports from FastQC and allow non-unique read file base names
- added check for unique sample IDs, return error otherwise

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
