### PR TITLE
Update to busco 5.1.0 and enable automated lineage selection

### DIFF
--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -23,7 +23,8 @@ top_modules:
     info: 'After trimming and, if requested, contamination removal.'
     path_filters:
         - '*trimmed*'
-- 'busco'
+- 'busco':
+    info: 'assesses genome assembly and annotation completeness with Benchmarking Universal Single-Copy Orthologs. Results are only shown for genome bins and kept, unbinned contigs for which the BUSCO analysis was successfull, i.e. not for contigs for which no BUSCO genes could be found.'
 - 'quast'
 
 

--- a/bin/summary_busco.py
+++ b/bin/summary_busco.py
@@ -1,26 +1,53 @@
 #!/usr/bin/env python
 
-# USAGE: ./summary.busco.py *.txt
+# USAGE: ./summary.busco.py -s <summaries> -f <failed_bins>
 
 import re
-from sys import argv
+import sys
+import argparse
 
-# "# Summarized benchmarking in BUSCO notation for file MEGAHIT-testset1.contigs.fa"
-# "	C:0.0%[S:0.0%,D:0.0%],F:0.0%,M:100.0%,n:148"
 
-regexes = [r"# Summarized benchmarking in BUSCO notation for file (\S+)", r"	C:(\S+)%\[S:",
-           r"%\[S:(\S+)%,D:", r"%,D:(\S+)%\],F:", r"%\],F:(\S+)%,M:", r"%,M:(\S+)%,n:", r"%,n:(\S+)"]
-columns = ["GenomeBin", "%Complete", "%Complete and single-copy",
-           "%Complete and duplicated", "%Fragmented", "%Missing", "Total number"]
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', "--summaries", nargs="+", metavar='FILE', help="List of Busco summary files.")
+    parser.add_argument('-f', "--failed_bins", nargs="+", metavar='FILE', help="List of files containing bin name for which Busco analysis failed.")
+    return parser.parse_args(args)
 
-# Search each file using its regex
-print("\t".join(columns))
-for FILE in argv[1:]:
-    with open(FILE) as x:
-        results = []
-        TEXT = x.read()
-        for REGEX in regexes:
-            match = re.search(REGEX, TEXT)
-            if match:
-                results.append(match.group(1))
-        print("\t".join(results))
+
+def main(args=None):
+    args = parse_args(args)
+
+    if not args.summaries and not args.failed_bins:
+        sys.exit("Either --summaries or --failed_bins must be specified!")
+
+    # "# Summarized benchmarking in BUSCO notation for file MEGAHIT-testset1.contigs.fa"
+    # "	C:0.0%[S:0.0%,D:0.0%],F:0.0%,M:100.0%,n:148"
+
+    regexes = [r"# Summarized benchmarking in BUSCO notation for file (\S+)", r"	C:(\S+)%\[S:",
+            r"%\[S:(\S+)%,D:", r"%,D:(\S+)%\],F:", r"%\],F:(\S+)%,M:", r"%,M:(\S+)%,n:", r"%,n:(\S+)"]
+    columns = ["GenomeBin", "%Complete", "%Complete and single-copy",
+            "%Complete and duplicated", "%Fragmented", "%Missing", "Total number"]
+
+    # Search each summary file using its regex
+    print("\t".join(columns))
+    if args.summaries:
+        for FILE in args.summaries:
+            with open(FILE) as x:
+                results = []
+                TEXT = x.read()
+                for REGEX in regexes:
+                    match = re.search(REGEX, TEXT)
+                    if match:
+                        results.append(match.group(1))
+                print("\t".join(results))
+
+    # Add entries for bins with failed analysis
+    if args.failed_bins:
+        for FILE in args.failed_bins:
+            with open(FILE) as x:
+                failed_bin = x.readline().split('\n')[0]
+                print(failed_bin, "0.0%", "0.0%", "0.0%", "0.0%", "100.0%", "NA", sep='\t')
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/summary_busco.py
+++ b/bin/summary_busco.py
@@ -5,7 +5,7 @@
 import re
 import sys
 import argparse
