### PR TITLE
Fix Kraken2 database handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#175](https://github.com/nf-core/mag/pull/175) - Fix bug in retrieving the `--max_unbinned_contigs` longest unbinned sequences that are longer than `--min_length_unbinned_contigs` (`split_fasta.py`)
 - [#175](https://github.com/nf-core/mag/pull/175) - Improved runtime of `split_fasta.py` in `METABAT2` process (important for large assemblies, e.g. when computing co-assemblies)
+- [#194](https://github.com/nf-core/mag/pull/194) - Allow different folder structures for Kraken2 databases containing `*.k2d` files [#187](https://github.com/nf-core/mag/issues/187)
 - [#195](https://github.com/nf-core/mag/pull/195) - Fix documentation regarding required compression of input FastQ files [#160](https://github.com/nf-core/mag/issues/160)
 - [#196](https://github.com/nf-core/mag/pull/196) - Add process for CAT database creation as solution for problem caused by incompatible `DIAMOND` version used for pre-built `CAT database` and `CAT classification` [#90](https://github.com/nf-core/mag/issues/90), [#188](https://github.com/nf-core/mag/issues/188)
 

--- a/modules/local/kraken2_db_preparation.nf
+++ b/modules/local/kraken2_db_preparation.nf
@@ -16,7 +16,7 @@ process KRAKEN2_DB_PREPARATION {
     path db
 
     output:
-    tuple val("${db.baseName}"), path("database/*.k2d"), emit: db
+    tuple val("${db.simpleName}"), path("database/*.k2d"), emit: db
 
     script:
     """

--- a/modules/local/kraken2_db_preparation.nf
+++ b/modules/local/kraken2_db_preparation.nf
@@ -16,10 +16,13 @@ process KRAKEN2_DB_PREPARATION {
     path db
 
     output:
-    tuple val("${db.baseName}"), path("*/*.k2d"), emit: db
+    tuple val("${db.baseName}"), path("database/*.k2d"), emit: db
 
     script:
     """
-    tar -xf "${db}"
+    mkdir db_tmp
+    tar -xf "${db}" -C db_tmp
+    mkdir database
+    mv `find db_tmp/ -name "*.k2d"` database/
     """
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -395,7 +395,7 @@
                 "kraken2_db": {
                     "type": "string",
                     "description": "Database for taxonomic binning with kraken2.",
-                    "help_text": "E.g. \"ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz\"."
+                    "help_text": "The database file must be a compressed tar archive that contains at least the three files `hash.k2d`, `opts.k2d` and `taxo.k2d`. E.g. \"ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz\"."
                 },
                 "skip_krona": {
                     "type": "boolean",


### PR DESCRIPTION
Fix Kraken2 database handling: allow different folder structures containing `*.k2d` files.

Addresses https://github.com/nf-core/mag/issues/187.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
