### PR TITLE
Change CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         # Run remaining test profiles with minimum nextflow version
-        profile: [test_host_rm, test_hybrid, test_hybrid_host_rm]
+        profile: [test_host_rm, test_hybrid, test_hybrid_host_rm, test_busco_auto]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,5 +22,6 @@ params {
   skip_krona = true
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  busco_reference = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   gtdb = false
 }

--- a/conf/test_busco_auto.config
+++ b/conf/test_busco_auto.config
@@ -1,0 +1,24 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/mag -profile test_busco_auto,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on GitHub Actions
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  input = 'https://github.com/nf-core/test-datasets/raw/mag/samplesheets/samplesheet.csv'
+  skip_spades = true
+  min_length_unbinned_contigs = 1
+  max_unbinned_contigs = 2
+  gtdb = false
+}

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -18,9 +18,6 @@ params {
   // Input data
   host_fasta = "https://github.com/nf-core/test-datasets/raw/mag/host_reference/genome.hg38.chr21_10000bp_region.fa"
   input = 'https://github.com/nf-core/test-datasets/raw/mag/samplesheets/samplesheet.host_rm.csv'
-  centrifuge_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_cf.tar.gz"
-  kraken2_db = "https://github.com/nf-core/test-datasets/raw/mag/test_data/minigut_kraken.tgz"
-  skip_krona = true
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
   busco_reference = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -23,5 +23,6 @@ params {
   skip_krona = true
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  busco_reference = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   gtdb = false
 }

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -19,5 +19,6 @@ params {
   input = 'https://github.com/nf-core/test-datasets/raw/mag/samplesheets/samplesheet.hybrid.csv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  busco_reference = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   gtdb = false
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -20,5 +20,6 @@ params {
   input = 'https://github.com/nf-core/test-datasets/raw/mag/samplesheets/samplesheet.hybrid_host_rm.csv'
   min_length_unbinned_contigs = 1
   max_unbinned_contigs = 2
+  busco_reference = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
   gtdb = false
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
   * Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker, Singularity, Podman, Shifter or Charliecloud.
   * A generic configuration profile to be used with [Conda](https://conda.io/docs/)
   * Pulls most software from [Bioconda](https://bioconda.github.io/)
-* `test`, `test_hybrid`, `test_host_rm`, `test_hybrid_host_rm`
+* `test`, `test_hybrid`, `test_host_rm`, `test_hybrid_host_rm`, `test_busco_auto`
   * Profiles with a complete configuration for automated testing
   * Includes links to test data so needs no other parameters
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,11 +190,12 @@ profiles {
     podman.enabled           = false
     shifter.enabled          = false
   }
-  test { includeConfig 'conf/test.config' }
-  test_host_rm { includeConfig 'conf/test_host_rm.config' }
-  test_hybrid { includeConfig 'conf/test_hybrid.config' }
+  test                { includeConfig 'conf/test.config'                }
+  test_host_rm        { includeConfig 'conf/test_host_rm.config'        }
+  test_hybrid         { includeConfig 'conf/test_hybrid.config'         }
   test_hybrid_host_rm { includeConfig 'conf/test_hybrid_host_rm.config' }
-  test_full { includeConfig 'conf/test_full.config' }
+  test_busco_auto     { includeConfig 'conf/test_busco_auto.config'     }
+  test_full           { includeConfig 'conf/test_full.config'           }
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container


### PR DESCRIPTION
- use `--busco_reference` instead of auto lineage selection for majority of tests
- do not run `centrifuge` and `kraken2` for `test_host_rm`
- add extra test profile `test_busco_auto` to run BUSCO with automated lineage selection, while skipping SPAdes

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