-
+import os.path
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
@@ -35,10 +35,13 @@ def main(args=None):
             with open(FILE) as x:
                 results = []
                 TEXT = x.read()
-                for REGEX in regexes:
+                for index, REGEX in enumerate(regexes):
                     match = re.search(REGEX, TEXT)
                     if match:
-                        results.append(match.group(1))
+                        if index == 0:
+                            results.append(os.path.basename(match.group(1)))
+                        else:
+                            results.append(match.group(1))
                 print("\t".join(results))
 
     # Add entries for bins with failed analysis

--- a/conf/base.config
+++ b/conf/base.config
@@ -106,6 +106,9 @@ process {
     memory = { check_max (20.GB * task.attempt, 'memory' ) }
     time = { check_max (8.h * task.attempt, 'time' ) }
   }
+  withName: BUSCO {
+    cpus = { check_max (8 * task.attempt, 'cpus' ) }
+  }
   withName: GET_SOFTWARE_VERSIONS {
     cache = false
   }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -108,6 +108,9 @@ params {
         'busco' {
             publish_dir    = "GenomeBinning/QC/BUSCO"
         }
+        'busco_save_download' {
+            publish_dir    = "GenomeBinning/QC/BUSCO"
+        }
         'busco_plot' {
             publish_dir    = "GenomeBinning/QC/BUSCO"
         }

--- a/main.nf
+++ b/main.nf
@@ -83,7 +83,7 @@ include {
 // Local: Sub-workflows
 include { INPUT_CHECK         } from './subworkflows/local/input_check'
 include { METABAT2_BINNING    } from './subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2']                                                   )
-include { BUSCO_QC            } from './subworkflows/local/busco_qc'              addParams( busco_db_options: modules['busco_db_preparation'], busco_options: modules['busco'], busco_plot_options: modules['busco_plot'], busco_summary_options: modules['busco_summary'])
+include { BUSCO_QC            } from './subworkflows/local/busco_qc'              addParams( busco_db_options: modules['busco_db_preparation'], busco_options: modules['busco'], busco_save_download_options: modules['busco_save_download'], busco_plot_options: modules['busco_plot'], busco_summary_options: modules['busco_summary'])
 
 // nf-core/modules: Modules
 include { FASTQC as FASTQC_RAW     } from './modules/nf-core/software/fastqc/main'              addParams( options: modules['fastqc_raw']            )

--- a/main.nf
+++ b/main.nf
@@ -203,11 +203,21 @@ if ( params.host_genome ) {
     ch_host_fasta = Channel.empty()
 }
 
+if (params.skip_busco && params.busco_reference){
+    exit 1, "Both --skip_busco and --busco_reference are specififed! Invalid combination, please specify either --skip_busco or --busco_reference."
+}
+if (params.skip_busco && params.busco_download_path){
+    exit 1, "Both --skip_busco and --busco_download_path are specififed! Invalid combination, please specify either --skip_busco or --busco_download_path."
+}
+if (params.busco_reference && params.busco_download_path){
+    exit 1, "Both --busco_reference and --busco_download_path are specififed! Invalid combination, please specify either --busco_reference or --busco_download_path."
+}
+
 ////////////////////////////////////////////////////
 /* --  Create channel for reference databases  -- */
 ////////////////////////////////////////////////////
 
