### PR TITLE
Add CAT database creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#179](https://github.com/nf-core/mag/pull/179) - Add BUSCO automated lineage selection functionality (new default). The pameter `--busco_auto_lineage_prok` can be used to only consider prokaryotes and the parameter `--busco_download_path` to run BUSCO in `offline` mode.
 - [#178](https://github.com/nf-core/mag/pull/178) - Add taxonomic bin classification with `GTDB-Tk` `v1.5.0` (for bins filtered based on `BUSCO` QC metrics).
+- [#196](https://github.com/nf-core/mag/pull/196) - Add process for CAT database creation as an alternative to using pre-built databases.
 
 ### `Changed`
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#175](https://github.com/nf-core/mag/pull/175) - Fix bug in retrieving the `--max_unbinned_contigs` longest unbinned sequences that are longer than `--min_length_unbinned_contigs` (`split_fasta.py`)
 - [#175](https://github.com/nf-core/mag/pull/175) - Improved runtime of `split_fasta.py` in `METABAT2` process (important for large assemblies, e.g. when computing co-assemblies)
+- [#196](https://github.com/nf-core/mag/pull/196) - Add process for CAT database creation as solution for problem caused by incompatible `DIAMOND` version used for pre-built `CAT database` and `CAT classification` [#90](https://github.com/nf-core/mag/issues/90), [#188](https://github.com/nf-core/mag/issues/188)
 
 ## v1.2.0 - 2020/02/10
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -66,6 +66,10 @@ process {
     memory = { check_max (20.GB * task.attempt, 'memory' ) }
     time = { check_max (12.h * task.attempt, 'time' ) }
   }
+  withName: CAT_DB_GENERATE {
+    memory = { check_max (200.GB * task.attempt, 'memory' ) }
+    time = { check_max (24.h * task.attempt, 'time' ) }
+  }
   withName: CAT {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }
     memory = { check_max (40.GB * task.attempt, 'memory' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -68,7 +68,7 @@ process {
   }
   withName: CAT_DB_GENERATE {
     memory = { check_max (200.GB * task.attempt, 'memory' ) }
-    time = { check_max (24.h * task.attempt, 'time' ) }
+    time = { check_max (16.h * task.attempt, 'time' ) }
   }
   withName: CAT {
     cpus = { check_max (8 * task.attempt, 'cpus' ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -128,6 +128,9 @@ params {
             publish_dir    = "Taxonomy/CAT"
             publish_files  = ['log':'', 'gz':'']
         }
+        'cat_db_generate' {
+            publish_dir    = "Taxonomy/CAT"
+        }
         'gtdbtk_classify' {
             args           = "--extension fa"
             publish_files  = ['log':'', 'tsv':'', 'tree.gz':'', 'fasta':'', 'fasta.gz':'']

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -129,6 +129,7 @@ params {
             publish_files  = ['log':'', 'gz':'']
         }
         'cat_db_generate' {
+            publish_files  = ['tar.gz':'']
             publish_dir    = "Taxonomy/CAT"
         }
         'gtdbtk_classify' {

--- a/docs/output.md
+++ b/docs/output.md
@@ -274,6 +274,10 @@ Besides the reference files or output files created by BUSCO, the following summ
   * `[assembler]-[sample/group].bin2classification.txt.gz`: Taxonomy classification of the genome bins
   * `[assembler]-[sample/group].log`: Log files
 
+If the parameters `--cat_db_generate` and `--save_cat_db` are set, additionally the generated CAT database is stored:
+
+* `Taxonomy/CAT/CAT_prepare_*.tar.gz`: Generated and used CAT database.
+
 ### GTDB-Tk
 
 [GTDB-Tk](https://github.com/Ecogenomics/GTDBTk) is a toolkit for assigning taxonomic classifications to bacterial and archaeal genomes based on the Genome Database Taxonomy [GTDB](https://gtdb.ecogenomic.org/). nf-core/mag uses GTDB-Tk to classify binned genomes which satisfy certain quality criteria (i.e. completeness and contamination assessed with the BUSCO analysis).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,8 @@ MetaBAT2 is run by default with a fixed seed within this pipeline, thus producin
 
 To allow also reproducible bin QC with BUSCO, run BUSCO providing already downloaded lineage datasets with `--busco_download_path` (BUSCO will be run using automated lineage selection in offline mode) or provide a specific lineage dataset via `--busco_reference` and use the parameter `--save_busco_reference`. This may be useful since BUSCO datasets are frequently updated and old versions do not always remain (easily) accessible.
 
+For the taxonomic bin classification with [CAT](https://github.com/dutilh/CAT), when running the pipeline with `--cat_db_generate` the parameter `--save_cat_db` can be used to also save the generated database to allow reproducibility in future runs. Note that when specifying a pre-built database with `--cat_db`, currently the database can not be saved.
+
 The taxonomic classification of bins with GTDB-Tk is not guaranteed to be reproducible, since the placement of bins in the reference tree is non-deterministic. However, the authors of the GTDB-Tk article examined the reproducibility on a set of 100 genomes across 50 trials and did not observe any difference (see [https://doi.org/10.1093/bioinformatics/btz848](https://doi.org/10.1093/bioinformatics/btz848)).
 
 ## Core Nextflow arguments

--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -132,6 +132,12 @@ class Workflow {
             log.error "Invalid combination of parameters --skip_busco and --gtdb are specififed! GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
             System.exit(1)
         }
+
+        // Check if CAT parameters are valid
+        if (params.cat_db && params.cat_db_generate) {
+            log.error "Invalid combination of parameters --cat_db and --cat_db_generate is specififed! Please specify either --cat_db or --cat_db_generate."
+            System.exit(1)
+        }
     }
 
     /*

--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -138,6 +138,9 @@ class Workflow {
             log.error "Invalid combination of parameters --cat_db and --cat_db_generate is specififed! Please specify either --cat_db or --cat_db_generate."
             System.exit(1)
         }
+        if (params.save_cat_db && !params.cat_db_generate) {
+            log.warn "Parameter --save_cat_db specified, but not --cat_db_generate! Parameter --save_cat_db will have no effect."
+        }
     }
 
     /*

--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -139,7 +139,8 @@ class Workflow {
             System.exit(1)
         }
         if (params.save_cat_db && !params.cat_db_generate) {
-            log.warn "Parameter --save_cat_db specified, but not --cat_db_generate! Parameter --save_cat_db will have no effect."
+            log.error "Invalid parameter combination: parameter --save_cat_db specified, but not --cat_db_generate! Note also that the parameter --save_cat_db does not work in combination with --cat_db."
+            System.exit(1)
         }
     }
 

--- a/modules/local/cat_db.nf
+++ b/modules/local/cat_db.nf
@@ -25,6 +25,6 @@ process CAT_DB {
     mkdir catDB
     tar -xf ${database} -C catDB
     mv `find catDB/ -type d -name "*taxonomy*"` taxonomy/
-    mv `find catDB/ -type d -name "*CAT_database*"` database/
+    mv `find catDB/ -type d -name "*database*"` database/
     """
 }

--- a/modules/local/cat_db_generate.nf
+++ b/modules/local/cat_db_generate.nf
@@ -1,0 +1,39 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process CAT_DB_GENERATE {
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> params.save_cat_db ? saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') : null }
+
+    conda (params.enable_conda ? "bioconda::cat=4.6 bioconda::diamond=2.0.6" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/mulled-v2-75e2a26f10cbf3629edf2d1600db3fed5ebe6e04:eae321284604f7dabbdf121e3070bda907b91266-0"
+    } else {
+        container "quay.io/biocontainers/mulled-v2-75e2a26f10cbf3629edf2d1600db3fed5ebe6e04:eae321284604f7dabbdf121e3070bda907b91266-0"
+    }
+
+    output:
+    tuple env(DB_NAME), path("database/*"), path("taxonomy/*"), emit: db
+    path '*.version.txt'                                      , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    """
+    CAT prepare --fresh
+
+    # get name of generated datase
+    out=(*_taxonomy/)
+    [[ \$out =~ (.*)_taxonomy/ ]];
+    DB_NAME="CAT_prepare_\${BASH_REMATCH[1]}"
+
+    mv *_taxonomy taxonomy
+    mv *_database database
+    rm database/*.nr.gz
+    CAT --version | sed "s/CAT v//; s/(.*//" > ${software}.version.txt
+    """
+}

--- a/modules/local/cat_db_generate.nf
+++ b/modules/local/cat_db_generate.nf
@@ -7,7 +7,7 @@ options    = initOptions(params.options)
 process CAT_DB_GENERATE {
 
     publishDir "${params.outdir}",
-        mode: params.publish_dir_mode,
+        mode: 'move',
         saveAs: { filename -> params.save_cat_db ? saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') : null }
 
     conda (params.enable_conda ? "bioconda::cat=4.6 bioconda::diamond=2.0.6" : null)

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,8 @@ params {
   kraken2_db                 = ''
   skip_krona                 = false
   cat_db                     = ''
+  cat_db_generate            = false
+  save_cat_db                = false
   gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
   gtdbtk_min_completeness    = 50.0
   gtdbtk_max_contamination   = 10.0

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -412,8 +412,8 @@
                 },
                 "save_cat_db": {
                     "type": "boolean",
-                    "description": "Save the used CAT database provided via --cat_db or generated when specified by --cat_db_generate.",
-                    "help_text": "Useful to allow reproducibility, as old versions of prebuild CAT databases do not always remain accessible and underlying NCBI taxonomy and nr databases, used when generating the database, change."
+                    "description": "Save the CAT database generated when specified by --cat_db_generate.",
+                    "help_text": "Useful to allow reproducibility, as old versions of prebuild CAT databases do not always remain accessible and underlying NCBI taxonomy and nr databases change."
                 },
                 "gtdb": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -408,7 +408,8 @@
                 },
                 "cat_db_generate": {
                     "type": "boolean",
-                    "description": "Generate CAT database."
+                    "description": "Generate CAT database.",
+                    "help_text": "Download the taxonomy files from NCBI taxonomy, the nr database and generate CAT database. Useful to build a CAT database with the same DIAMOND version as used for running CAT classification, avoiding compatibility problems."
                 },
                 "save_cat_db": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -406,6 +406,15 @@
                     "description": "Database for taxonomic classification of metagenome assembled genomes.",
                     "help_text": "E.g. \"https://tbb.bio.uu.nl/bastiaan/CAT_prepare/CAT_prepare_20210107.tar.gz\".\nThe zipped file needs to contain a folder named \"*taxonomy*\" and \"*CAT_database*\" that hold the respective files."
                 },
+                "cat_db_generate": {
+                    "type": "boolean",
+                    "description": "Generate CAT database."
+                },
+                "save_cat_db": {
+                    "type": "boolean",
+                    "description": "Save the used CAT database provided via --cat_db or generated when specified by --cat_db_generate.",
+                    "help_text": "Useful to allow reproducibility, as old versions of prebuild CAT databases do not always remain accessible and underlying NCBI taxonomy and nr databases, used when generating the database, change."
+                },
                 "gtdb": {
                     "type": "string",
                     "default": "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz",

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -79,8 +79,9 @@ include { QUAST                                               } from '../modules
 include { QUAST_BINS                                          } from '../modules/local/quast_bins'                  addParams( options: modules['quast_bins']                 )
 include { QUAST_BINS_SUMMARY                                  } from '../modules/local/quast_bins_summary'          addParams( options: modules['quast_bins_summary']         )
 include { CAT_DB                                              } from '../modules/local/cat_db'
+include { CAT_DB_GENERATE                                     } from '../modules/local/cat_db_generate'             addParams( options: modules['cat_db_generate']            )
 include { CAT                                                 } from '../modules/local/cat'                         addParams( options: modules['cat']                        )
-include { MERGE_QUAST_BUSCO_GTDBTK                            } from '../modules/local/merge_quast_busco_gtdbtk'   addParams( options: modules['merge_quast_busco_gtdbtk']   )
+include { MERGE_QUAST_BUSCO_GTDBTK                            } from '../modules/local/merge_quast_busco_gtdbtk'    addParams( options: modules['merge_quast_busco_gtdbtk']   )
 include { MULTIQC                                             } from '../modules/local/multiqc'                     addParams( options: multiqc_options                       )
 
 // Local: Sub-workflows
@@ -492,10 +493,17 @@ workflow MAG {
         /*
          * CAT: Bin Annotation Tool (BAT) are pipelines for the taxonomic classification of long DNA sequences and metagenome assembled genomes (MAGs/bins)
          */
-        CAT_DB ( ch_cat_db_file )
-        CAT ( 
+        ch_cat_db = Channel.empty()
+        if (params.cat_db){
+            CAT_DB ( ch_cat_db_file )
+            ch_cat_db = CAT_DB.out.db
+        } else if (params.cat_db_generate){
+            CAT_DB_GENERATE ()
+            ch_cat_db = CAT_DB_GENERATE.out.db
+        }
+        CAT (
             METABAT2_BINNING.out.bins,
-            CAT_DB.out.db
+            ch_cat_db
         )
         ch_software_versions = ch_software_versions.mix(CAT.out.version.first().ifEmpty(null))
 


### PR DESCRIPTION
Add CAT database creation as an alternative to using pre-built databases. 

The problem with pre-build CAT databases is that they do not stay accessible on https://tbb.bio.uu.nl/bastiaan/CAT_prepare/ and that databases built with a different `DIAMOND` version than that used for running `CAT classification` are not always compatible (see https://github.com/nf-core/mag/issues/188 and https://github.com/nf-core/mag/issues/90).

By adding this step, it will be ensured the same `DIAMOND` is used for building the database and running the actual classification. The parameter `--save_cat_db` can be used to save the generated db for future reproducibility.

The process requires up to `200 GB` memory, up to `300 GB` for the generated database in the `work` dir and > `100 GB` for the saved database.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
