### PR TITLE
Update docs: only compressed fastq files as input allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#175](https://github.com/nf-core/mag/pull/175) - Fix bug in retrieving the `--max_unbinned_contigs` longest unbinned sequences that are longer than `--min_length_unbinned_contigs` (`split_fasta.py`)
 - [#175](https://github.com/nf-core/mag/pull/175) - Improved runtime of `split_fasta.py` in `METABAT2` process (important for large assemblies, e.g. when computing co-assemblies)
+- [#195](https://github.com/nf-core/mag/pull/195) - Fix documentation regarding required compression of input FastQ files [#160](https://github.com/nf-core/mag/issues/160)
 
 ## v1.2.0 - 2020/02/10
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -163,7 +163,7 @@ This input method only works with short read data and will assign all files to t
 Please note the following additional requirements:
 
 * Files names must be unique
-* Valid file extensions: `.fastq.gz`, `.fastq`, `.fq.gz`, `.fq`
+* Valid file extensions: `.fastq.gz`, `.fq.gz` (files must be compressed)
 * The path must be enclosed in quotes
 * The path must have at least one `*` wildcard character
 * When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs
@@ -201,6 +201,7 @@ Please note the following requirements:
 * Valid file extension: `.csv`
 * Must contain the header `sample,group,short_reads_1,short_reads_2,long_reads`
 * Sample IDs must be unique
+* FastQ files must be compressed (`.fastq.gz`, `.fq.gz`)
 * `long_reads` can only be provided in combination with paired-end short read data
 * Within one samplesheet either only single-end or only paired-end reads can be specified
 * If single-end reads are specified, the command line parameter `--single_end` must be specified as well

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -15,7 +15,7 @@
                     "type": "string",
                     "fa_icon": "fas fa-dna",
                     "description": "Input FastQ files or CSV samplesheet file.",
-                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq'\n``` \n\nAlternatively, to assign different groups or to include long reads for hybrid assembly with metaSPAdes, you can specify a CSV samplesheet input file with 5 columns and the following header: sample,group,short_reads_1,short_reads_2,long_reads. See [usage docs](https://nf-co.re/mag/usage#input-specifications)."
+                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--input 'path/to/data/sample_*_{1,2}.fastq.gz'\n``` \n\nAlternatively, to assign different groups or to include long reads for hybrid assembly with metaSPAdes, you can specify a CSV samplesheet input file with 5 columns and the following header: sample,group,short_reads_1,short_reads_2,long_reads. See [usage docs](https://nf-co.re/mag/usage#input-specifications)."
                 },
                 "single_end": {
                     "type": "boolean",


### PR DESCRIPTION
Update docs: only compressed FastQ files (`*.fastq.gz`) as input allowed. See https://github.com/nf-core/mag/issues/160. 

Since the nf-core modules `fastqc` and `fastp` expect compressed fastq files, it would currently require an extra compression process and unnecessary space. Thus for now, I updated the `docs`, but did not add the handling of uncompressed FastQ files.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
