### PR TITLE
Add taxonomic classification for bins with gtdb-tk

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,14 +10,15 @@ Remember that PRs should be made against the dev branch, unless you're preparing
 
 Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 -->
+<!-- markdownlint-disable ul-indent -->
 
 ## PR checklist
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
-  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
-  - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
+    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
+    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/mag/tree/master/.github/CONTRIBUTING.md)
+    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#179](https://github.com/nf-core/mag/pull/179) - Add BUSCO automated lineage selection functionality (new default). The pameter `--busco_auto_lineage_prok` can be used to only consider prokaryotes and the parameter `--busco_download_path` to run BUSCO in `offline` mode.
+- [#178](https://github.com/nf-core/mag/pull/178) - Add taxonomic bin classification with `GTDB-Tk` `v1.5.0` (for bins filtered based on `BUSCO` QC metrics).
 
 ### `Changed`
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#176](https://github.com/nf-core/mag/pull/176) - Update CAT DB link
 - [#179](https://github.com/nf-core/mag/pull/179) - Update `BUSCO` from version `4.1.4` to `5.1.0`
 - [#179](https://github.com/nf-core/mag/pull/179) - By default BUSCO now performs automated lineage selection instead of using the bacteria_odb10 lineage as reference. Specific lineage datasets can still be provided via `--busco_reference`.
+- [#178](https://github.com/nf-core/mag/pull/178) - Change output file: `results/GenomeBinning/QC/quast_and_busco_summary.tsv` -> `results/GenomeBinning/bin_summary.tsv`, contains GTDB-Tk results as well.
 
 ### `Fixed`
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -29,6 +29,9 @@
 
 * [Filtlong](https://github.com/rrwick/Filtlong)
 
+* [GTDB-Tk](https://doi.org/10.1093/bioinformatics/btz848)
+  > Chaumeil, P. A., Mussig, A. J., Hugenholtz, P., & Parks, D. H. (2020). GTDB-Tk: a toolkit to classify genomes with the Genome Taxonomy Database. Bioinformatics , 36(6), 1925–1927. doi: 10.1093/bioinformatics/btz848.
+
 * [Kraken2](https://doi.org/10.1186/s13059-019-1891-0)
   > Wood, D et al., 2019. Improved metagenomic analysis with Kraken 2. Genome Biology volume 20, Article number: 257. doi: 10.1186/s13059-019-1891-0.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The pipeline then:
 * assigns taxonomy to reads using [Centrifuge](https://ccb.jhu.edu/software/centrifuge/) and/or [Kraken2](https://github.com/DerrickWood/kraken2/wiki)
 * performs assembly using [MEGAHIT](https://github.com/voutcn/megahit) and [SPAdes](http://cab.spbu.ru/software/spades/), and checks their quality using [Quast](http://quast.sourceforge.net/quast)
 * performs metagenome binning using [MetaBAT2](https://bitbucket.org/berkeleylab/metabat/src/master/), and checks the quality of the genome bins using [Busco](https://busco.ezlab.org/)
-* assigns taxonomy to bins using [CAT](https://github.com/dutilh/CAT)
+* assigns taxonomy to bins using [GTDB-Tk](https://github.com/Ecogenomics/GTDBTk) and/or [CAT](https://github.com/dutilh/CAT)
 
 Furthermore, the pipeline creates various reports in the results directory specified, including a [MultiQC](https://multiqc.info/) report summarizing some of the findings and software versions.
 

--- a/bin/combine_tables.py
+++ b/bin/combine_tables.py
@@ -1,17 +1,57 @@
 #!/usr/bin/env python
 
-#USAGE: ./combine_tables.py <BUSCO_table> <QUAST_table>
-
+import sys
+import argparse
+import os.path
 import pandas as pd
-from sys import stdout
-from sys import argv
 
-# Read files
-file1 = pd.read_csv(argv[1], sep="\t")
-file2 = pd.read_csv(argv[2], sep="\t")
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-b', "--busco_summary",                    metavar='FILE',                               help="BUSCO summary file.")
+    parser.add_argument('-q', "--quast_summary",                    metavar='FILE',                               help="QUAST BINS summary file.")
+    parser.add_argument('-g', "--gtdbtk_summary",                   metavar='FILE',                               help="GTDB-Tk summary file.")
 
-# Merge files
-result = pd.merge(file1, file2, left_on="GenomeBin", right_on="Assembly", how='outer')
+    parser.add_argument('-o',  "--out",               required=True, metavar='FILE', type=argparse.FileType('w'), help="Output file containing final summary.")
+    return parser.parse_args(args)
 
-# Print to stdout
-result.to_csv(stdout, sep='\t')
+
+def main(args=None):
+    args = parse_args(args)
+
+    if not args.busco_summary and not args.quast_summary and not args.gtdbtk_summary:
+        sys.exit("No summary specified! Please specify at least two summaries.")
+
+    # At least two summaries must be specified for merging
+    # Since GTDB-Tk can only be run in combination with BUSCO, test if (BUSCO && GTDB-TK) || (BUSCO && QUAST)
+    if args.gtdbtk_summary and not args.busco_summary:
+        sys.exit("Invalid parameter combination: GTDB-TK summary specified, but no BUSCO summary!")
+    if args.quast_summary and not args.busco_summary:
+        sys.exit("At least two summaries must be specified, but only QUAST summary was given! Please specify BUSCO summary.")
+
+    results = pd.DataFrame()
+    bins    = pd.Series()
+
+    if args.busco_summary:
+        results = pd.read_csv(args.busco_summary, sep="\t")
+        bins    = results['GenomeBin'].sort_values().reset_index(drop=True)
+
+    if args.quast_summary:
+        quast_results = pd.read_csv(args.quast_summary, sep="\t")
+        if bins.empty:
+            bins = quast_results['Assembly'].sort_values().reset_index(drop=True)
+        elif not bins.equals(quast_results['Assembly'].sort_values().reset_index(drop=True)):
+            sys.exit("Bins in QUAST summary do not match bins in BUSCO summary!")
+        results = pd.merge(results, quast_results, left_on="GenomeBin", right_on="Assembly", how='outer')
+
+    if args.gtdbtk_summary:
+        gtdbtk_results = pd.read_csv(args.gtdbtk_summary, sep="\t")
+        if not bins.equals(gtdbtk_results['user_genome'].sort_values().reset_index(drop=True)):
+            sys.exit("Bins in GTDB-Tk summary do not match bins in BUSCO summary!")   # GTDB-Tk can currently anyway only run in combination with BUSCO
+        results = pd.merge(results, gtdbtk_results, left_on="GenomeBin", right_on="user_genome", how='outer')   # again assuming BUSCO summary must be given
+
+    # Print to stdout
+    results.to_csv(args.out, sep='\t')
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/summary_gtdbtk.py
+++ b/bin/summary_gtdbtk.py
@@ -65,7 +65,7 @@ def main(args=None):
                 bin_name = infile.readline().split("\t")[0]
                 bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
                 filtered.append(bin_results)
-    
+
     df_filtered = pd.DataFrame(filtered, columns=columns)
     df_filtered['user_genome'] = df_filtered['user_genome'].astype(str) + '.' + args.extension
     df_filtered.set_index('user_genome', inplace=True)

--- a/bin/summary_gtdbtk.py
+++ b/bin/summary_gtdbtk.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
+    parser.add_argument('-x',  "--extension",                    required=True,                 type=str,                    help="File extension passed to GTDB-TK and substracted by GTDB-Tk from bin names in results files.")
     parser.add_argument('-s',  "--summaries",         nargs="+",                metavar='FILE',                              help="List of GTDB-tk summary files.")
     parser.add_argument('-fi', "--filtered_bins",     nargs="+",                metavar='FILE',                              help="List of files containing names of bins which where filtered out during GTDB-tk analysis.")
     parser.add_argument('-fa', "--failed_bins",       nargs="+",                metavar='FILE',                              help="List of files containing bin names for which GTDB-tk analysis failed.")
@@ -51,6 +52,8 @@ def main(args=None):
     if args.summaries:
         for file in args.summaries:
             df_summary = pd.read_csv(file, sep='\t')[columns]
+            # add by GTDB-Tk substracted file extension again to bin names (at least until changed consistently in rest of pipeline)
+            df_summary['user_genome'] = df_summary['user_genome'].astype(str) + '.' + args.extension
             df_summary.set_index('user_genome', inplace=True)
             df_final = df_final.append(df_summary, verify_integrity=True)
 
@@ -64,6 +67,7 @@ def main(args=None):
                 filtered.append(bin_results)
     
     df_filtered = pd.DataFrame(filtered, columns=columns)
+    df_filtered['user_genome'] = df_filtered['user_genome'].astype(str) + '.' + args.extension
     df_filtered.set_index('user_genome', inplace=True)
     df_final = df_final.append(df_filtered, verify_integrity=True)
 
@@ -77,6 +81,7 @@ def main(args=None):
                 failed.append(bin_results)
 
     df_failed = pd.DataFrame(failed, columns=columns)
+    df_failed['user_genome'] = df_failed['user_genome'].astype(str) + '.' + args.extension
     df_failed.set_index('user_genome', inplace=True)
     df_final = df_final.append(df_failed, verify_integrity=True)
 

--- a/bin/summary_gtdbtk.py
+++ b/bin/summary_gtdbtk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import re
+import sys
+import argparse
+import os.path
+import pandas as pd
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s',  "--summaries",         nargs="+",                metavar='FILE',                              help="List of GTDB-tk summary files.")
+    parser.add_argument('-fi', "--filtered_bins",     nargs="+",                metavar='FILE',                              help="List of files containing names of bins which where filtered out during GTDB-tk analysis.")
+    parser.add_argument('-fa', "--failed_bins",       nargs="+",                metavar='FILE',                              help="List of files containing bin names for which GTDB-tk analysis failed.")
+    parser.add_argument('-d',  "--qc_discarded_bins", nargs="+",                metavar='FILE', type=str,                    help="List of files containing names of bins which were discarded based on BUSCO metrics.")
+
+    parser.add_argument('-o',  "--out",                          required=True, metavar='FILE', type=argparse.FileType('w'), help="Output file containing final GTDB-tk summary.")
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    if not args.summaries and not args.filtered_bins and not args.failed_bins and not args.qc_discarded_bins:
+        sys.exit("Either --summaries, --filtered_bins, --failed_bins or --qc_discarded_bins must be specified!")
+
+    columns = ["user_genome", \
+                "classification", \
+                "fastani_reference", \
+                "fastani_ani", \
+                "fastani_af", \
+                "closest_placement_reference", \
+                "closest_placement_ani", \
+                "closest_placement_af", \
+                "classification_method", \
+                "msa_percent", \
+                "red_value", \
+                "warnings"]
+    # TODO add more columns?
+
+    # For bins already discarded based on BUSCO QC metrics
+    discarded = []
+    if args.qc_discarded_bins:
+        for bin_name in args.qc_discarded_bins:
+            bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+            discarded.append(bin_results)
+
+    df_final = pd.DataFrame(discarded, columns=columns)
+    df_final.set_index('user_genome', inplace=True)
+
+    # For bins with succesfull GTDB-tk classification
+    if args.summaries:
+        for file in args.summaries:
+            df_summary = pd.read_csv(file, sep='\t')[columns]
+            df_summary.set_index('user_genome', inplace=True)
+            df_final = df_final.append(df_summary, verify_integrity=True)
+
+    # For bins that were filtered out by GTDB-tk (e.g. due to insufficient number of AAs in MSA)
+    filtered = []
+    if args.filtered_bins:
+        for file in args.filtered_bins:
+            with open(file) as infile:
+                bin_name = infile.readline().split("\t")[0]
+                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+                filtered.append(bin_results)
+    
+    df_filtered = pd.DataFrame(filtered, columns=columns)
+    df_filtered.set_index('user_genome', inplace=True)
+    df_final = df_final.append(df_filtered, verify_integrity=True)
+
+    # For bins for which GTDB-tk classification failed
+    failed = []
+    if args.failed_bins:
+        for file in args.failed_bins:
+            with open(file) as infile:
+                bin_name = infile.readline().split("\t")[0]
+                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+                failed.append(bin_results)
+
+    df_failed = pd.DataFrame(failed, columns=columns)
+    df_failed.set_index('user_genome', inplace=True)
+    df_final = df_final.append(df_failed, verify_integrity=True)
+
+    # write output
+    df_final\
+        .reset_index()\
+        .rename(columns={"index": "user_genome"})\
+        .to_csv(args.out, sep="\t", index=False)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/summary_gtdbtk.py
+++ b/bin/summary_gtdbtk.py
@@ -27,22 +27,30 @@ def main(args=None):
     columns = ["user_genome", \
                 "classification", \
                 "fastani_reference", \
+                "fastani_reference_radius", \
+                "fastani_taxonomy", \
                 "fastani_ani", \
                 "fastani_af", \
                 "closest_placement_reference", \
+                "closest_placement_radius", \
+                "closest_placement_taxonomy", \
                 "closest_placement_ani", \
                 "closest_placement_af", \
+                "pplacer_taxonomy", \
                 "classification_method", \
+                "note", \
+                "other_related_references(genome_id,species_name,radius,ANI,AF)", \
                 "msa_percent", \
+                "translation_table", \
                 "red_value", \
                 "warnings"]
-    # TODO add more columns?
+    # Note: currently all columns included
 
     # For bins already discarded based on BUSCO QC metrics
     discarded = []
     if args.qc_discarded_bins:
         for bin_name in args.qc_discarded_bins:
-            bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+            bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
             discarded.append(bin_results)
 
     df_final = pd.DataFrame(discarded, columns=columns)
@@ -63,7 +71,7 @@ def main(args=None):
         for file in args.filtered_bins:
             with open(file) as infile:
                 bin_name = infile.readline().split("\t")[0]
-                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
                 filtered.append(bin_results)
 
     df_filtered = pd.DataFrame(filtered, columns=columns)
@@ -77,7 +85,7 @@ def main(args=None):
         for file in args.failed_bins:
             with open(file) as infile:
                 bin_name = infile.readline().split("\t")[0]
-                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+                bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
                 failed.append(bin_results)
 
     df_failed = pd.DataFrame(failed, columns=columns)

--- a/conf/base.config
+++ b/conf/base.config
@@ -71,6 +71,11 @@ process {
     memory = { check_max (40.GB * task.attempt, 'memory' ) }
     time = { check_max (12.h * task.attempt, 'time' ) }
   }
+  withName: GTDBTK_CLASSIFY {
+    cpus = { check_max (10 * task.attempt, 'cpus' ) }
+    memory = { check_max (128.GB * task.attempt, 'memory' ) }
+    time = { check_max (12.h * task.attempt, 'time' ) }
+  }
   //MEGAHIT returns exit code 250 when running out of memory
   withName: MEGAHIT {
     cpus = { check_megahit_cpus (8, task.attempt ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -130,7 +130,10 @@ params {
         'gtdbtk_classify' {
             publish_files  = ['log':'', 'tsv':'', 'tree':'', 'fasta':'']
             publish_by_id  = true
-            publish_dir    = "Taxonomy/"
+            publish_dir    = "Taxonomy/GTDB-Tk"
+        }
+        'gtdbtk_summary' {
+            publish_dir    = "Taxonomy/GTDB-Tk"
         }
         'multiqc' {
             args = ""

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -120,7 +120,7 @@ params {
         'quast_bins' {
             publish_dir    = "GenomeBinning/QC"
         }
-        'merge_quast_and_busco' {
+        'quast_bins_summary' {
             publish_dir    = "GenomeBinning/QC"
         }
         'cat' {
@@ -128,12 +128,17 @@ params {
             publish_dir    = "Taxonomy/"
         }
         'gtdbtk_classify' {
+            args           = "--extension fa"
             publish_files  = ['log':'', 'tsv':'', 'tree':'', 'fasta':'']
             publish_by_id  = true
             publish_dir    = "Taxonomy/GTDB-Tk"
         }
         'gtdbtk_summary' {
+            args           = "--extension fa"
             publish_dir    = "Taxonomy/GTDB-Tk"
+        }
+        'merge_quast_busco_gtdbtk' {
+            publish_dir    = "GenomeBinning/QC"
         }
         'multiqc' {
             args = ""

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -125,7 +125,7 @@ params {
         }
         'cat' {
             publish_by_id  = true
-            publish_dir    = "Taxonomy/"
+            publish_dir    = "Taxonomy/CAT"
         }
         'gtdbtk_classify' {
             args           = "--extension fa"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -138,7 +138,7 @@ params {
             publish_dir    = "Taxonomy/GTDB-Tk"
         }
         'merge_quast_busco_gtdbtk' {
-            publish_dir    = "GenomeBinning/QC"
+            publish_dir    = "GenomeBinning"
         }
         'multiqc' {
             args = ""

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -127,6 +127,11 @@ params {
             publish_by_id  = true
             publish_dir    = "Taxonomy/"
         }
+        'gtdbtk_classify' {
+            publish_files  = ['log':'', 'tsv':'', 'tree':'', 'fasta':'']
+            publish_by_id  = true
+            publish_dir    = "Taxonomy/"
+        }
         'multiqc' {
             args = ""
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -129,7 +129,7 @@ params {
         }
         'gtdbtk_classify' {
             args           = "--extension fa"
-            publish_files  = ['log':'', 'tsv':'', 'tree':'', 'fasta':'']
+            publish_files  = ['log':'', 'tsv':'', 'tree.gz':'', 'fasta':'', 'fasta.gz':'']
             publish_by_id  = true
             publish_dir    = "Taxonomy/GTDB-Tk"
         }

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,4 +22,5 @@ params {
   skip_krona = true
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  gtdb = false
 }

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -23,4 +23,5 @@ params {
   skip_krona = true
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  gtdb = false
 }

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -19,4 +19,5 @@ params {
   input = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/samplesheet.hybrid.csv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  gtdb = false
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -20,4 +20,5 @@ params {
   input = 'https://github.com/nf-core/test-datasets/raw/mag/test_data/samplesheet.hybrid_host_rm.csv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  gtdb = false
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -12,10 +12,11 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/)
 and processes data using the following steps:
 
 * [Quality control](#quality-control) of input reads - trimming and contaminant removal
-* [Taxonomic classification of trimmed reads](#taxonomic-classification-reads)
+* [Taxonomic classification of trimmed reads](#taxonomic-classification-of-trimmed-reads)
 * [Assembly](#assembly) of trimmed reads
 * [Binning](#binning) of assembled contigs
-* [Taxonomic classification of binned genomes](#taxonomic-classification-bins)
+* [Taxonomic classification of binned genomes](#taxonomic-classification-of-binned-genomes)
+* [Additional summary for binned genomes](#additional-summary-for-binned-genomes)
 * [MultiQC](#multiqc) - aggregate report, describing results of the whole pipeline
 * [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
 
@@ -228,7 +229,6 @@ Files in these two folders contain all contigs of an assembly.
 
 * `GenomeBinning/QC/`
   * `quast_summary.tsv`: QUAST output for all bins summarized
-  * `quast_and_busco_summary.tsv`: Summary of BUSCO and QUAST results
 
 ### QC for metagenome assembled genomes with BUSCO
 
@@ -258,7 +258,6 @@ Besides the reference files or output files created by BUSCO, the following summ
 
 * `GenomeBinning/QC/`
   * `busco_summary.tsv`: A summary table of the BUSCO results, with % of marker genes found. If run in automated lineage selection mode, both the results for the selected domain and for the selected more specific lineage will be given, if available.
-  * `quast_and_busco_summary.tsv`; Summary of BUSCO and QUAST results
 
 ## Taxonomic classification of binned genomes
 
@@ -291,6 +290,12 @@ Besides the reference files or output files created by BUSCO, the following summ
   * `gtdbtk.[assembler]-[sample/group].*.log`: Log files.
   * `gtdbtk.[assembler]-[sample/group].failed_genomes.tsv`: A list of genomes for which the GTDB-Tk analysis failed, e.g. because Prodigal could not detect any genes.
 * `Taxonomy/GTDB-Tk/gtdbtk_summary.tsv`: A summary table of the GTDB-Tk classification results for all bins, also containing bins which were discarded based on the BUSCO QC, which were filtered out by GTDB-Tk ((listed in `*.filtered.tsv`) or for which the analysis failed (listed in `*.failed_genomes.tsv`).
+
+## Additional summary for binned genomes
+
+**Output files:**
+
+* `GenomeBinning/bin_summary.tsv`: Summary of BUSCO, QUAST and GTDB-Tk results, if at least two of those were generated.
 
 ## MultiQC
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -280,9 +280,9 @@ Besides the reference files or output files created by BUSCO, the following summ
 
 * `Taxonomy/GTDB-Tk/[assembler]-[sample/group]/`
   * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.summary.tsv`: Classifications for bacterial and archaeal genomes (see the [GTDB-Tk documentation for details](https://ecogenomics.github.io/GTDBTk/files/summary.tsv.html).
-  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.classify.tree`: Reference tree in Newick format containing query genomes placed with pplacer.
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.classify.tree.gz`: Reference tree in Newick format containing query genomes placed with pplacer.
   * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.markers_summary.tsv`: A summary of unique, duplicated, and missing markers within the 120 bacterial marker set, or the 122 archaeal marker set for each submitted genome.
-  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.msa.fasta`: FASTA file containing MSA of submitted and reference genomes.
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.msa.fasta.gz`: FASTA file containing MSA of submitted and reference genomes.
   * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.filtered.tsv`: A list of genomes with an insufficient number of amino acids in MSA.
   * `gtdbtk.[assembler]-[sample/group].*.log`: Log files.
   * `gtdbtk.[assembler]-[sample/group].failed_genomes.tsv`: A list of genomes for which the GTDB-Tk analysis failed, e.g. because Prodigal could not detect any genes.

--- a/docs/output.md
+++ b/docs/output.md
@@ -268,7 +268,7 @@ Besides the reference files or output files created by BUSCO, the following summ
 
 **Output files:**
 
-* `Taxonomy/[assembler]/`
+* `Taxonomy/CAT/[assembler]/`
   * `[assembler]-[sample/group].ORF2LCA.txt`: Tab-delimited files containing the lineage of each contig
   * `[assembler]-[sample/group].names.txt`: Taxonomy classification, with names of each lineage levels instead og taxids
   * `[assembler]-[sample/group].predicted_proteins.faa`: predicted protein sequences for each genome bins, in fasta format

--- a/docs/output.md
+++ b/docs/output.md
@@ -12,9 +12,10 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/)
 and processes data using the following steps:
 
 * [Quality control](#quality-control) of input reads - trimming and contaminant removal
-* [Taxonomic classification](#taxonomic-classification) of trimmed reads
+* [Taxonomic classification of trimmed reads](#taxonomic-classification-reads)
 * [Assembly](#assembly) of trimmed reads
 * [Binning](#binning) of assembled contigs
+* [Taxonomic classification of binned genomes](#taxonomic-classification-bins)
 * [MultiQC](#multiqc) - aggregate report, describing results of the whole pipeline
 * [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
 
@@ -94,7 +95,7 @@ NanoPlot is used to calculate various metrics and plots about the quality and le
   * `raw_*.[png/html/txt]`: Plots and reports for raw data
   * `filtered_*.[png/html/txt]`: Plots and reports for filtered data
 
-## Taxonomic Classification
+## Taxonomic classification of trimmed reads
 
 ### Kraken
 
@@ -118,20 +119,6 @@ More information on the [Centrifuge](https://ccb.jhu.edu/software/centrifuge/) w
   * `report.txt`: Tab-delimited result file. See the [centrifuge manual](https://ccb.jhu.edu/software/centrifuge/manual.shtml#centrifuge-classification-output) for information about the fields
   * `kreport.txt`: Classification in the Kraken report format. See the [kraken2 manual](https://github.com/DerrickWood/kraken2/wiki/Manual#output-formats) for more details
   * `taxonomy.krona.html`: Interactive pie chart produced by [KronaTools](https://github.com/marbl/Krona/wiki)
-
-### CAT
-
-[CAT](https://github.com/dutilh/CAT) is a toolkit for annotating contigs and bins from metagenome-assembled-genomes. The MAG pipeline uses CAT to assign taxonomy to genome bins based on the taxnomy of the contigs.
-
-**Output files:**
-
-* `Taxonomy/[assembler]/`
-  * `[assembler]-[sample/group].ORF2LCA.txt`: Tab-delimited files containing the lineage of each contig
-  * `[assembler]-[sample/group].names.txt`: Taxonomy classification, with names of each lineage levels instead og taxids
-  * `[assembler]-[sample/group].predicted_proteins.faa`: predicted protein sequences for each genome bins, in fasta format
-  * `[assembler]-[sample/group].predicted_proteins.gff`: predicted protein features for each genome bins, in gff format
-  * `[assembler]-[sample/group].log`: Log files
-  * `[assembler]-[sample/group].bin2classification.txt`: Taxonomy classification of the genome bins
 
 ## Assembly
 
@@ -272,6 +259,38 @@ Besides the reference files or output files created by BUSCO, the following summ
 * `GenomeBinning/QC/`
   * `busco_summary.tsv`: A summary table of the BUSCO results, with % of marker genes found. If run in automated lineage selection mode, both the results for the selected domain and for the selected more specific lineage will be given, if available.
   * `quast_and_busco_summary.tsv`; Summary of BUSCO and QUAST results
+
+## Taxonomic classification of binned genomes
+
+### CAT
+
+[CAT](https://github.com/dutilh/CAT) is a toolkit for annotating contigs and bins from metagenome-assembled-genomes. The MAG pipeline uses CAT to assign taxonomy to genome bins based on the taxnomy of the contigs.
+
+**Output files:**
+
+* `Taxonomy/[assembler]/`
+  * `[assembler]-[sample/group].ORF2LCA.txt`: Tab-delimited files containing the lineage of each contig
+  * `[assembler]-[sample/group].names.txt`: Taxonomy classification, with names of each lineage levels instead og taxids
+  * `[assembler]-[sample/group].predicted_proteins.faa`: predicted protein sequences for each genome bins, in fasta format
+  * `[assembler]-[sample/group].predicted_proteins.gff`: predicted protein features for each genome bins, in gff format
+  * `[assembler]-[sample/group].log`: Log files
+  * `[assembler]-[sample/group].bin2classification.txt`: Taxonomy classification of the genome bins
+
+### GTDB-Tk
+
+[GTDB-Tk](https://github.com/Ecogenomics/GTDBTk) is a toolkit for assigning taxonomic classifications to bacterial and archaeal genomes based on the Genome Database Taxonomy [GTDB](https://gtdb.ecogenomic.org/). nf-core/mag uses GTDB-Tk to classify binned genomes which satisfy certain quality criteria (i.e. completeness and contamination assessed with the BUSCO analysis).
+
+**Output files:**
+
+* `Taxonomy/GTDB-Tk/[assembler]-[sample/group]/`
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.summary.tsv`: Classifications for bacterial and archaeal genomes (see the [GTDB-Tk documentation for details](https://ecogenomics.github.io/GTDBTk/files/summary.tsv.html).
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.classify.tree`: Reference tree in Newick format containing query genomes placed with pplacer.
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.markers_summary.tsv`: A summary of unique, duplicated, and missing markers within the 120 bacterial marker set, or the 122 archaeal marker set for each submitted genome.
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.msa.fasta`: FASTA file containing MSA of submitted and reference genomes.
+  * `gtdbtk.[assembler]-[sample/group].{bac120/ar122}.filtered.tsv`: A list of genomes with an insufficient number of amino acids in MSA.
+  * `gtdbtk.[assembler]-[sample/group].*.log`: Log files.
+  * `gtdbtk.[assembler]-[sample/group].failed_genomes.tsv`: A list of genomes for which the GTDB-Tk analysis failed, e.g. because Prodigal could not detect any genes.
+* `Taxonomy/GTDB-Tk/gtdbtk_summary.tsv`: A summary table of the GTDB-Tk classification results for all bins, also containing bins which were discarded based on the BUSCO QC, which were filtered out by GTDB-Tk ((listed in `*.filtered.tsv`) or for which the analysis failed (listed in `*.failed_genomes.tsv`).
 
 ## MultiQC
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -224,9 +224,6 @@ Files in these two folders contain all contigs of an assembly.
   * `report.*`: QUAST report in various formats, such as html, txt, tsv or tex
   * `quast.log`: QUAST log file
   * `predicted_genes/[assembler]-[sample/group].rna.gff`: Contig positions for rRNA genes in gff version 3 format
-  
-**Output files:**
-
 * `GenomeBinning/QC/`
   * `quast_summary.tsv`: QUAST output for all bins summarized
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,8 @@ MetaBAT2 is run by default with a fixed seed within this pipeline, thus producin
 
 To allow also reproducible bin QC with BUSCO, run BUSCO providing already downloaded lineage datasets with `--busco_download_path` (BUSCO will be run using automated lineage selection in offline mode) or provide a specific lineage dataset via `--busco_reference` and use the parameter `--save_busco_reference`. This may be useful since BUSCO datasets are frequently updated and old versions do not always remain (easily) accessible.
 
+The taxonomic classification of bins with GTDB-Tk is not guaranteed to be reproducible, since the placement of bins in the reference tree is non-deterministic. However, the authors of the GTDB-Tk article examined the reproducibility on a set of 100 genomes across 50 trials and did not observe any difference (see [https://doi.org/10.1093/bioinformatics/btz848](https://doi.org/10.1093/bioinformatics/btz848)).
+
 ## Core Nextflow arguments
 
 > **NB:** These options are part of Nextflow and use a _single_ hyphen (pipeline parameters use a double-hyphen).

--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -128,8 +128,10 @@ class Workflow {
             System.exit(1)
         }
 
-        if (params.skip_busco && !params.skip_filt_gtdbtk && params.gtdb)
-            log.warn "GTDB-tk bin classification is run on all bins without filtering based on BUSCO QC results, because BUSCO analysis is skipped (specified by --skip_busco)! Results can be impaired due to not enough marker genes or contamination."
+        if (params.skip_busco && params.gtdb) {
+            log.error "Invalid combination of parameters --skip_busco and --gtdb are specififed! GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
+            System.exit(1)
+        }
     }
 
     /*

--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -127,6 +127,9 @@ class Workflow {
             log.error "Both --busco_auto_lineage_prok and --busco_reference are specififed! Invalid combination, please specify either --busco_auto_lineage_prok or --busco_reference."
             System.exit(1)
         }
+
+        if (params.skip_busco && !params.skip_filt_gtdbtk && params.gtdb)
+            log.warn "GTDB-tk bin classification is run on all bins without filtering based on BUSCO QC results, because BUSCO analysis is skipped (specified by --skip_busco)! Results can be impaired due to not enough marker genes or contamination."
     }
 
     /*

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -1,0 +1,33 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process GTDBTK_CLASSIFY {
+    tag "${meta.assembler}-${meta.id}"
+
+    conda (params.enable_conda ? "conda-forge::gtdbtk=1.4.1" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/gtdbtk:1.4.1--py_1"
+    } else {
+        container "quay.io/biocontainers/gtdbtk:1.4.1--py_1"
+    }
+
+    input:
+    tuple val(meta), path("bins/*")
+    tuple val(db_name), path("database/*")
+
+    output:
+    tuple val(meta), path("classify/*"), emit: taxonomy
+    path '*.version.txt'               , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    """
+    export GTDBTK_DATA_PATH="\${PWD}/database"
+    gtdbtk classify_wf --genome_dir bins --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa 5 --min_af 0.4
+
+    gtdbtk --version | sed "s/gtdbtk: version //; s/ Copyright.*//" > ${software}.version.txt
+    """
+}

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -36,13 +36,20 @@ process GTDBTK_CLASSIFY {
 
     script:
     def software = getSoftwareName(task.process)
+    def pplacer_scratch = params.gtdbtk_pplacer_scratch ? "--scratch_dir pplacer_tmp" : ""
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
+    if [ ${pplacer_scratch} != "" ] ; then
+        mkdir pplacer_tmp
+    fi
+
     gtdbtk classify_wf $options.args \
                        --genome_dir bins \
                        --prefix "gtdbtk.${meta.assembler}-${meta.id}" \
                        --out_dir "\${PWD}" \
                        --cpus ${task.cpus} \
+                       --pplacer_cpus ${params.gtdbtk_pplacer_cpus} \
+                       ${pplacer_scratch} \
                        --min_perc_aa ${params.gtdbtk_min_perc_aa} \
                        --min_af ${params.gtdbtk_min_af}
 

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -23,25 +23,31 @@ process GTDBTK_CLASSIFY {
     tuple val(db_name), path("database/*")
 
     output:
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.summary.tsv"        , emit: summary
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree"      , emit: tree
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.markers_summary.tsv", emit: markers
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta"          , emit: msa
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.user_msa.fasta"     , emit: user_msa
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.filtered.tsv"       , emit: filtered
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.log"                  , emit: log
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.warnings.log"         , emit: warnings
-    path "classify/gtdbtk.${meta.assembler}-${meta.id}.failed_genomes.tsv"   , emit: failed
-    path '*.version.txt'                                                     , emit: version
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.summary.tsv"        , emit: summary
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree"      , emit: tree
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.markers_summary.tsv", emit: markers
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta"          , emit: msa
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.user_msa.fasta"     , emit: user_msa
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.filtered.tsv"       , emit: filtered
+    path "gtdbtk.${meta.assembler}-${meta.id}.log"                  , emit: log
+    path "gtdbtk.${meta.assembler}-${meta.id}.warnings.log"         , emit: warnings
+    path "gtdbtk.${meta.assembler}-${meta.id}.failed_genomes.tsv"   , emit: failed
+    path '*.version.txt'                                            , emit: version
 
     script:
     def software = getSoftwareName(task.process)
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
-    gtdbtk classify_wf --genome_dir bins --prefix "gtdbtk.${meta.assembler}-${meta.id}" --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa ${params.gtdbtk_min_perc_aa} --min_af ${params.gtdbtk_min_af}
+    gtdbtk classify_wf --genome_dir bins \
+                       --prefix "gtdbtk.${meta.assembler}-${meta.id}" \
+                       --out_dir "\${PWD}" \
+                       -x fa \
+                       --cpus ${task.cpus} \
+                       --min_perc_aa ${params.gtdbtk_min_perc_aa} \
+                       --min_af ${params.gtdbtk_min_af}
 
-    mv classify/gtdbtk.log "classify/gtdbtk.${meta.assembler}-${meta.id}.log"
-    mv classify/gtdbtk.warnings.log "classify/gtdbtk.${meta.assembler}-${meta.id}.warnings.log"
+    mv gtdbtk.log "gtdbtk.${meta.assembler}-${meta.id}.log"
+    mv gtdbtk.warnings.log "gtdbtk.${meta.assembler}-${meta.id}.warnings.log"
     gtdbtk --version | sed "s/gtdbtk: version //; s/ Copyright.*//" > ${software}.version.txt
     """
 }

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -38,10 +38,10 @@ process GTDBTK_CLASSIFY {
     def software = getSoftwareName(task.process)
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
-    gtdbtk classify_wf --genome_dir bins \
+    gtdbtk classify_wf $options.args \
+                       --genome_dir bins \
                        --prefix "gtdbtk.${meta.assembler}-${meta.id}" \
                        --out_dir "\${PWD}" \
-                       -x fa \
                        --cpus ${task.cpus} \
                        --min_perc_aa ${params.gtdbtk_min_perc_aa} \
                        --min_af ${params.gtdbtk_min_af}

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -9,7 +9,7 @@ process GTDBTK_CLASSIFY {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}/${meta.id}") }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}-${meta.id}") }
 
     conda (params.enable_conda ? "conda-forge::gtdbtk=1.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -23,15 +23,16 @@ process GTDBTK_CLASSIFY {
     tuple val(db_name), path("database/*")
 
     output:
-    path 'classify/gtdbtk.*.summary.tsv'        , emit: summary
-    path 'classify/gtdbtk.*.classify.tree'      , emit: tree
-    path 'classify/gtdbtk.*.markers_summary.tsv', emit: markers
-    path 'classify/gtdbtk.*.msa.fasta'          , emit: msa
-    path 'classify/gtdbtk.*.user_msa.fasta'     , emit: user_msa
-    path 'classify/gtdbtk.*.filtered.tsv'       , emit: filtered
-    path 'classify/gtdbtk.*.log'                , emit: log
-    path 'classify/gtdbtk.*.warnings.log'       , emit: warnings
-    path '*.version.txt'                        , emit: version
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.summary.tsv"        , emit: summary
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree"      , emit: tree
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.markers_summary.tsv", emit: markers
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta"          , emit: msa
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.user_msa.fasta"     , emit: user_msa
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.*.filtered.tsv"       , emit: filtered
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.log"                  , emit: log
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.warnings.log"         , emit: warnings
+    path "classify/gtdbtk.${meta.assembler}-${meta.id}.failed_genomes.tsv"   , emit: failed
+    path '*.version.txt'                                                     , emit: version
 
     script:
     def software = getSoftwareName(task.process)

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -11,11 +11,11 @@ process GTDBTK_CLASSIFY {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}/${meta.id}") }
 
-    conda (params.enable_conda ? "conda-forge::gtdbtk=1.4.1" : null)
+    conda (params.enable_conda ? "conda-forge::gtdbtk=1.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/gtdbtk:1.4.1--py_1"
+        container "https://depot.galaxyproject.org/singularity/gtdbtk:1.5.0--pyhdfd78af_0"
     } else {
-        container "quay.io/biocontainers/gtdbtk:1.4.1--py_1"
+        container "quay.io/biocontainers/gtdbtk:1.5.0--pyhdfd78af_0"
     }
 
     input:

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -37,7 +37,7 @@ process GTDBTK_CLASSIFY {
     def software = getSoftwareName(task.process)
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
-    gtdbtk classify_wf --genome_dir bins --prefix "gtdbtk.${meta.assembler}-${meta.id}" --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa 5 --min_af 0.4
+    gtdbtk classify_wf --genome_dir bins --prefix "gtdbtk.${meta.assembler}-${meta.id}" --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa ${params.gtdbtk_min_perc_aa} --min_af ${params.gtdbtk_min_af}
 
     mv classify/gtdbtk.log "classify/gtdbtk.${meta.assembler}-${meta.id}.log"
     mv classify/gtdbtk.warnings.log "classify/gtdbtk.${meta.assembler}-${meta.id}.warnings.log"

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -29,16 +29,18 @@ process GTDBTK_CLASSIFY {
     path 'classify/gtdbtk.*.msa.fasta'          , emit: msa
     path 'classify/gtdbtk.*.user_msa.fasta'     , emit: user_msa
     path 'classify/gtdbtk.*.filtered.tsv'       , emit: filtered
-    path 'classify/gtdbtk.log'                  , emit: log
-    path 'classify/gtdbtk.warnings.log'         , emit: warnings
+    path 'classify/gtdbtk.*.log'                , emit: log
+    path 'classify/gtdbtk.*.warnings.log'       , emit: warnings
     path '*.version.txt'                        , emit: version
 
     script:
     def software = getSoftwareName(task.process)
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
-    gtdbtk classify_wf --genome_dir bins --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa 5 --min_af 0.4
+    gtdbtk classify_wf --genome_dir bins --prefix "gtdbtk.${meta.assembler}-${meta.id}" --out_dir classify -x fa --cpus ${task.cpus} --min_perc_aa 5 --min_af 0.4
 
+    mv classify/gtdbtk.log "classify/gtdbtk.${meta.assembler}-${meta.id}.log"
+    mv classify/gtdbtk.warnings.log "classify/gtdbtk.${meta.assembler}-${meta.id}.warnings.log"
     gtdbtk --version | sed "s/gtdbtk: version //; s/ Copyright.*//" > ${software}.version.txt
     """
 }

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -7,6 +7,10 @@ options    = initOptions(params.options)
 process GTDBTK_CLASSIFY {
     tag "${meta.assembler}-${meta.id}"
 
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}/${meta.id}") }
+
     conda (params.enable_conda ? "conda-forge::gtdbtk=1.4.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/gtdbtk:1.4.1--py_1"
@@ -19,8 +23,15 @@ process GTDBTK_CLASSIFY {
     tuple val(db_name), path("database/*")
 
     output:
-    tuple val(meta), path("classify/*"), emit: taxonomy
-    path '*.version.txt'               , emit: version
+    path 'classify/gtdbtk.*.summary.tsv'        , emit: summary
+    path 'classify/gtdbtk.*.classify.tree'      , emit: tree
+    path 'classify/gtdbtk.*.markers_summary.tsv', emit: markers
+    path 'classify/gtdbtk.*.msa.fasta'          , emit: msa
+    path 'classify/gtdbtk.*.user_msa.fasta'     , emit: user_msa
+    path 'classify/gtdbtk.*.filtered.tsv'       , emit: filtered
+    path 'classify/gtdbtk.log'                  , emit: log
+    path 'classify/gtdbtk.warnings.log'         , emit: warnings
+    path '*.version.txt'                        , emit: version
 
     script:
     def software = getSoftwareName(task.process)

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -24,9 +24,9 @@ process GTDBTK_CLASSIFY {
 
     output:
     path "gtdbtk.${meta.assembler}-${meta.id}.*.summary.tsv"        , emit: summary
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree"      , emit: tree
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree.gz"   , emit: tree
     path "gtdbtk.${meta.assembler}-${meta.id}.*.markers_summary.tsv", emit: markers
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta"          , emit: msa
+    path "gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta.gz"       , emit: msa
     path "gtdbtk.${meta.assembler}-${meta.id}.*.user_msa.fasta"     , emit: user_msa
     path "gtdbtk.${meta.assembler}-${meta.id}.*.filtered.tsv"       , emit: filtered
     path "gtdbtk.${meta.assembler}-${meta.id}.log"                  , emit: log
@@ -53,6 +53,7 @@ process GTDBTK_CLASSIFY {
                        --min_perc_aa ${params.gtdbtk_min_perc_aa} \
                        --min_af ${params.gtdbtk_min_af}
 
+    gzip "gtdbtk.${meta.assembler}-${meta.id}".*.classify.tree "gtdbtk.${meta.assembler}-${meta.id}".*.msa.fasta
     mv gtdbtk.log "gtdbtk.${meta.assembler}-${meta.id}.log"
     mv gtdbtk.warnings.log "gtdbtk.${meta.assembler}-${meta.id}.warnings.log"
     gtdbtk --version | sed "s/gtdbtk: version //; s/ Copyright.*//" > ${software}.version.txt

--- a/modules/local/gtdbtk_db_preparation.nf
+++ b/modules/local/gtdbtk_db_preparation.nf
@@ -1,0 +1,28 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process GTDBTK_DB_PREPARATION {
+    tag "${database}"
+
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
+    } else {
+        container "biocontainers/biocontainers:v1.2.0_cv1"
+    }
+
+    input:
+    path(database)
+
+    output:
+    tuple val("${database.toString().replace(".tar.gz", "")}"), path("database/*")
+
+    script:
+    """
+    mkdir database
+    tar -xzf ${database} -C database --strip 1
+    """
+}

--- a/modules/local/gtdbtk_summary.nf
+++ b/modules/local/gtdbtk_summary.nf
@@ -1,0 +1,37 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process GTDBTK_SUMMARY {
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+
+    conda (params.enable_conda ? "conda-forge::pandas=1.1.5" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/pandas:1.1.5"
+    } else {
+        container "quay.io/biocontainers/pandas:1.1.5"
+    }
+
+    input:
+    path(qc_discarded_bins)
+    path(summaries)
+    path(filtered_bins)
+    path(failed_bins)
+
+    output:
+    path "gtdbtk_summary.tsv", emit: summary
+
+    script:
+    def discarded = qc_discarded_bins.size() > 0 ? "--qc_discarded_bins ${qc_discarded_bins}" : ""
+    def summaries = summaries.size() > 0 ?         "--summaries ${summaries}" : ""
+    def filtered  = filtered_bins.size() > 0 ?     "--filtered_bins ${filtered_bins}" : ""
+    def failed    = failed_bins.size() > 0 ?       "--failed_bins ${failed_bins}" : ""
+    """
+    summary_gtdbtk.py $discarded $summaries $filtered $failed --out gtdbtk_summary.tsv
+    """
+}

--- a/modules/local/gtdbtk_summary.nf
+++ b/modules/local/gtdbtk_summary.nf
@@ -32,6 +32,6 @@ process GTDBTK_SUMMARY {
     def filtered  = filtered_bins.size() > 0 ?     "--filtered_bins ${filtered_bins}" : ""
     def failed    = failed_bins.size() > 0 ?       "--failed_bins ${failed_bins}" : ""
     """
-    summary_gtdbtk.py $discarded $summaries $filtered $failed --out gtdbtk_summary.tsv
+    summary_gtdbtk.py $options.args $discarded $summaries $filtered $failed --out gtdbtk_summary.tsv
     """
 }

--- a/modules/local/quast_bins_summary.nf
+++ b/modules/local/quast_bins_summary.nf
@@ -1,0 +1,31 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process QUAST_BINS_SUMMARY {
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+
+    input:
+    path(summaries)
+
+    output:
+    path("quast_summary.tsv"), emit: summary
+
+    script:
+    """
+    QUAST_BIN=\$(echo \"$summaries\" | sed 's/[][]//g')
+    IFS=', ' read -r -a quast_bin <<< \"\$QUAST_BIN\"
+    for quast_file in \"\${quast_bin[@]}\"; do
+        if ! [ -f "quast_summary.tsv" ]; then 
+            cp "\${quast_file}" "quast_summary.tsv"
+        else
+            tail -n +2 "\${quast_file}" >> "quast_summary.tsv"
+        fi
+    done
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,8 @@ params {
   gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
   gtdbtk_min_completeness    = 50.0
   gtdbtk_max_contamination   = 10.0
+  gtdbtk_min_perc_aa         = 10
+  gtdbtk_min_af              = 0.65
 
   // long read preprocessing options
   skip_adapter_trimming      = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,7 @@ params {
   kraken2_db                 = ''
   skip_krona                 = false
   cat_db                     = ''
+  gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz"
 
   // long read preprocessing options
   skip_adapter_trimming      = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,8 @@ params {
   gtdbtk_max_contamination   = 10.0
   gtdbtk_min_perc_aa         = 10
   gtdbtk_min_af              = 0.65
+  gtdbtk_pplacer_cpus        = 1
+  gtdbtk_pplacer_scratch     = true
 
   // long read preprocessing options
   skip_adapter_trimming      = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,6 @@ params {
   gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
   gtdbtk_min_completeness    = 50.0
   gtdbtk_max_contamination   = 10.0
-  skip_filt_gtdbtk           = false
 
   // long read preprocessing options
   skip_adapter_trimming      = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,9 @@ params {
   skip_krona                 = false
   cat_db                     = ''
   gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz"
+  gtdbtk_min_completeness    = 50.0
+  gtdbtk_max_contamination   = 10.0
+  skip_filt_gtdbtk           = false
 
   // long read preprocessing options
   skip_adapter_trimming      = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
   kraken2_db                 = ''
   skip_krona                 = false
   cat_db                     = ''
-  gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz"
+  gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
   gtdbtk_min_completeness    = 50.0
   gtdbtk_max_contamination   = 10.0
   skip_filt_gtdbtk           = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -441,6 +441,18 @@
                     "description": "Min. alignment fraction to consider closest genome.",
                     "minimum": 0.0,
                     "maximum": 1.0
+                },
+                "gtdbtk_pplacer_cpus": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Number of CPUs used for the by GTDB-Tk run tool pplacer.",
+                    "help_text": "A low number of CPUs helps to reduce the memory required/reported by GTDB-Tk. See also the [GTDB-Tk documentation](https://ecogenomics.github.io/GTDBTk/faq.html#gtdb-tk-reaches-the-memory-limit-pplacer-crashes)."
+                },
+                "gtdbtk_pplacer_scratch": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Reduce GTDB-Tk memory consumption by running pplacer in a setting writing to disk.",
+                    "help_text": "Will be slower. Set to `false` to turn this off."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -405,6 +405,12 @@
                     "type": "string",
                     "description": "Database for taxonomic classification of metagenome assembled genomes.",
                     "help_text": "E.g. \"https://tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20210107.tar.gz\".\nThe zipped file needs to contain a folder named \"*taxonomy*\" and \"*CAT_database*\" that hold the respective files."
+                },
+                "gtdb": {
+                    "type": "string",
+                    "default": "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz",
+                    "description": "GTDB database for taxonomic classification of bins with GTDB-tk.",
+                    "help_text": "for information which GTDB reference databases are compatible with the used GTDB-tk version see https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -415,7 +415,7 @@
                 "gtdbtk_min_completeness": {
                     "type": "number",
                     "default": 50.0,
-                    "description": "Min. bin completeness required to apply GTDB-tk classification.",
+                    "description": "Min. bin completeness (in %) required to apply GTDB-tk classification.",
                     "help_text": "Must be greater than 0 (min. 0.01) to avoid GTDB-tk errors. If too low, GTDB-tk classification results can be impaired due to not enough marker genes!",
                     "minimum": 0.01,
                     "maximum": 100.0
@@ -423,9 +423,24 @@
                 "gtdbtk_max_contamination": {
                     "type": "number",
                     "default": 10.0,
-                    "description": "Max. bin contamination allowed to apply GTDB-tk classification. If too high, GTDB-tk classification results can be impaired due to contamination!",
+                    "description": "Max. bin contamination (in %) allowed to apply GTDB-tk classification.",
+                    "help_text": "If too high, GTDB-tk classification results can be impaired due to contamination!",
                     "minimum": 0.0,
                     "maximum": 100.0
+                },
+                "gtdbtk_min_perc_aa": {
+                    "type": "number",
+                    "default": 10,
+                    "description": "Min. fraction of AA (in %) in the MSA for bins to be kept.",
+                    "minimum": 0.0,
+                    "maximum": 100.0
+                },
+                "gtdbtk_min_af": {
+                    "type": "number",
+                    "default": 0.65,
+                    "description": "Min. alignment fraction to consider closest genome.",
+                    "minimum": 0.0,
+                    "maximum": 1.0
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -416,7 +416,7 @@
                     "type": "number",
                     "default": 50.0,
                     "description": "Min. bin completeness (in %) required to apply GTDB-tk classification.",
-                    "help_text": "Must be greater than 0 (min. 0.01) to avoid GTDB-tk errors. If too low, GTDB-tk classification results can be impaired due to not enough marker genes!",
+                    "help_text": "Completeness assessed with BUSCO analysis (100% - %Missing). Must be greater than 0 (min. 0.01) to avoid GTDB-tk errors. If too low, GTDB-tk classification results can be impaired due to not enough marker genes!",
                     "minimum": 0.01,
                     "maximum": 100.0
                 },
@@ -424,7 +424,7 @@
                     "type": "number",
                     "default": 10.0,
                     "description": "Max. bin contamination (in %) allowed to apply GTDB-tk classification.",
-                    "help_text": "If too high, GTDB-tk classification results can be impaired due to contamination!",
+                    "help_text": "Contamination approximated based on BUSCO analysis (%Complete and duplicated). If too high, GTDB-tk classification results can be impaired due to contamination!",
                     "minimum": 0.0,
                     "maximum": 100.0
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -408,7 +408,7 @@
                 },
                 "gtdb": {
                     "type": "string",
-                    "default": "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz",
+                    "default": "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz",
                     "description": "GTDB database for taxonomic classification of bins with GTDB-tk.",
                     "help_text": "For information which GTDB reference databases are compatible with the used GTDB-tk version see https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -415,12 +415,17 @@
                 "gtdbtk_min_completeness": {
                     "type": "number",
                     "default": 50.0,
-                    "description": "Min. bin completeness required to apply GTDB-tk classification."
+                    "description": "Min. bin completeness required to apply GTDB-tk classification.",
+                    "help_text": "Must be greater than 0 (min. 0.01) to avoid GTDB-tk errors. If too low, GTDB-tk classification results can be impaired due to not enough marker genes!",
+                    "minimum": 0.01,
+                    "maximum": 100.0
                 },
                 "gtdbtk_max_contamination": {
                     "type": "number",
                     "default": 10.0,
-                    "description": "Max. bin contamination allowed to apply GTDB-tk classification."
+                    "description": "Max. bin contamination allowed to apply GTDB-tk classification. If too high, GTDB-tk classification results can be impaired due to contamination!",
+                    "minimum": 0.0,
+                    "maximum": 100.0
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -421,10 +421,6 @@
                     "type": "number",
                     "default": 10.0,
                     "description": "Max. bin contamination allowed to apply GTDB-tk classification."
-                },
-                "skip_filt_gtdbtk": {
-                    "type": "boolean",
-                    "description": "Skip filtering of bins based on BUSCO results for GTDB-tk classification."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -410,7 +410,21 @@
                     "type": "string",
                     "default": "https://data.gtdb.ecogenomic.org/releases/release95/95.0/auxillary_files/gtdbtk_r95_data.tar.gz",
                     "description": "GTDB database for taxonomic classification of bins with GTDB-tk.",
-                    "help_text": "for information which GTDB reference databases are compatible with the used GTDB-tk version see https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
+                    "help_text": "For information which GTDB reference databases are compatible with the used GTDB-tk version see https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
+                },
+                "gtdbtk_min_completeness": {
+                    "type": "number",
+                    "default": 50.0,
+                    "description": "Min. bin completeness required to apply GTDB-tk classification."
+                },
+                "gtdbtk_max_contamination": {
+                    "type": "number",
+                    "default": 10.0,
+                    "description": "Max. bin contamination allowed to apply GTDB-tk classification."
+                },
+                "skip_filt_gtdbtk": {
+                    "type": "boolean",
+                    "description": "Skip filtering of bins based on BUSCO results for GTDB-tk classification."
                 }
             }
         },

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -1,0 +1,71 @@
+/*
+ * GTDB-Tk bin classification, using BUSCO QC to filter bins
+ */
+
+params.gtdbtk_classify_options = [:]
+params.gtdbtk_summary_options  = [:]
+
+include { GTDBTK_DB_PREPARATION } from '../../modules/local/gtdbtk_db_preparation'
+include { GTDBTK_CLASSIFY       } from '../../modules/local/gtdbtk_classify'         addParams( options: params.gtdbtk_classify_options )
+include { GTDBTK_SUMMARY        } from '../../modules/local/gtdbtk_summary'          addParams( options: params.gtdbtk_summary_options  )
+
+workflow GTDBTK {
+    take:
+    bins              // channel: [ val(meta), [bins] ]
+    busco_summary     // channel: path
+    gtdb              // channel: path
+
+    main:
+    // Filter bins: classify only medium & high quality MAGs
+    // Collect completness and contamination metrics from busco summary
+    def bin_metrics = [:]
+    busco_summary
+        .splitCsv(header: true, sep: '\t')
+        .map { row ->
+                    def completeness  = -1
+                    def contamination = -1
+                    def missing, duplicated
+                    if (params.busco_reference) {
+                        missing    = row.'%Missing (specific)'      // TODO or just take '%Complete'?
+                        duplicated = row.'%Complete and duplicated (specific)'
+                    } else {
+                        missing    = row.'%Missing (domain)'
+                        duplicated = row.'%Complete and duplicated (domain)'
+                    }
+                    if (missing != '') completeness = 100.0 - Double.parseDouble(missing)
+                    if (duplicated != '') contamination = Double.parseDouble(duplicated)
+                    [row.'GenomeBin', completeness, contamination]
+        }
+        .set { ch_busco_metrics }
+
+    // Filter bins based on collected metrics: completeness, contamination
+    bins
+        .transpose()
+        .map { meta, bin -> [bin.getName(), bin, meta]}
+        .join(ch_busco_metrics, failOnDuplicate: true, failOnMismatch: true)
+        .map { bin_name, bin, meta, completeness, contamination -> [meta, bin, completeness, contamination] }
+        .branch {
+            passed: (it[2] != -1 && it[2] >= params.gtdbtk_min_completeness && it[3] != -1 && it[3] <= params.gtdbtk_max_contamination)
+                return [it[0], it[1]]
+            discarded: (it[2] == -1 || it[2] < params.gtdbtk_min_completeness || it[3] == -1 || it[3] > params.gtdbtk_max_contamination)
+                return [it[0], it[1]]
+        }
+        .set { ch_filtered_bins }
+
+    GTDBTK_DB_PREPARATION ( gtdb )
+    GTDBTK_CLASSIFY (
+        ch_filtered_bins.passed.groupTuple(),
+        GTDBTK_DB_PREPARATION.out
+    )
+
+    GTDBTK_SUMMARY (
+        ch_filtered_bins.discarded.map{it[1]}.collect().ifEmpty([]),
+        GTDBTK_CLASSIFY.out.summary.collect().ifEmpty([]),
+        GTDBTK_CLASSIFY.out.filtered.collect().ifEmpty([]),
+        GTDBTK_CLASSIFY.out.failed.collect().ifEmpty([])
+    )
+
+    emit:
+    summary     = GTDBTK_SUMMARY.out.summary
+    version     = GTDBTK_CLASSIFY.out.version
+}

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -81,8 +81,8 @@ include { MERGE_QUAST_AND_BUSCO                               } from '../modules
 include { CAT_DB                                              } from '../modules/local/cat_db'
 include { CAT                                                 } from '../modules/local/cat'                         addParams( options: modules['cat']                        )
 include { GTDBTK_DB_PREPARATION                               } from '../modules/local/gtdbtk_db_preparation'       addParams( options: [:]                                   )
-include { GTDBTK_CLASSIFY                                     } from '../modules/local/gtdbtk_classify'             addParams( options: [:]                                   )
-include { GTDBTK_SUMMARY                                     } from '../modules/local/gtdbtk_summary'             addParams( options: [:]                                   )
+include { GTDBTK_CLASSIFY                                     } from '../modules/local/gtdbtk_classify'             addParams( options: modules['gtdbtk_classify']            )
+include { GTDBTK_SUMMARY                                      } from '../modules/local/gtdbtk_summary'              addParams( options: modules['gtdbtk_summary']             )
 include { MULTIQC                                             } from '../modules/local/multiqc'                     addParams( options: multiqc_options                       )
 
 // Local: Sub-workflows

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -504,43 +504,40 @@ workflow MAG {
          * GTDB-tk: taxonomic classifications using GTDB reference
          */
         if ( params.gtdb ){
-            ch_bins_gtdbtk = METABAT2_BINNING.out.bins
             // Filter bins: classify only medium & high quality MAGs
-            if (!params.skip_busco && !params.skip_filt_gtdbtk) {
-                // Collect completness and contamination metrics from busco summary
-                def bin_metrics = [:]
-                ch_busco_summary
-                    .splitCsv(header: true, sep: '\t')
-                    .map { row ->
-                                def completeness  = -1
-                                def contamination = -1
-                                def missing, duplicated
-                                if (params.busco_reference) {
-                                    missing    = row.'%Missing (specific)'      // TODO or just take '%Complete'?
-                                    duplicated = row.'%Complete and duplicated (specific)'
-                                } else {
-                                    missing    = row.'%Missing (domain)'
-                                    duplicated = row.'%Complete and duplicated (domain)'
-                                }
-                                if (missing != '') completeness = 100.0 - Double.parseDouble(missing)
-                                if (duplicated != '') contamination = Double.parseDouble(duplicated)
-                                [row.'GenomeBin', completeness, contamination]
-                    }
-                    .set { ch_busco_metrics }
-                // Filter bins based on collected metrics: completeness, contamination
-                METABAT2_BINNING.out.bins
-                    .transpose()
-                    .map { meta, bin -> [bin.getName(), bin, meta]}
-                    .join(ch_busco_metrics, failOnDuplicate: true, failOnMismatch: true)
-                    .map { bin_name, bin, meta, completeness, contamination ->
-                            if (completeness != -1 && completeness >= params.gtdbtk_min_completeness &&
-                                contamination != -1 && contamination <= params.gtdbtk_max_contamination)
-                                [meta, bin]
-                    }
-                    .groupTuple()
-                    .view()
-                    .set { ch_bins_gtdbtk }
-            }
+            // Collect completness and contamination metrics from busco summary
+            def bin_metrics = [:]
+            ch_busco_summary
+                .splitCsv(header: true, sep: '\t')
+                .map { row ->
+                            def completeness  = -1
+                            def contamination = -1
+                            def missing, duplicated
+                            if (params.busco_reference) {
+                                missing    = row.'%Missing (specific)'      // TODO or just take '%Complete'?
+                                duplicated = row.'%Complete and duplicated (specific)'
+                            } else {
+                                missing    = row.'%Missing (domain)'
+                                duplicated = row.'%Complete and duplicated (domain)'
+                            }
+                            if (missing != '') completeness = 100.0 - Double.parseDouble(missing)
+                            if (duplicated != '') contamination = Double.parseDouble(duplicated)
+                            [row.'GenomeBin', completeness, contamination]
+                }
+                .set { ch_busco_metrics }
+            // Filter bins based on collected metrics: completeness, contamination
+            METABAT2_BINNING.out.bins
+                .transpose()
+                .map { meta, bin -> [bin.getName(), bin, meta]}
+                .join(ch_busco_metrics, failOnDuplicate: true, failOnMismatch: true)
+                .map { bin_name, bin, meta, completeness, contamination ->
+                        if (completeness != -1 && completeness >= params.gtdbtk_min_completeness &&
+                            contamination != -1 && contamination <= params.gtdbtk_max_contamination)
+                            [meta, bin]
+                }
+                .groupTuple()
+                .view()
+                .set { ch_bins_gtdbtk }
 
             GTDBTK_DB_PREPARATION ( ch_gtdb )
             GTDBTK_CLASSIFY (


### PR DESCRIPTION
I played with [GTDB-tk](https://ecogenomics.github.io/GTDBTk/index.html#) for taxonomic classification as an alternative for CAT:

- previous GTDB references stay accessible (CAT DBs only upon request currently)
- it will be clear which GTDB references will be compatible with which GTDB-tk version, i.e. it will be guaranteed that all pipelines version (with a specific GTDB-tk version) can be run at all times

Disadvantages:

- only uses marker genes, will not work for smaller bins

TODOs:

- [x] update BUSCO and make use of auto lineage functionality
- [ ] ~use `--force` to continue processing if an error occurs on a single genome (since `*.classify.tree` output would be interesting, parallelising over individual bins is likely not a good option)~
- [x] merge summary with Busco and quast summaries


(addresses https://github.com/nf-core/mag/issues/173)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
