### PR TITLE
Compute bin depths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.1.0dev - [date]
 
+### `Added`
+
+- [#212](https://github.com/nf-core/mag/pull/212) - Add bin abundance estimation based on mean sequencing depths of corresponding contigs (results are written to `results/GenomeBinning/bin_depths_summary.tsv` and `results/GenomeBinning/bin_summary.tsv`) [#197](https://github.com/nf-core/mag/issues/197).
+
 ## v2.0.0 - 2021/06/01
 
 ### `Added`

--- a/bin/combine_tables.py
+++ b/bin/combine_tables.py
@@ -7,11 +7,12 @@ import pandas as pd
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-b', "--busco_summary",                    metavar='FILE',                               help="BUSCO summary file.")
-    parser.add_argument('-q', "--quast_summary",                    metavar='FILE',                               help="QUAST BINS summary file.")
-    parser.add_argument('-g', "--gtdbtk_summary",                   metavar='FILE',                               help="GTDB-Tk summary file.")
+    parser.add_argument('-d', "--depths_summary", required=True, metavar='FILE',                              help="Bin depths summary file.")
+    parser.add_argument('-b', "--busco_summary",                 metavar='FILE',                              help="BUSCO summary file.")
+    parser.add_argument('-q', "--quast_summary",                 metavar='FILE',                              help="QUAST BINS summary file.")
+    parser.add_argument('-g', "--gtdbtk_summary",                metavar='FILE',                              help="GTDB-Tk summary file.")
 
-    parser.add_argument('-o',  "--out",               required=True, metavar='FILE', type=argparse.FileType('w'), help="Output file containing final summary.")
+    parser.add_argument('-o',  "--out",           required=True, metavar='FILE', type=argparse.FileType('w'), help="Output file containing final summary.")
     return parser.parse_args(args)
 
 
@@ -19,37 +20,34 @@ def main(args=None):
     args = parse_args(args)
 
     if not args.busco_summary and not args.quast_summary and not args.gtdbtk_summary:
-        sys.exit("No summary specified! Please specify at least two summaries.")
+        sys.exit("No summary specified! Please specify at least BUSCO or QUAST summary.")
 
-    # At least two summaries must be specified for merging
-    # Since GTDB-Tk can only be run in combination with BUSCO, test if (BUSCO && GTDB-TK) || (BUSCO && QUAST)
+    # GTDB-Tk can only be run in combination with BUSCO
     if args.gtdbtk_summary and not args.busco_summary:
         sys.exit("Invalid parameter combination: GTDB-TK summary specified, but no BUSCO summary!")
-    if args.quast_summary and not args.busco_summary:
-        sys.exit("At least two summaries must be specified, but only QUAST summary was given! Please specify BUSCO summary.")
 
-    results = pd.DataFrame()
-    bins    = pd.Series()
+    # handle bin depths
+    results = pd.read_csv(args.depths_summary, sep="\t")
+    bins    = results['bin'].sort_values().reset_index(drop=True)
 
     if args.busco_summary:
-        results = pd.read_csv(args.busco_summary, sep="\t")
-        bins    = results['GenomeBin'].sort_values().reset_index(drop=True)
+        busco_results = pd.read_csv(args.busco_summary, sep="\t")
+        if not bins.equals(busco_results['GenomeBin'].sort_values().reset_index(drop=True)):
+            sys.exit("Bins in BUSCO summary do not match bins in bin depths summary!")
+        results = pd.merge(results, busco_results, left_on="bin", right_on="GenomeBin", how='outer')            # assuming depths for all bins are given
 
     if args.quast_summary:
         quast_results = pd.read_csv(args.quast_summary, sep="\t")
-        if bins.empty:
-            bins = quast_results['Assembly'].sort_values().reset_index(drop=True)
-        elif not bins.equals(quast_results['Assembly'].sort_values().reset_index(drop=True)):
-            sys.exit("Bins in QUAST summary do not match bins in BUSCO summary!")
-        results = pd.merge(results, quast_results, left_on="GenomeBin", right_on="Assembly", how='outer')
+        if not bins.equals(quast_results['Assembly'].sort_values().reset_index(drop=True)):
+            sys.exit("Bins in QUAST summary do not match bins in bin depths summary!")
+        results = pd.merge(results, quast_results, left_on="bin", right_on="Assembly", how='outer')             # assuming depths for all bins are given
 
     if args.gtdbtk_summary:
         gtdbtk_results = pd.read_csv(args.gtdbtk_summary, sep="\t")
         if not bins.equals(gtdbtk_results['user_genome'].sort_values().reset_index(drop=True)):
-            sys.exit("Bins in GTDB-Tk summary do not match bins in BUSCO summary!")   # GTDB-Tk can currently anyway only run in combination with BUSCO
-        results = pd.merge(results, gtdbtk_results, left_on="GenomeBin", right_on="user_genome", how='outer')   # again assuming BUSCO summary must be given
+            sys.exit("Bins in GTDB-Tk summary do not match bins in BUSCO summary!")                             # GTDB-Tk can currently anyway only run in combination with BUSCO
+        results = pd.merge(results, gtdbtk_results, left_on="GenomeBin", right_on="user_genome", how='outer')   # assuming BUSCO summary must be given
 
-    # Print to stdout
     results.to_csv(args.out, sep='\t')
 
 

--- a/bin/combine_tables.py
+++ b/bin/combine_tables.py
@@ -28,6 +28,7 @@ def main(args=None):
 
     # handle bin depths
     results = pd.read_csv(args.depths_summary, sep="\t")
+    results.columns = ["Depth " + str(col) if col != "bin" else col for col in results.columns ]
     bins    = results['bin'].sort_values().reset_index(drop=True)
 
     if args.busco_summary:

--- a/bin/get_mag_depths.py
+++ b/bin/get_mag_depths.py
@@ -13,7 +13,7 @@ from Bio import SeqIO
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--bins'         , required=True, nargs="+", metavar='FILE'                             , help="Bins: FASTA containing all contigs.")
-    parser.add_argument('-d', '--depths'       , required=True           , metavar='FILE'                             , help="(Compressed) TSV file containing contig depths for each sample (within group): contigName, contigLen, totalAvgDepth, sample1_avgDepth, sample1_var [, sample2_avgDepth, sample2_var, ...].")
+    parser.add_argument('-d', '--depths'       , required=True           , metavar='FILE'                             , help="(Compressed) TSV file containing contig depths for each sample: contigName, contigLen, totalAvgDepth, sample1_avgDepth, sample1_var [, sample2_avgDepth, sample2_var, ...].")
     parser.add_argument('-a', '--assembly_name', required=True                           , type=str                   , help="Assembly name.")
     parser.add_argument('-o', "--out"          , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depth for each bin.")
     return parser.parse_args(args)

--- a/bin/get_mag_depths.py
+++ b/bin/get_mag_depths.py
@@ -12,9 +12,10 @@ from Bio import SeqIO
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-b', '--bins'       , required=True, nargs="+", metavar='FILE'                             , help="Bins: FASTA containing all contigs.")
-    parser.add_argument('-d', '--depths'     , required=True           , metavar='FILE'                             , help="(Compressed) TSV file containing contig depths for each sample (within group): contigName, contigLen, totalAvgDepth, sample1_avgDepth, sample1_var [, sample2_avgDepth, sample2_var, ...].")
-    parser.add_argument('-o', "--out"        , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depth for each bin.")
+    parser.add_argument('-b', '--bins'         , required=True, nargs="+", metavar='FILE'                             , help="Bins: FASTA containing all contigs.")
+    parser.add_argument('-d', '--depths'       , required=True           , metavar='FILE'                             , help="(Compressed) TSV file containing contig depths for each sample (within group): contigName, contigLen, totalAvgDepth, sample1_avgDepth, sample1_var [, sample2_avgDepth, sample2_var, ...].")
+    parser.add_argument('-a', '--assembly_name', required=True                           , type=str                   , help="Assembly name.")
+    parser.add_argument('-o', "--out"          , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depth for each bin.")
     return parser.parse_args(args)
 
 def main(args=None):
@@ -28,7 +29,10 @@ def main(args=None):
         # process header
         header = next(reader)
         for sample in range(int((len(header)-3)/2)):
-            sample_names.append(header[3+2*sample])
+            col_name = header[3+2*sample]
+            # retrieve sample name: "<assembly_name>-<sample_name>.bam"
+            sample_name = col_name[len(args.assembly_name)+1:-4]
+            sample_names.append(sample_name)
         # process contig depths
         for row in reader:
             contig_depths = []

--- a/bin/get_mag_depths.py
+++ b/bin/get_mag_depths.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import os.path
+import pandas as pd
+import csv
+import gzip
+
+from Bio import SeqIO
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-b', '--bins'       , required=True, nargs="+", metavar='FILE'                             , help="Bins: FASTA containing all contigs.")
+    parser.add_argument('-d', '--depths'     , required=True           , metavar='FILE'                             , help="(Compressed) TSV file containing contig depths for each sample (within group): contigName, contigLen, totalAvgDepth, sample1_avgDepth, sample1_var [, sample2_avgDepth, sample2_var, ...].")
+    parser.add_argument('-o', "--out"        , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depth for each bin of assembly.")
+    return parser.parse_args(args)
+
+def main(args=None):
+    args = parse_args(args)
+
+    # load all contig depths into dict, roughly estimated the memory consuption should be feasible even for extremely large assemblies (?)
+    # contig : [depth1, depth2, ...]
+
+    sample_names = []
+    dict_contig_depths = {}
+    with gzip.open(args.depths, "rt") as infile:
+        reader = csv.reader(infile, delimiter = "\t")
+        # process header
+        header = next(reader)
+        for sample in range(int((len(header)-3)/2)):
+            sample_names.append(header[3+2*sample])
+        # process rest
+        for row in reader:
+            contig_depths = []
+            for sample in range(int((len(row)-3)/2)):
+                contig_depths.append(float(row[3+2*sample]))
+            dict_contig_depths[str(row[0])] = contig_depths
+
+    n_samples = len(sample_names)
+    print("bin", '\t'.join(sample_names), file=args.out)
+    for file in args.bins:
+        mean_depths = [0] * n_samples
+        with open(file, "rt") as infile:
+            c = 0
+            for rec in SeqIO.parse(infile,'fasta'):
+                print("rec: ", rec.id)
+                depths = dict_contig_depths[rec.id]
+                for sample in range(n_samples):
+                    mean_depths[sample] += depths[sample]
+                c += 1
+        for sample in range(n_samples):
+            mean_depths[sample] = mean_depths[sample]/float(c)
+        print(os.path.basename(file), '\t'.join(str(d) for d in mean_depths), file=args.out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/get_mag_depths.py
+++ b/bin/get_mag_depths.py
@@ -42,7 +42,7 @@ def main(args=None):
 
     n_samples = len(sample_names)
     # for each bin, access contig depths and compute mean bin depth (for all samples)
-    print("bin", '\t'.join(sample_names), file=args.out)
+    print("bin", '\t'.join(sample_names), sep='\t', file=args.out)
     for file in args.bins:
         mean_depths = [0] * n_samples
         with open(file, "rt") as infile:
@@ -54,7 +54,7 @@ def main(args=None):
                 c += 1
         for sample in range(n_samples):
             mean_depths[sample] = mean_depths[sample]/float(c)
-        print(os.path.basename(file), '\t'.join(str(d) for d in mean_depths), file=args.out)
+        print(os.path.basename(file), '\t'.join(str(d) for d in mean_depths), sep='\t', file=args.out)
 
 
 if __name__ == "__main__":

--- a/bin/get_mag_depths_summary.py
+++ b/bin/get_mag_depths_summary.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import pandas as pd
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--depths'       , required=True, nargs="+", metavar='FILE'                             , help="TSV file for each assembly containing bin depths for samples: bin, sample1, ....")
+    parser.add_argument('-o', "--out"          , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depths for all assemblies and all samples.")
+    return parser.parse_args(args)
+
+def main(args=None):
+    args = parse_args(args)
+
+    results = pd.DataFrame()
+    for assembly_depths_file in args.depths:
+        assembly_results = pd.read_csv(assembly_depths_file, index_col="bin", sep="\t")
+        results          = results.append(assembly_results, sort=True, verify_integrity=True)
+
+    results.to_csv(args.out, sep='\t')
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/base.config
+++ b/conf/base.config
@@ -141,6 +141,9 @@ process {
     memory = { check_max (20.GB * task.attempt, 'memory' ) }
     time   = { check_max (8.h   * task.attempt, 'time'   ) }
   }
+  withName: MAG_DEPTHS {
+    memory = { check_max (16.GB * task.attempt, 'memory' ) }
+  }
   withName: BUSCO {
     cpus   = { check_max (8     * task.attempt, 'cpus'   ) }
     memory = { check_max (20.GB * task.attempt, 'memory' ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -101,6 +101,9 @@ params {
             publish_files  = ['txt.gz':'', 'fa':'', 'fa.gz':'']
             publish_dir    = "GenomeBinning"
         }
+        'mag_depths' {
+            publish_dir    = "GenomeBinning"
+        }
         'busco_db_preparation' {
             publish_files  = ['tar.gz':'']
             publish_dir    = "GenomeBinning/QC/BUSCO"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -148,7 +148,7 @@ params {
             args           = "--extension fa"
             publish_dir    = "Taxonomy/GTDB-Tk"
         }
-        'merge_quast_busco_gtdbtk' {
+        'bin_summary' {
             publish_dir    = "GenomeBinning"
         }
         'multiqc' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -102,6 +102,9 @@ params {
             publish_dir    = "GenomeBinning"
         }
         'mag_depths' {
+            publish_files  = false
+        }
+        'mag_depths_summary' {
             publish_dir    = "GenomeBinning"
         }
         'busco_db_preparation' {

--- a/docs/output.md
+++ b/docs/output.md
@@ -214,6 +214,15 @@ All the files in this folder contain small and/or unbinned contigs that are not 
 
 Files in these two folders contain all contigs of an assembly.
 
+### Bin sequencing depth
+
+For each genome bin the average sequencing depth is computed based on the corresponding contig depths given in `GenomeBinning/[assembler]-[sample/group]-depth.txt.gz`.
+
+**Output files:**
+
+* `GenomeBinning/`
+  * `[assembler]-[sample/group]-binDepths.tsv`: Bin sequencing depths for samples mapped against the assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
+
 ### QC for metagenome assembled genomes with QUAST
 
 [QUAST](http://cab.spbu.ru/software/quast/) is a tool that evaluates genome assemblies by computing various metrics. The QUAST output is also included in the MultiQC report, as well as in the assembly directories themselves.

--- a/docs/output.md
+++ b/docs/output.md
@@ -307,7 +307,7 @@ If the parameters `--cat_db_generate` and `--save_cat_db` are set, additionally 
 
 **Output files:**
 
-* `GenomeBinning/bin_summary.tsv`: Summary of BUSCO, QUAST and GTDB-Tk results, if at least two of those were generated.
+* `GenomeBinning/bin_summary.tsv`: Summary of bin sequencing depths together with BUSCO, QUAST and GTDB-Tk results, if at least one of the later was generated.
 
 ## MultiQC
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -221,7 +221,7 @@ For each genome bin the average sequencing depth is computed based on the corres
 **Output files:**
 
 * `GenomeBinning/`
-  * `[assembler]-[sample/group]-binDepths.tsv`: Bin sequencing depths for samples mapped against the assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
+  * `bin_depths_summary.tsv`: Summary of bin sequencing depths for all samples. Depths are available for samples mapped against the corresponding assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
 
 ### QC for metagenome assembled genomes with QUAST
 

--- a/modules/local/bin_summary.nf
+++ b/modules/local/bin_summary.nf
@@ -4,7 +4,7 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 params.options = [:]
 options    = initOptions(params.options)
 
-process MERGE_QUAST_BUSCO_GTDBTK {
+process BIN_SUMMARY {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -11,7 +11,7 @@ process MAG_DEPTHS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.assembler) }
 
-    // TODO create own container without metabat?
+    // Using container from metabat2 process, since this will be anyway already downloaded and contains biopython and pandas
     conda (params.enable_conda ? "bioconda::metabat2=2.15 conda-forge::python=3.6.7 conda-forge::biopython=1.74 conda-forge::pandas=1.1.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-e25d1fa2bb6cbacd47a4f8b2308bd01ba38c5dd7:75310f02364a762e6ba5206fcd11d7529534ed6e-0"

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -24,7 +24,7 @@ process MAG_DEPTHS {
     path(contig_depths)
 
     output:
-    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.tsv")
+    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.tsv"), emit: depths
 
     script:
     def software = getSoftwareName(task.process)

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -9,7 +9,7 @@ process MAG_DEPTHS {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.assembler) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}-${meta.id}") }
 
     // Using container from metabat2 process, since this will be anyway already downloaded and contains biopython and pandas
     conda (params.enable_conda ? "bioconda::metabat2=2.15 conda-forge::python=3.6.7 conda-forge::biopython=1.74 conda-forge::pandas=1.1.5" : null)

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -31,6 +31,7 @@ process MAG_DEPTHS {
     """
     get_mag_depths.py --bins ${bins} \
                       --depths ${contig_depths} \
+                      --assembly_name "${meta.assembler}-${meta.id}" \
                       --out "${meta.assembler}-${meta.id}-binDepths.tsv"
     """
 }

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -1,0 +1,36 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process MAG_DEPTHS {
+    tag "${meta.assembler}-${meta.id}"
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.assembler) }
+
+    // TODO create own container without metabat?
+    conda (params.enable_conda ? "bioconda::metabat2=2.15 conda-forge::python=3.6.7 conda-forge::biopython=1.74 conda-forge::pandas=1.1.5" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/mulled-v2-e25d1fa2bb6cbacd47a4f8b2308bd01ba38c5dd7:75310f02364a762e6ba5206fcd11d7529534ed6e-0"
+    } else {
+        container "quay.io/biocontainers/mulled-v2-e25d1fa2bb6cbacd47a4f8b2308bd01ba38c5dd7:75310f02364a762e6ba5206fcd11d7529534ed6e-0"
+    }
+
+    input:
+    tuple val(meta), path(bins)
+    path(contig_depths)
+
+    output:
+    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.tsv")
+
+    script:
+    def software = getSoftwareName(task.process)
+    """
+    get_mag_depths.py --bins ${bins} \
+                      --depths ${contig_depths} \
+                      --out "${meta.assembler}-${meta.id}-binDepths.tsv"
+    """
+}

--- a/modules/local/mag_depths_summary.nf
+++ b/modules/local/mag_depths_summary.nf
@@ -1,0 +1,32 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process MAG_DEPTHS_SUMMARY {
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+
+    conda (params.enable_conda ? "conda-forge::pandas=1.1.5" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/pandas:1.1.5"
+    } else {
+        container "quay.io/biocontainers/pandas:1.1.5"
+    }
+
+    input:
+    path(mag_depths)
+
+    output:
+    path("bin_depths_summary.tsv"), emit: summary
+
+    script:
+    def software = getSoftwareName(task.process)
+    """
+    get_mag_depths_summary.py --depths ${mag_depths} \
+                              --out "bin_depths_summary.tsv"
+    """
+}

--- a/modules/local/merge_quast_busco_gtdbtk.nf
+++ b/modules/local/merge_quast_busco_gtdbtk.nf
@@ -18,6 +18,7 @@ process MERGE_QUAST_BUSCO_GTDBTK {
     }
 
     input:
+    path(bin_depths)
     path(busco_sum)
     path(quast_sum)
     path(gtdbtk_sum)
@@ -30,7 +31,8 @@ process MERGE_QUAST_BUSCO_GTDBTK {
     def quast_summary  = quast_sum.sort().size() > 0 ?  "--quast_summary ${quast_sum}" : ""
     def gtdbtk_summary = gtdbtk_sum.sort().size() > 0 ? "--gtdbtk_summary ${gtdbtk_sum}" : ""
     """
-    combine_tables.py $busco_summary \
+    combine_tables.py --depths_summary ${bin_depths} \
+                      $busco_summary \
                       $quast_summary \
                       $gtdbtk_summary \
                       --out bin_summary.tsv

--- a/subworkflows/local/metabat2_binning.nf
+++ b/subworkflows/local/metabat2_binning.nf
@@ -2,15 +2,17 @@
  * Binning with MetaBAT2
  */
 
-params.bowtie2_build_options = [:]
-params.bowtie2_align_options = [:]
-params.metabat2_options      = [:]
-params.mag_depths_options    = [:]
+params.bowtie2_build_options      = [:]
+params.bowtie2_align_options      = [:]
+params.metabat2_options           = [:]
+params.mag_depths_options         = [:]
+params.mag_depths_summary_options = [:]
 
-include { BOWTIE2_ASSEMBLY_BUILD    } from '../../modules/local/bowtie2_assembly_build'   addParams( options: params.bowtie2_build_options )
-include { BOWTIE2_ASSEMBLY_ALIGN    } from '../../modules/local/bowtie2_assembly_align'   addParams( options: params.bowtie2_align_options )
-include { METABAT2                  } from '../../modules/local/metabat2'                 addParams( options: params.metabat2_options      )
-include { MAG_DEPTHS                } from '../../modules/local/mag_depths'               addParams( options: params.mag_depths_options      )
+include { BOWTIE2_ASSEMBLY_BUILD    } from '../../modules/local/bowtie2_assembly_build'   addParams( options: params.bowtie2_build_options      )
+include { BOWTIE2_ASSEMBLY_ALIGN    } from '../../modules/local/bowtie2_assembly_align'   addParams( options: params.bowtie2_align_options      )
+include { METABAT2                  } from '../../modules/local/metabat2'                 addParams( options: params.metabat2_options           )
+include { MAG_DEPTHS                } from '../../modules/local/mag_depths'               addParams( options: params.mag_depths_options         )
+include { MAG_DEPTHS_SUMMARY        } from '../../modules/local/mag_depths_summary'       addParams( options: params.mag_depths_summary_options )
 
 workflow METABAT2_BINNING {
     take:
@@ -55,10 +57,12 @@ workflow METABAT2_BINNING {
         METABAT2.out.bins,
         METABAT2.out.depths
      )
+    MAG_DEPTHS_SUMMARY ( MAG_DEPTHS.out.depths.map{it[1]}.collect() )
 
     emit:
     bowtie2_assembly_multiqc = BOWTIE2_ASSEMBLY_ALIGN.out.log.map { assembly_meta, reads_meta, log -> if (assembly_meta.id == reads_meta.id) {return [ log ]} }
     bowtie2_version          = BOWTIE2_ASSEMBLY_ALIGN.out.version
     bins                     = METABAT2.out.bins
+    depths_summary           = MAG_DEPTHS_SUMMARY.out.summary
     metabat2_version         = METABAT2.out.version
 }

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -81,7 +81,7 @@ include { QUAST_BINS_SUMMARY                                  } from '../modules
 include { CAT_DB                                              } from '../modules/local/cat_db'
 include { CAT_DB_GENERATE                                     } from '../modules/local/cat_db_generate'             addParams( options: modules['cat_db_generate']            )
 include { CAT                                                 } from '../modules/local/cat'                         addParams( options: modules['cat']                        )
-include { MERGE_QUAST_BUSCO_GTDBTK                            } from '../modules/local/merge_quast_busco_gtdbtk'    addParams( options: modules['merge_quast_busco_gtdbtk']   )
+include { BIN_SUMMARY                                         } from '../modules/local/bin_summary'                 addParams( options: modules['bin_summary']                )
 include { MULTIQC                                             } from '../modules/local/multiqc'                     addParams( options: multiqc_options                       )
 
 // Local: Sub-workflows
@@ -522,7 +522,7 @@ workflow MAG {
         }
 
         if (!params.skip_busco || !params.skip_quast || params.gtdb){
-            MERGE_QUAST_BUSCO_GTDBTK (
+            BIN_SUMMARY (
                 METABAT2_BINNING.out.depths_summary,
                 ch_busco_summary.ifEmpty([]),
                 ch_quast_bins_summary.ifEmpty([]),

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -521,10 +521,9 @@ workflow MAG {
             ch_gtdbtk_summary = GTDBTK.out.summary
         }
 
-        if ( (!params.skip_busco && !params.skip_quast) ||
-             (!params.skip_busco && params.gtdb ) ||
-             (!params.skip_quast && params.gtdb )) {
+        if (!params.skip_busco || !params.skip_quast || params.gtdb){
             MERGE_QUAST_BUSCO_GTDBTK (
+                METABAT2_BINNING.out.depths_summary,
                 ch_busco_summary.ifEmpty([]),
                 ch_quast_bins_summary.ifEmpty([]),
                 ch_gtdbtk_summary.ifEmpty([])

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -86,7 +86,7 @@ include { MULTIQC                                             } from '../modules
 
 // Local: Sub-workflows
 include { INPUT_CHECK         } from '../subworkflows/local/input_check'
-include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2'], mag_depths_options: modules['mag_depths'])
+include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2'], mag_depths_options: modules['mag_depths'], mag_depths_summary_options: modules['mag_depths_summary'])
 include { BUSCO_QC            } from '../subworkflows/local/busco_qc'              addParams( busco_db_options: modules['busco_db_preparation'], busco_options: modules['busco'], busco_save_download_options: modules['busco_save_download'], busco_plot_options: modules['busco_plot'], busco_summary_options: modules['busco_summary'])
 include { GTDBTK              } from '../subworkflows/local/gtdbtk'                addParams( gtdbtk_classify_options: modules['gtdbtk_classify'], gtdbtk_summary_options: modules['gtdbtk_summary'])
 

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -86,7 +86,7 @@ include { MULTIQC                                             } from '../modules
 
 // Local: Sub-workflows
 include { INPUT_CHECK         } from '../subworkflows/local/input_check'
-include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2']                                                   )
+include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2'], mag_depths_options: modules['mag_depths'])
 include { BUSCO_QC            } from '../subworkflows/local/busco_qc'              addParams( busco_db_options: modules['busco_db_preparation'], busco_options: modules['busco'], busco_save_download_options: modules['busco_save_download'], busco_plot_options: modules['busco_plot'], busco_summary_options: modules['busco_summary'])
 include { GTDBTK              } from '../subworkflows/local/gtdbtk'                addParams( gtdbtk_classify_options: modules['gtdbtk_classify'], gtdbtk_summary_options: modules['gtdbtk_summary'])
 


### PR DESCRIPTION
Estimate bin abundances by computing mean bin depths of corresponding contig depths obtained from MetaBAT2 process (i.e. `[assembler]-[sample/group]-depth.txt.gz` generated by `jgi_summarize_bam_contig_depths`).

Addresses https://github.com/nf-core/mag/issues/197.

Open todo:

- [x] add to `bin_summary`

## PR checklists

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
