### PR TITLE
Compress unbinned MetaBAT2 output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/mag/pull/162) - Update `FastP` from version `0.20.0` to `0.20.1`
 - [#162](https://github.com/nf-core/mag/pull/162) - Update `Bowtie2` from version `2.3.5` to `2.4.2`
 - [#162](https://github.com/nf-core/mag/pull/162) - Update `FastQC` from version `0.11.8` to `0.11.9`
+- [#172](https://github.com/nf-core/mag/pull/172) - Compressed discarded MetaBAT2 output files
 
 ## v1.2.0 - 2020/02/10
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -98,7 +98,7 @@ params {
             publish_dir    = "Assembly"
         }
         'metabat2' {
-            publish_files  = ['txt.gz':'', 'fa':'']
+            publish_files  = ['txt.gz':'', 'fa':'', 'fa.gz':'']
             publish_dir    = "GenomeBinning"
         }
         'busco_db_preparation' {

--- a/docs/output.md
+++ b/docs/output.md
@@ -221,10 +221,10 @@ All the files and contigs in this folder will be assessed by QUAST and BUSCO.
 **Output files:**
 
 * `GenomeBinning/MetaBAT2/discarded/`
-  * `*.lowDepth.fa`: Low depth contigs that are filtered by MetaBat2
-  * `*.tooShort.fa`: Too short contigs that are filtered by MetaBat2
-  * `*.unbinned.pooled.fa`: Pooled unbinned contigs equal or above `--min_contig_size`, by default 1500 bp.
-  * `*.unbinned.remaining.fa`: Remaining unbinned contigs below `--min_contig_size`, by default 1500 bp, but not in any other file.
+  * `*.lowDepth.fa.gz`: Low depth contigs that are filtered by MetaBat2
+  * `*.tooShort.fa.gz`: Too short contigs that are filtered by MetaBat2
+  * `*.unbinned.pooled.fa.gz`: Pooled unbinned contigs equal or above `--min_contig_size`, by default 1500 bp.
+  * `*.unbinned.remaining.fa.gz`: Remaining unbinned contigs below `--min_contig_size`, by default 1500 bp, but not in any other file.
 
 All the files in this folder contain small and/or unbinned contigs that are not further processed.
 

--- a/modules/local/metabat2.nf
+++ b/modules/local/metabat2.nf
@@ -38,10 +38,11 @@ process METABAT2 {
     split_fasta.py "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa" ${params.min_length_unbinned_contigs} ${params.max_unbinned_contigs} ${params.min_contig_size}
 
     mkdir MetaBAT2/discarded
-    mv "MetaBAT2/${meta.assembler}-${meta.id}.lowDepth.fa" MetaBAT2/discarded/
-    mv "MetaBAT2/${meta.assembler}-${meta.id}.tooShort.fa" MetaBAT2/discarded/
-    mv "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.pooled.fa" MetaBAT2/discarded/
-    mv "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.remaining.fa" MetaBAT2/discarded/
+    gzip "MetaBAT2/${meta.assembler}-${meta.id}.lowDepth.fa" \
+         "MetaBAT2/${meta.assembler}-${meta.id}.tooShort.fa" \
+         "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.pooled.fa" \
+         "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.remaining.fa"
+    mv "MetaBAT2/${meta.assembler}-${meta.id}".*.fa.gz MetaBAT2/discarded/
 
     # mv splitted file so that it doesnt end up in following processes
     mv "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa" "${meta.assembler}-${meta.id}.unbinned.fa"

--- a/modules/local/metabat2.nf
+++ b/modules/local/metabat2.nf
@@ -39,15 +39,15 @@ process METABAT2 {
     # save unbinned contigs above thresholds into individual files, dump others in one file
     split_fasta.py "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa" ${params.min_length_unbinned_contigs} ${params.max_unbinned_contigs} ${params.min_contig_size}
 
+    # delete splitted file so that it doesnt end up in following processes
+    rm "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa"
+
     mkdir MetaBAT2/discarded
     gzip "MetaBAT2/${meta.assembler}-${meta.id}.lowDepth.fa" \
          "MetaBAT2/${meta.assembler}-${meta.id}.tooShort.fa" \
          "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.pooled.fa" \
          "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.remaining.fa"
     mv "MetaBAT2/${meta.assembler}-${meta.id}".*.fa.gz MetaBAT2/discarded/
-
-    # mv splitted file so that it doesnt end up in following processes
-    mv "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa" "${meta.assembler}-${meta.id}.unbinned.fa"
 
     echo \$(metabat2 --help 2>&1) | sed "s/^.*version 2\\://; s/ (Bioconda.*//" > ${software}.version.txt
     """

--- a/modules/local/metabat2.nf
+++ b/modules/local/metabat2.nf
@@ -23,7 +23,7 @@ process METABAT2 {
 
     output:
     tuple val(meta), path("MetaBAT2/*.fa")            , emit: bins
-    path "${meta.assembler}-${assembly}-depth.txt.gz" , emit: depths
+    path "${meta.assembler}-${meta.id}-depth.txt.gz"  , emit: depths
     path "MetaBAT2/discarded/*"                       , emit: discarded
     path '*.version.txt'                              , emit: version
 
@@ -31,8 +31,10 @@ process METABAT2 {
     def software = getSoftwareName(task.process)
     """
     OMP_NUM_THREADS=${task.cpus} jgi_summarize_bam_contig_depths --outputDepth depth.txt ${bam}
-    gzip -c depth.txt > "${meta.assembler}-${assembly}-depth.txt.gz"
     metabat2 -t "${task.cpus}" -i "${assembly}" -a depth.txt -o "MetaBAT2/${meta.assembler}-${meta.id}" -m ${params.min_contig_size} --unbinned --seed ${params.metabat_rng_seed}
+
+    gzip depth.txt
+    mv depth.txt.gz "${meta.assembler}-${meta.id}-depth.txt.gz"
 
     # save unbinned contigs above thresholds into individual files, dump others in one file
     split_fasta.py "MetaBAT2/${meta.assembler}-${meta.id}.unbinned.fa" ${params.min_length_unbinned_contigs} ${params.max_unbinned_contigs} ${params.min_contig_size}


### PR DESCRIPTION
Compress unbinned MetaBAT2 output files (solves https://github.com/nf-core/mag/issues/165) and fix depth filename.



## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
