### PR TITLE
Fix GTDB-Tk summary process

### DIFF
--- a/bin/summary_gtdbtk.py
+++ b/bin/summary_gtdbtk.py
@@ -69,8 +69,9 @@ def main(args=None):
     filtered = []
     if args.filtered_bins:
         for file in args.filtered_bins:
-            with open(file) as infile:
-                bin_name = infile.readline().split("\t")[0]
+            df = pd.read_csv(file, sep='\t', names=["bin_name", "reason"])
+            for index, row in df.iterrows():
+                bin_name = row['bin_name']
                 bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
                 filtered.append(bin_results)
 
@@ -83,8 +84,9 @@ def main(args=None):
     failed = []
     if args.failed_bins:
         for file in args.failed_bins:
-            with open(file) as infile:
-                bin_name = infile.readline().split("\t")[0]
+            df = pd.read_csv(file, sep='\t', names=["bin_name", "reason"])
+            for index, row in df.iterrows():
+                bin_name = row['bin_name']
                 bin_results = [bin_name, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
                 failed.append(bin_results)
 

--- a/modules/local/busco_summary.nf
+++ b/modules/local/busco_summary.nf
@@ -27,10 +27,10 @@ process BUSCO_SUMMARY {
 
     script:
     def auto = params.busco_reference ? "" : "-a"
-    def ss = summaries_specific.size() > 0 ? "-ss ${summaries_specific}" : ""
-    def sd = summaries_domain.size() > 0 ? "-sd ${summaries_domain}" : ""
+    def ss = summaries_specific.sort().size() > 0 ? "-ss ${summaries_specific}" : ""
+    def sd = summaries_domain.sort().size() > 0 ? "-sd ${summaries_domain}" : ""
     def f = ""
-    if (!params.busco_reference && failed_bins.size() > 0)
+    if (!params.busco_reference && failed_bins.sort().size() > 0)
         f = "-f ${failed_bins}"
     """
     summary_busco.py $auto $ss $sd $f -o busco_summary.tsv

--- a/modules/local/gtdbtk_summary.nf
+++ b/modules/local/gtdbtk_summary.nf
@@ -19,7 +19,7 @@ process GTDBTK_SUMMARY {
 
     input:
     path(qc_discarded_bins)
-    path(summaries)
+    path(gtdbtk_summaries)
     path(filtered_bins)
     path(failed_bins)
 
@@ -28,7 +28,7 @@ process GTDBTK_SUMMARY {
 
     script:
     def discarded = qc_discarded_bins.sort().size() > 0 ? "--qc_discarded_bins ${qc_discarded_bins}" : ""
-    def summaries = summaries.sort().size() > 0 ?         "--summaries ${summaries}" : ""
+    def summaries = gtdbtk_summaries.sort().size() > 0 ?  "--summaries ${gtdbtk_summaries}" : ""
     def filtered  = filtered_bins.sort().size() > 0 ?     "--filtered_bins ${filtered_bins}" : ""
     def failed    = failed_bins.sort().size() > 0 ?       "--failed_bins ${failed_bins}" : ""
     """

--- a/modules/local/gtdbtk_summary.nf
+++ b/modules/local/gtdbtk_summary.nf
@@ -27,10 +27,10 @@ process GTDBTK_SUMMARY {
     path "gtdbtk_summary.tsv", emit: summary
 
     script:
-    def discarded = qc_discarded_bins.size() > 0 ? "--qc_discarded_bins ${qc_discarded_bins}" : ""
-    def summaries = summaries.size() > 0 ?         "--summaries ${summaries}" : ""
-    def filtered  = filtered_bins.size() > 0 ?     "--filtered_bins ${filtered_bins}" : ""
-    def failed    = failed_bins.size() > 0 ?       "--failed_bins ${failed_bins}" : ""
+    def discarded = qc_discarded_bins.sort().size() > 0 ? "--qc_discarded_bins ${qc_discarded_bins}" : ""
+    def summaries = summaries.sort().size() > 0 ?         "--summaries ${summaries}" : ""
+    def filtered  = filtered_bins.sort().size() > 0 ?     "--filtered_bins ${filtered_bins}" : ""
+    def failed    = failed_bins.sort().size() > 0 ?       "--failed_bins ${failed_bins}" : ""
     """
     summary_gtdbtk.py $options.args $discarded $summaries $filtered $failed --out gtdbtk_summary.tsv
     """

--- a/modules/local/merge_quast_busco_gtdbtk.nf
+++ b/modules/local/merge_quast_busco_gtdbtk.nf
@@ -26,9 +26,9 @@ process MERGE_QUAST_BUSCO_GTDBTK {
     path("bin_summary.tsv"), emit: summary
 
     script:
-    def busco_summary  = busco_sum.size() > 0 ?  "--busco_summary ${busco_sum}" : ""
-    def quast_summary  = quast_sum.size() > 0 ?  "--quast_summary ${quast_sum}" : ""
-    def gtdbtk_summary = gtdbtk_sum.size() > 0 ? "--gtdbtk_summary ${gtdbtk_sum}" : ""
+    def busco_summary  = busco_sum.sort().size() > 0 ?  "--busco_summary ${busco_sum}" : ""
+    def quast_summary  = quast_sum.sort().size() > 0 ?  "--quast_summary ${quast_sum}" : ""
+    def gtdbtk_summary = gtdbtk_sum.sort().size() > 0 ? "--gtdbtk_summary ${gtdbtk_sum}" : ""
     """
     combine_tables.py $busco_summary \
                       $quast_summary \


### PR DESCRIPTION
So far `.size()` was used to check the number of input files within a process, which apparently does not work (or does not work anymore, not sure). When using `.sort.size()` (as in [modules/software/picard/mergesamfiles/main.nf](https://github.com/nf-core/modules/blob/68c678de935f9a2d26e55f70351d19358568f505/software/picard/mergesamfiles/main.nf#L31)) it works as expected, so I used this instead. @drpatelh since you added the `PICARD_MERGESAMFILES` process, do you think that's a reasonable solution here too or would there be a better way?

However, in [modules/software/picard/mergesamfiles/main.nf](https://github.com/nf-core/modules/blob/68c678de935f9a2d26e55f70351d19358568f505/software/sortmerna/main.nf#L35) the plain `.size()` is used. I am wondering, if this is working like this?

Additionally fixed handling of failed and filtered bins in `summary_gtdbtk.py` for files containing multiple or no bins. 




## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
