### PR TITLE
Fix split_fasta.py bug and improve runtime

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,6 +19,34 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint
         run: markdownlint ${GITHUB_WORKSPACE} -c ${GITHUB_WORKSPACE}/.github/markdownlint.yml
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ## Markdown linting is failing
+
+            To keep the code consistent with lots of contributors, we run automated code consistency checks.
+            To fix this CI test, please run:
+
+            * Install `markdownlint-cli`
+                * On Mac: `brew install markdownlint-cli`
+                * Everything else: [Install `npm`](https://www.npmjs.com/get-npm) then [install `markdownlint-cli`](https://www.npmjs.com/package/markdownlint-cli) (`npm install -g markdownlint-cli`)
+            * Fix the markdown errors
+                * Automatically: `markdownlint . --config .github/markdownlint.yml --fix`
+                * Manually resolve anything left from `markdownlint . --config .github/markdownlint.yml`
+
+            Once you push these changes the test should pass, and you can hide this comment :+1:
+
+            We highly recommend setting up markdownlint in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
+
+
   YAML:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +57,34 @@ jobs:
       - name: Install yaml-lint
         run: npm install -g yaml-lint
       - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml")
+        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml")
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ## YAML linting is failing
+
+            To keep the code consistent with lots of contributors, we run automated code consistency checks.
+            To fix this CI test, please run:
+
+            * Install `yaml-lint`
+                * [Install `npm`](https://www.npmjs.com/get-npm) then [install `yaml-lint`](https://www.npmjs.com/package/yaml-lint) (`npm install -g yaml-lint`)
+            * Fix the markdown errors
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml")`
+                * Fix any reported errors in your YAML files
+
+            Once you push these changes the test should pass, and you can hide this comment :+1:
+
+            We highly recommend setting up yaml-lint in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
+
+
   nf-core:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/mag/pull/162) - Update `FastQC` from version `0.11.8` to `0.11.9`
 - [#172](https://github.com/nf-core/mag/pull/172) - Compressed discarded MetaBAT2 output files
 
+### `Fixed`
+
+- [#175](https://github.com/nf-core/mag/pull/175) - Fix bug in retrieving the `--max_unbinned_contigs` longest unbinned sequences that are longer than `--min_length_unbinned_contigs` (`split_fasta.py`)
+- [#175](https://github.com/nf-core/mag/pull/175) - Improved runtime of `split_fasta.py` in `METABAT2` process (important for large assemblies, e.g. when computing co-assemblies)
+
 ## v1.2.0 - 2020/02/10
 
 ### `Added`

--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -19,35 +19,41 @@ min_length_to_retain_contig = int(argv[4])
 # Base name for file output
 out_base = (os.path.splitext(input_file)[0])
 
+# Data structures to separate and store sequences
+df_above_threshold = pd.DataFrame(columns=['id','seq','length'])
+pooled             = []
+remaining          = []
+
 # Read file
 with open(input_file) as f:
     fasta_sequences = SeqIO.parse(f,'fasta')
 
-# make table
-    df = pd.DataFrame(columns=['id','seq','length'])
     for fasta in fasta_sequences:
         name, sequence = fasta.id, str(fasta.seq)
         length = len(sequence)
-        df = df.append({"id":name, "seq":sequence, "length":length}, ignore_index = True)
 
-#sort table by sequence length
-df.sort_values(by=['length'], ascending=False)
+        # store each sequence above threshold together with its length into df
+        if length >= length_threshold:
+            df_above_threshold = df_above_threshold.append({"id":name, "seq":sequence, "length":length}, ignore_index = True)
+        # contigs to retain and pool
+        elif length >= min_length_to_retain_contig:
+            pooled.append(SeqRecord(Seq(sequence, generic_dna), id = name))
+        # remaining sequences
+        else:
+            remaining.append(SeqRecord(Seq(sequence, generic_dna), id = name))
 
-# Save sequences
-remaining = []
-pooled = []
-for index, row in df.iterrows():
-    # each sequence above threshold into one file
-    if row['length'] >= length_threshold and index+1 <= max_sequences:
+# Sort sequences above threshold by length
+df_above_threshold.sort_values(by=['length'], ascending=False, inplace=True)
+df_above_threshold.reset_index(drop=True, inplace=True)
+
+# Write `max_sequences` longest sequences (above threshold) into separate files, add remainder to pooled
+for index, row in df_above_threshold.iterrows():
+    if index+1 <= max_sequences:
         print("write "+out_base+"."+str(index+1)+".fa")
         out = (SeqRecord(Seq(row['seq'], generic_dna), id = row['id']))
         SeqIO.write(out, out_base+"."+str(index+1)+".fa", "fasta")
-    # contigs to retain
-    elif row['length'] >= min_length_to_retain_contig:
-        pooled.append(SeqRecord(Seq(row['seq'], generic_dna), id = row['id']))
-    # remaining sequences
     else:
-        remaining.append(SeqRecord(Seq(row['seq'], generic_dna), id = row['id']))
+        pooled.append(SeqRecord(Seq(row['seq'], generic_dna), id = row['id']))
 
 print("write "+out_base+".pooled.fa")
 SeqIO.write(pooled, out_base+".pooled.fa", "fasta")

--- a/lib/NfcoreSchema.groovy
+++ b/lib/NfcoreSchema.groovy
@@ -219,7 +219,7 @@ class NfcoreSchema {
                     }
                 }
             }
-            if(rawSchema.keySet().contains('properties') && rawSchema.get('properties').containsKey(ignore_param)) {
+            if(rawSchema.keySet().contains('properties') && rawSchema.get('properties').keySet().contains(ignore_param)) {
                 rawSchema.get("properties").remove(ignore_param)
             }
             if(rawSchema.keySet().contains('required') && rawSchema.required.contains(ignore_param)) {


### PR DESCRIPTION
There were two problems with the `split_fasta.py` script:

Bug:
 -  The sort function `sort_values()` was applied to `df`, but the result was nowhere stored. So I added an `inplace=True`.
 -  In any case, the index still refers to the position before sorting. Currently, after `max_sequences` it stops writing sequences to individual files, although the first `max_sequences` where not the longest and not necessarily have a `length >= length_threshold`. Thus sequences are missed. To address this I reset the index.

Runtime (see https://github.com/nf-core/mag/issues/166):
  - The `sort_values()` function is  applied to all sequences (O(n log n)). This is not necessary, since one can first separate all sequences below the `length_threshold`. Thus one can sort only the sequences `>= length_threshold`, take the longest `max_sequences` and add the remaining to the `pooled` list.
  - For the file with the unbinned sequences, which required > 300h this run through in a couple of minutes
 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