-if(params.busco_reference){ //!params.skip_busco){ // TODO remove param?
+if(params.busco_reference){
     Channel
         .value(file( "${params.busco_reference}" ))
         .set { ch_busco_db_file }
@@ -221,9 +231,6 @@ if (params.busco_download_path) {
 } else {
     ch_busco_download_folder = Channel.empty()
 }
-// TODO check if both specified -> error!
-// TODO add auto-lineage param
-// TODO if offline mode and no busco_download_path -> error
 
 if(params.centrifuge_db){
     Channel

--- a/main.nf
+++ b/main.nf
@@ -203,15 +203,18 @@ if ( params.host_genome ) {
     ch_host_fasta = Channel.empty()
 }
 
-if (params.skip_busco && params.busco_reference){
-    exit 1, "Both --skip_busco and --busco_reference are specififed! Invalid combination, please specify either --skip_busco or --busco_reference."
+if (params.skip_busco){
+    if (params.busco_reference)
+        exit 1, "Both --skip_busco and --busco_reference are specififed! Invalid combination, please specify either --skip_busco or --busco_reference."
+    if (params.busco_download_path)
+        exit 1, "Both --skip_busco and --busco_download_path are specififed! Invalid combination, please specify either --skip_busco or --busco_download_path."
+    if (params.busco_auto_lineage_prok)
+        exit 1, "Both --skip_busco and --busco_auto_lineage_prok are specififed! Invalid combination, please specify either --skip_busco or --busco_auto_lineage_prok."
 }
-if (params.skip_busco && params.busco_download_path){
-    exit 1, "Both --skip_busco and --busco_download_path are specififed! Invalid combination, please specify either --skip_busco or --busco_download_path."
-}
-if (params.busco_reference && params.busco_download_path){
+if (params.busco_reference && params.busco_download_path)
     exit 1, "Both --busco_reference and --busco_download_path are specififed! Invalid combination, please specify either --busco_reference or --busco_download_path."
-}
+if (params.busco_auto_lineage_prok && params.busco_reference)
+    exit 1, "Both --busco_auto_lineage_prok and --busco_reference are specififed! Invalid combination, please specify either --busco_auto_lineage_prok or --busco_reference."
 
 ////////////////////////////////////////////////////
 /* --  Create channel for reference databases  -- */

--- a/main.nf
+++ b/main.nf
@@ -207,13 +207,23 @@ if ( params.host_genome ) {
 /* --  Create channel for reference databases  -- */
 ////////////////////////////////////////////////////
 
-if(!params.skip_busco){
+if(params.busco_reference){ //!params.skip_busco){ // TODO remove param?
     Channel
         .value(file( "${params.busco_reference}" ))
         .set { ch_busco_db_file }
 } else {
     ch_busco_db_file = Channel.empty()
 }
+if (params.busco_download_path) {
+    Channel
+        .value(file( "${params.busco_download_path}" ))
+        .set { ch_busco_download_folder }
+} else {
+    ch_busco_download_folder = Channel.empty()
+}
+// TODO check if both specified -> error!
+// TODO add auto-lineage param
+// TODO if offline mode and no busco_download_path -> error
 
 if(params.centrifuge_db){
     Channel
@@ -548,6 +558,7 @@ workflow {
         */
         BUSCO_QC (
             ch_busco_db_file,
+            ch_busco_download_folder,
             METABAT2_BINNING.out.bins.transpose()
         )
         ch_busco_multiqc = BUSCO_QC.out.multiqc

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -9,7 +9,7 @@ process BUSCO {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+        saveAs: { filename -> filename.indexOf("busco_downloads") == -1 ? saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') : null }
 
     conda (params.enable_conda ? "bioconda::busco=5.1.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -25,6 +25,7 @@ process BUSCO {
 
     output:
     tuple val(meta), path("short_summary.specific.*.${bin}.txt"), optional:true , emit: summary
+    path('busco_downloads/'), optional:true                                     , emit: busco_downloads
     path("${bin}_busco.log")
     path("${bin}_buscos.faa.gz"), optional:true
     path("${bin}_buscos.fna.gz"), optional:true

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -11,11 +11,11 @@ process BUSCO {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::busco=4.1.4" : null)
+    conda (params.enable_conda ? "bioconda::busco=5.1.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/busco:4.1.4--py_2"
+        container "https://depot.galaxyproject.org/singularity/busco:5.1.0--py_1"
     } else {
-        container "quay.io/biocontainers/busco:4.1.4--py_2"
+        container "quay.io/biocontainers/busco:5.1.0--py_1"
     }
 
     input:
@@ -37,10 +37,6 @@ process BUSCO {
         cp_augustus_config = "N"
 
     """
-    # get path to custom config file for busco (already configured during conda installation)
-    busco_path="\$(which busco)"
-    config_file="\${busco_path%bin/busco}share/busco/config.ini"
-
     # ensure augustus has write access to config directory
     if [ ${cp_augustus_config} = "Y" ] ; then
         cp -r /usr/local/config/ augustus_config/
@@ -54,7 +50,6 @@ process BUSCO {
     busco --lineage_dataset dataset/${db} \
         --mode genome \
         --in ${bin} \
-        --config \${config_file} \
         --cpu "${task.cpus}" \
         --out "BUSCO" > ${bin}_busco.log
 

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -38,12 +38,16 @@ process BUSCO {
     else
         cp_augustus_config = "N"
 
-    if (params.busco_reference)
+    if (params.busco_reference){
         p = "--lineage_dataset dataset/${db}"
-    else if (params.busco_download_path)
-        p = "--auto-lineage --offline --download_path ${download_folder}"
-    else
-        p = "--auto-lineage"
+    } else {
+        if (params.busco_auto_lineage_prok)
+            p = "--auto-lineage-prok"
+        else
+            p = "--auto-lineage"
+        if (params.busco_download_path)
+            p += " --offline --download_path ${download_folder}"
+    }
     """
     # ensure augustus has write access to config directory
     if [ ${cp_augustus_config} = "Y" ] ; then

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -41,7 +41,7 @@ process BUSCO {
     if (params.busco_reference)
         p = "--lineage_dataset dataset/${db}"
     else if (params.busco_download_path)
-        p = "--auto-lineage --offline --download_path ${params.busco_download_path}"
+        p = "--auto-lineage --offline --download_path ${download_folder}"
     else
         p = "--auto-lineage"
     """

--- a/modules/local/busco_plot.nf
+++ b/modules/local/busco_plot.nf
@@ -11,11 +11,11 @@ process BUSCO_PLOT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::busco=4.1.4" : null)
+    conda (params.enable_conda ? "bioconda::busco=5.1.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/busco:4.1.4--py_2"
+        container "https://depot.galaxyproject.org/singularity/busco:5.1.0--py_1"
     } else {
-        container "quay.io/biocontainers/busco:4.1.4--py_2"
+        container "quay.io/biocontainers/busco:5.1.0--py_1"
     }
 
     input:
@@ -31,7 +31,7 @@ process BUSCO_PLOT {
     def software = getSoftwareName(task.process)
     """
     # replace dots in bin names within summary file names by underscores
-    # currently (BUSCO v4.1.3) generate_plot.py does not allow further dots
+    # currently (BUSCO v5.1.0) generate_plot.py does not allow further dots
     for sum in ${summaries}; do
         [[ \${sum} =~ short_summary.(.*).${meta.assembler}-${meta.id}.(.*).txt ]];
         db_name=\${BASH_REMATCH[1]}

--- a/modules/local/busco_plot.nf
+++ b/modules/local/busco_plot.nf
@@ -19,32 +19,38 @@ process BUSCO_PLOT {
     }
 
     input:
-    tuple val(meta), path(summaries)
+    tuple val(meta), path(summaries), path(failed_bins)
 
     output:
-    path("${meta.assembler}-${meta.id}-busco_figure.png") , emit: png
-    path("${meta.assembler}-${meta.id}-busco_figure.R")   , emit: rscript
-    path("${meta.assembler}-${meta.id}-busco_summary.txt"), emit: summary
-    path '*.version.txt'                                  , emit: version
+    path("${meta.assembler}-${meta.id}-busco_figure.png") , optional:true, emit: png
+    path("${meta.assembler}-${meta.id}-busco_figure.R")   , optional:true, emit: rscript
+    path("${meta.assembler}-${meta.id}-busco_summary.txt")               , emit: summary
+    path '*.version.txt'                                                 , emit: version
 
     script:
     def software = getSoftwareName(task.process)
+    def f        = failed_bins.size() > 0 ? "-f ${failed_bins}" : ""
     """
-    # replace dots in bin names within summary file names by underscores
-    # currently (BUSCO v5.1.0) generate_plot.py does not allow further dots
-    for sum in ${summaries}; do
-        [[ \${sum} =~ short_summary.(.*).${meta.assembler}-${meta.id}.(.*).txt ]];
-        db_name=\${BASH_REMATCH[1]}
-        bin="${meta.assembler}-${meta.id}.\${BASH_REMATCH[2]}"
-        bin_new="\${bin//./_}"
-        mv \${sum} short_summary.\${db_name}.\${bin_new}.txt
-    done
-    generate_plot.py --working_directory .
+    if [ -n "${summaries}" ]
+    then
+        # replace dots in bin names within summary file names by underscores
+        # currently (BUSCO v5.1.0) generate_plot.py does not allow further dots
+        for sum in ${summaries}; do
+            [[ \${sum} =~ short_summary.(.*).${meta.assembler}-${meta.id}.(.*).txt ]];
+            db_name=\${BASH_REMATCH[1]}
+            bin="${meta.assembler}-${meta.id}.\${BASH_REMATCH[2]}"
+            bin_new="\${bin//./_}"
+            mv \${sum} short_summary.\${db_name}.\${bin_new}.txt
+        done
+        generate_plot.py --working_directory .
 
-    mv busco_figure.png "${meta.assembler}-${meta.id}-busco_figure.png"
-    mv busco_figure.R "${meta.assembler}-${meta.id}-busco_figure.R"
+        mv busco_figure.png "${meta.assembler}-${meta.id}-busco_figure.png"
+        mv busco_figure.R "${meta.assembler}-${meta.id}-busco_figure.R"
 
-    summary_busco.py short_summary.*.txt > "${meta.assembler}-${meta.id}-busco_summary.txt"
+        summary_busco.py -s short_summary.*.txt $f > "${meta.assembler}-${meta.id}-busco_summary.txt"
+    else
+        summary_busco.py -f ${failed_bins} > "${meta.assembler}-${meta.id}-busco_summary.txt"
+    fi
 
     busco --version | sed "s/BUSCO //" > ${software}.version.txt
     """

--- a/modules/local/busco_save_download.nf
+++ b/modules/local/busco_save_download.nf
@@ -1,0 +1,22 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process BUSCO_SAVE_DOWNLOAD {
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+
+    input:
+    path(busco_downloads)
+
+    output:
+    path(busco_downloads, includeInputs: true)
+
+    script:
+    """
+    """
+}

--- a/modules/local/busco_summary.nf
+++ b/modules/local/busco_summary.nf
@@ -18,13 +18,17 @@ process BUSCO_SUMMARY {
     }
 
     input:
-    path "short_summary.*.txt"
+    path(summaries)
+    path(failed_bins)
 
     output:
     path "busco_summary.txt", emit: summary
 
     script:
+    def s = summaries.size() > 0 ? "-s ${summaries}" : ""
+    def f = failed_bins.size() > 0 ? "-f ${failed_bins}" : ""
     """
-    summary_busco.py short_summary.*.txt > busco_summary.txt
+    summary_busco.py $s $f > busco_summary.txt
     """
 }
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,8 @@ params {
   skip_busco                 = false
   busco_reference            = "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   save_busco_reference       = false
+  busco_download_path        = ''
+
 
   // Reproducibility options
   megahit_fix_cpu_1          = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,10 +57,10 @@ params {
 
   // Bin QC
   skip_busco                 = false
-  busco_reference            = ''   // e.g. "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-  save_busco_reference       = false
+  busco_reference            = ''
   busco_download_path        = ''
   busco_auto_lineage_prok    = false
+  save_busco_reference       = false
 
   // Reproducibility options
   megahit_fix_cpu_1          = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,7 +60,7 @@ params {
   busco_reference            = "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   save_busco_reference       = false
   busco_download_path        = ''
-
+  busco_auto_lineage_prok    = false
 
   // Reproducibility options
   megahit_fix_cpu_1          = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,7 +57,7 @@ params {
 
   // Bin QC
   skip_busco                 = false
-  busco_reference            = "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
+  busco_reference            = ''   // e.g. "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   save_busco_reference       = false
   busco_download_path        = ''
   busco_auto_lineage_prok    = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -472,9 +472,8 @@
                 },
                 "busco_reference": {
                     "type": "string",
-                    "default": "https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz",
                     "description": "Download path for BUSCO database.",
-                    "help_text": "Available databases are listed here: https://busco.ezlab.org/."
+                    "help_text": "E.g. https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz. Available databases are listed here: https://busco.ezlab.org/."
                 },
                 "save_busco_reference": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -472,12 +472,21 @@
                 },
                 "busco_reference": {
                     "type": "string",
-                    "description": "Download path for BUSCO database.",
-                    "help_text": "E.g. https://busco-data.ezlab.org/v4/data/lineages/bacteria_odb10.2020-03-06.tar.gz. Available databases are listed here: https://busco.ezlab.org/."
+                    "description": "Download path for BUSCO lineage dataset, instead of using automated lineage selection.",
+                    "help_text": "E.g. https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz. Available databases are listed here: https://busco-data.ezlab.org/v5/data/lineages/."
+                },
+                "busco_download_path": {
+                    "type": "string",
+                    "description": "Path to local folder containing already downloaded and unpacked lineage datasets.",
+                    "help_text": "If provided, BUSCO analysis will be run in offline mode. Data can be downloaded from https://busco-data.ezlab.org/v5/data/. Run in combination with automated lineage selection."
+                },
+                "busco_auto_lineage_prok": {
+                    "type": "boolean",
+                    "description": "Run BUSCO with automated lineage selection, but ignoring eukaryotes (saves runtime)."
                 },
                 "save_busco_reference": {
                     "type": "boolean",
-                    "description": "Save BUSCO reference.",
+                    "description": "Save the used BUSCO lineage datasets provided via --busco_reference or downloaded when not using --busco_reference or --busco_download_path.",
                     "help_text": "Useful to allow reproducibility, as BUSCO datasets are frequently updated and old versions do not always remain accessible."
                 }
             }

--- a/subworkflows/local/busco_qc.nf
+++ b/subworkflows/local/busco_qc.nf
@@ -15,13 +15,20 @@ include { BUSCO_SUMMARY                           } from '../../modules/local/bu
 workflow BUSCO_QC {
     take:
     busco_db_file           // channel: path
+    busco_download_folder
     bins                    // channel: [ val(meta), path(bin) ]
 
     main:
-    BUSCO_DB_PREPARATION ( busco_db_file )
+    if (params.busco_reference){
+        BUSCO_DB_PREPARATION ( busco_db_file )
+        ch_busco_db = BUSCO_DB_PREPARATION.out.db
+    } else {
+        ch_busco_db = Channel.empty()
+    }
     BUSCO (
         bins,
-        BUSCO_DB_PREPARATION.out.db
+        ch_busco_db.collect().ifEmpty([]),
+        busco_download_folder.collect().ifEmpty([])
     )
 
     // group by assembler and sample name for plotting

--- a/subworkflows/local/busco_qc.nf
+++ b/subworkflows/local/busco_qc.nf
@@ -15,7 +15,7 @@ include { BUSCO_SUMMARY                           } from '../../modules/local/bu
 workflow BUSCO_QC {
     take:
     busco_db_file           // channel: path
-    busco_download_folder
+    busco_download_folder   // channel: path
     bins                    // channel: [ val(meta), path(bin) ]
 
     main:

--- a/subworkflows/local/busco_qc.nf
+++ b/subworkflows/local/busco_qc.nf
@@ -2,15 +2,17 @@
  * BUSCO: Quantitative measures for the assessment of genome assembly
  */
 
-params.busco_db_options      = [:]
-params.busco_options         = [:]
-params.busco_plot_options    = [:]
-params.busco_summary_options = [:]
+params.busco_db_options            = [:]
+params.busco_options               = [:]
+params.busco_save_download_options = [:]
+params.busco_plot_options          = [:]
+params.busco_summary_options       = [:]
 
-include { BUSCO_DB_PREPARATION                    } from '../../modules/local/busco_db_preparation'        addParams( options: params.busco_db_options      )
-include { BUSCO                                   } from '../../modules/local/busco'                       addParams( options: params.busco_options         )
-include { BUSCO_PLOT                              } from '../../modules/local/busco_plot'                  addParams( options: params.busco_plot_options    )
-include { BUSCO_SUMMARY                           } from '../../modules/local/busco_summary'               addParams( options: params.busco_summary_options )
+include { BUSCO_DB_PREPARATION            } from '../../modules/local/busco_db_preparation'        addParams( options: params.busco_db_options            )
+include { BUSCO                           } from '../../modules/local/busco'                       addParams( options: params.busco_options               )
+include { BUSCO_SAVE_DOWNLOAD             } from '../../modules/local/busco_save_download'         addParams( options: params.busco_save_download_options )
+include { BUSCO_PLOT                      } from '../../modules/local/busco_plot'                  addParams( options: params.busco_plot_options          )
+include { BUSCO_SUMMARY                   } from '../../modules/local/busco_summary'               addParams( options: params.busco_summary_options       )
 
 workflow BUSCO_QC {
     take:
@@ -30,6 +32,12 @@ workflow BUSCO_QC {
         ch_busco_db.collect().ifEmpty([]),
         busco_download_folder.collect().ifEmpty([])
     )
+    if (params.save_busco_reference){
+        // publish files downloaded by Busco
+        BUSCO_SAVE_DOWNLOAD (
+            BUSCO.out.busco_downloads.first()
+        )
+    }
 
     // group by assembler and sample name for plotting, join with files for failed bins and reformat
     BUSCO.out.summary.groupTuple(by: 0)


### PR DESCRIPTION
Among others in preparation for adding GTDB-tk (https://github.com/nf-core/mag/pull/178).

This updates Busco from 4.1.4 to 5.1.0 and enables the use of the automated lineage selection.

- by default now the BUSCO parameter `--auto-lineage` is used and the data is downloaded automatically (also for tests)
- the lineage can still be specified by providing a lineage dataset via the mag parameter `--busco_reference` (uses BUSCO parameter `--lineage_dataset`). This still requires the download of a `file_versions.tsv` file, which is used to check if the newest lineage dataset is used (BUSCO warns if not).
- to run BUSCO in offline mode, the mag parameter `--busco_download_path` can be used (BUSCO: `--download_path` in currently only in combination with `--auto-lineage` or `--auto-lineage-prok`)
- additionally the mag parameter `--busco_auto_lineage_prok` can be used to ignore eukaryotes (BUSCO: `--auto_lineage_prok`)
- the mag parameter `--save_busco_reference` is also used to save the lineage datasets downloaded by BUSCO

Open todos:
- [ ] compress files when saving dowloaded lineage datasets
- [ ] update docs
- [ ] update to 5.1.2: maybe in another PR, since I had problems with the current singularity images


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
