### PR TITLE
Add and fix container

### DIFF
--- a/modules/local/busco_save_download.nf
+++ b/modules/local/busco_save_download.nf
@@ -14,6 +14,13 @@ process BUSCO_SAVE_DOWNLOAD {
         overwrite: false,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
+    } else {
+        container "biocontainers/biocontainers:v1.2.0_cv1"
+    }
+
     input:
     path(busco_downloads)
 

--- a/modules/local/get_software_versions.nf
+++ b/modules/local/get_software_versions.nf
@@ -11,8 +11,12 @@ process GET_SOFTWARE_VERSIONS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'pipeline_info', publish_id:'') }
 
-    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    container "quay.io/biocontainers/python:3.8.3"
+    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
+    } else {
+        container "quay.io/biocontainers/python:3.8.3"
+    }
 
     cache false
 

--- a/modules/local/quast_bins_summary.nf
+++ b/modules/local/quast_bins_summary.nf
@@ -10,6 +10,13 @@ process QUAST_BINS_SUMMARY {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
+    } else {
+        container "biocontainers/biocontainers:v1.2.0_cv1"
+    }
+
     input:
     path(summaries)
 


### PR DESCRIPTION
The `AWS full-size` test failed, because there was no container specified for the process `QUAST_BINS_SUMMARY`.

I added basic containers for `QUAST_BINS_SUMMARY` and `BUSCO_SAVE_DOWNLOAD`, and adjusted the specifications for `get_software_versions`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
