### PR TITLE
Check if SPAdes is enabled in combination with single-end data

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -219,6 +219,11 @@ if (params.megahit_fix_cpu_1 || params.spades_fix_cpus || params.spadeshybrid_fi
         log.warn "At least one assembly process is run with a parameter to ensure reproducible results, but for MetaBAT2 a random seed is specified ('--metabat_rng_seed 0'). Consider specifying a positive seed instead."
 }
 
+// Check if SPAdes and singl_end
+if ( (!params.skip_spades || !params.skip_spadeshybrid) && params.single_end) {
+    log.warn "metaSPAdes does not support single-end data. SPAdes will be skipped."
+}
+
 /*
  * Create a channel for reference databases
  */


### PR DESCRIPTION
Return warning if `single_end = true` and param `skip_spades` or `skip_spadeshybrid` not set.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/mag branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/mag)
