### PR TITLE
Adjust fastp parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#193](https://github.com/nf-core/mag/pull/193) - Compress CAT output files [#180](https://github.com/nf-core/mag/issues/180)
 - [#198](https://github.com/nf-core/mag/pull/198) - Requires nextflow version `>= 21.04.0`
 - [#200](https://github.com/nf-core/mag/pull/200) - Small changes in GitHub Actions tests
+- [#203](https://github.com/nf-core/mag/pull/203) - Renamed `fastp` params and improved description in documentation: `--mean_quality` -> `--fastp_qualified_quality`, `--trimming_quality` -> `--fastp_cut_mean_quality`
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -23,8 +23,8 @@ params {
             publish_files  = ['html':'']
             publish_dir    = "QC_shortreads/fastqc"
         }
-        'fastp' {   // TODO check parameter: -q vs -e?
-            args           = "-q ${params.mean_quality} --cut_by_quality5 --cut_by_quality3 --cut_mean_quality ${params.trimming_quality}"
+        'fastp' {
+            args           = "-q ${params.fastp_qualified_quality} --cut_by_quality5 --cut_by_quality3 --cut_mean_quality ${params.trimming_quality}"
             publish_files  = ['html':'', 'json':'']
             publish_by_id  = true
             publish_dir    = "QC_shortreads/fastp"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,7 +24,7 @@ params {
             publish_dir    = "QC_shortreads/fastqc"
         }
         'fastp' {
-            args           = "-q ${params.fastp_qualified_quality} --cut_by_quality5 --cut_by_quality3 --cut_mean_quality ${params.trimming_quality}"
+            args           = "-q ${params.fastp_qualified_quality} --cut_by_quality5 --cut_by_quality3 --cut_mean_quality ${params.fastp_cut_mean_quality}"
             publish_files  = ['html':'', 'json':'']
             publish_by_id  = true
             publish_dir    = "QC_shortreads/fastp"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -24,7 +24,7 @@ params {
             publish_dir    = "QC_shortreads/fastqc"
         }
         'fastp' {
-            args           = "-q ${params.fastp_qualified_quality} --cut_by_quality5 --cut_by_quality3 --cut_mean_quality ${params.fastp_cut_mean_quality}"
+            args           = "-q ${params.fastp_qualified_quality} --cut_front --cut_tail --cut_mean_quality ${params.fastp_cut_mean_quality}"
             publish_files  = ['html':'', 'json':'']
             publish_by_id  = true
             publish_dir    = "QC_shortreads/fastp"

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,7 +15,7 @@ params {
   // short read preprocessing options
   save_trimmed_fail          = false
   fastp_qualified_quality    = 15
-  trimming_quality           = 15
+  fastp_cut_mean_quality     = 15
   keep_phix                  = false
   // phix_reference           = "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/viral/Enterobacteria_phage_phiX174_sensu_lato/all_assembly_versions/GCA_002596845.1_ASM259684v1/GCA_002596845.1_ASM259684v1_genomic.fna.gz"
   phix_reference             = "${baseDir}/assets/data/GCA_002596845.1_ASM259684v1_genomic.fna.gz"

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
 
   // short read preprocessing options
   save_trimmed_fail          = false
-  mean_quality               = 15
+  fastp_qualified_quality    = 15
   trimming_quality           = 15
   keep_phix                  = false
   // phix_reference           = "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/viral/Enterobacteria_phage_phiX174_sensu_lato/all_assembly_versions/GCA_002596845.1_ASM259684v1/GCA_002596845.1_ASM259684v1_genomic.fna.gz"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -303,10 +303,11 @@
                     "description": "Save the trimmed FastQ files in the results directory.",
                     "help_text": "By default, trimmed FastQ files will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 },
-                "mean_quality": {
+                "fastp_qualified_quality": {
                     "type": "integer",
                     "default": 15,
-                    "description": "Mean qualified quality value for keeping read."
+                    "description": "Minimum phred quality value of a base to be qualified.",
+                    "help": "Reads with more than 40% of unqualified bases will be discarded."
                 },
                 "trimming_quality": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -309,10 +309,11 @@
                     "description": "Minimum phred quality value of a base to be qualified.",
                     "help": "Reads with more than 40% of unqualified bases will be discarded."
                 },
-                "trimming_quality": {
+                "fastp_cut_mean_quality": {
                     "type": "integer",
                     "default": 15,
-                    "description": "Trimming quality value for the sliding window."
+                    "description": "The mean quality requirement used for per read sliding window cutting by fastp.",
+                    "help": "Used in combination with the fastp options '--cut_front' and '--cut_tail'. If the mean quality within a window (of size 4) is below `--fastp_cut_mean_quality`, the bases are dropped and the sliding window is moved further, otherwise it stops."
                 },
                 "host_genome": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -300,7 +300,7 @@
                 "save_trimmed_fail": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
-                    "description": "Save the trimmed FastQ files in the results directory.",
+                    "description": "Save the by fastp trimmed FastQ files in the results directory.",
                     "help_text": "By default, trimmed FastQ files will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 },
                 "fastp_qualified_quality": {


### PR DESCRIPTION
- Renamed param `--mean_quality` to `--fastp_qualified_quality` and adjusted description
- Renamed param `--trimming_quality` to `--fastp_cut_mean_quality` and adjusted description
- Replaced deprecated fastp params `--cut_by_quality5` and `--cut_by_quality3`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
