### PR TITLE
Plot bin abundances as heat map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#212](https://github.com/nf-core/mag/pull/212) - Add bin abundance estimation based on mean sequencing depths of corresponding contigs (results are written to `results/GenomeBinning/bin_depths_summary.tsv` and `results/GenomeBinning/bin_summary.tsv`) [#197](https://github.com/nf-core/mag/issues/197).
+- [#212](https://github.com/nf-core/mag/pull/212), [#214](https://github.com/nf-core/mag/pull/214) - Add bin abundance estimation based on median sequencing depths of corresponding contigs (results are written to `results/GenomeBinning/bin_depths_summary.tsv` and `results/GenomeBinning/bin_summary.tsv`) [#197](https://github.com/nf-core/mag/issues/197).
+- [#214](https://github.com/nf-core/mag/pull/214) - Add generation of (clustered) heat maps with bin abundances across samples (using centered log-ratios)
 
 ## v2.0.0 - 2021/06/01
 

--- a/bin/get_mag_depths.py
+++ b/bin/get_mag_depths.py
@@ -6,6 +6,7 @@ import os.path
 import pandas as pd
 import csv
 import gzip
+import statistics
 
 from Bio import SeqIO
 
@@ -44,17 +45,13 @@ def main(args=None):
     # for each bin, access contig depths and compute mean bin depth (for all samples)
     print("bin", '\t'.join(sample_names), sep='\t', file=args.out)
     for file in args.bins:
-        mean_depths = [0] * n_samples
+        all_depths = [[] for i in range(n_samples)]
         with open(file, "rt") as infile:
-            c = 0
             for rec in SeqIO.parse(infile,'fasta'):
-                depths = dict_contig_depths[rec.id]
+                contig_depths = dict_contig_depths[rec.id]
                 for sample in range(n_samples):
-                    mean_depths[sample] += depths[sample]
-                c += 1
-        for sample in range(n_samples):
-            mean_depths[sample] = mean_depths[sample]/float(c)
-        print(os.path.basename(file), '\t'.join(str(d) for d in mean_depths), sep='\t', file=args.out)
+                    all_depths[sample].append(contig_depths[sample])
+        print(os.path.basename(file), '\t'.join(str(statistics.median(sample_depths)) for sample_depths in all_depths), sep='\t', file=args.out)
 
 
 if __name__ == "__main__":

--- a/bin/plot_mag_depths.py
+++ b/bin/plot_mag_depths.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import os.path
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from scipy import stats
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--bin_depths'   , required=True, metavar='FILE'          , help="Bin depths file in TSV format (for one assembly): bin, sample1_depth, sample2_depth, ....")
+    parser.add_argument('-o', "--out"          , required=True, metavar='FILE', type=str, help="Output file.")
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    # load data
+    df=pd.read_csv(args.bin_depths, sep='\t', index_col=0)
+    # add pseudo-abundances (sample-wise? dependent on lib-size)
+    pseudo_cov = 0.1 * df[df > 0].min().min()
+    df.replace(0, pseudo_cov, inplace=True)
+    print(df)
+    # compute centered log-ratios
+    # divide df by sample-wise geometric means
+    gmeans = stats.gmean(df, axis=0)                # apply on axis=0: 'index'
+    df = np.log(df.div(gmeans, axis='columns'))     # divide column-wise (axis=1|'columns'), take natural logorithm
+    # NOTE NaNs should not occur
+    print(df)
+    df.index.name='MAGs'
+    df.columns.name='Samples'
+
+    # plot
+    plt.figure()
+    # TODO add colors for group information for samples
+    # TODO col_cluster=False ?
+    # TODO yticklabels=False ? if number of bins > 20 ?
+    # TODO add colors for tax. classification at certain level, e.g. phylum (if adding clustering based on phylogenetic information)
+    sns.clustermap(df, row_cluster=False, cmap="vlag")
+    plt.savefig(args.out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/bin/plot_mag_depths.py
+++ b/bin/plot_mag_depths.py
@@ -12,6 +12,7 @@ from scipy import stats
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--bin_depths'   , required=True, metavar='FILE'          , help="Bin depths file in TSV format (for one assembly): bin, sample1_depth, sample2_depth, ....")
+    parser.add_argument('-g', '--groups'       , required=True, metavar='FILE'          , help="File in TSV format containing group information for samples: sample, group")
     parser.add_argument('-o', "--out"          , required=True, metavar='FILE', type=str, help="Output file.")
     return parser.parse_args(args)
 
@@ -20,7 +21,9 @@ def main(args=None):
     args = parse_args(args)
 
     # load data
-    df=pd.read_csv(args.bin_depths, sep='\t', index_col=0)
+    df     = pd.read_csv(args.bin_depths, sep='\t', index_col=0)
+    groups = pd.read_csv(args.groups, sep='\t', index_col=0, names=['sample', 'group'])
+
     # add pseudo-abundances (sample-wise? dependent on lib-size)
     pseudo_cov = 0.1 * df[df > 0].min().min()
     df.replace(0, pseudo_cov, inplace=True)
@@ -34,13 +37,14 @@ def main(args=None):
     df.index.name='MAGs'
     df.columns.name='Samples'
 
+    # prepare colors for group information
+    color_map= dict(zip(groups['group'].unique(), sns.color_palette(n_colors=len(groups['group'].unique()))))
+
     # plot
     plt.figure()
-    # TODO add colors for group information for samples
-    # TODO col_cluster=False ?
+    # TODO row_cluster=False ? add colors for tax. classification at certain level, e.g. phylum (if adding clustering based on phylogenetic information)
     # TODO yticklabels=False ? if number of bins > 20 ?
-    # TODO add colors for tax. classification at certain level, e.g. phylum (if adding clustering based on phylogenetic information)
-    sns.clustermap(df, row_cluster=False, cmap="vlag")
+    sns.clustermap(df, row_cluster=True, cmap="vlag", col_colors=groups.group.map(color_map))
     plt.savefig(args.out)
 
 

--- a/bin/plot_mag_depths.py
+++ b/bin/plot_mag_depths.py
@@ -44,7 +44,7 @@ def main(args=None):
     plt.figure()
     # TODO row_cluster=False ? add colors for tax. classification at certain level, e.g. phylum (if adding clustering based on phylogenetic information)
     # TODO yticklabels=False ? if number of bins > 20 ?
-    sns.clustermap(df, row_cluster=True, cmap="vlag", col_colors=groups.group.map(color_map))
+    sns.clustermap(df, row_cluster=True, cmap="vlag", center=0, col_colors=groups.group.map(color_map))
     plt.savefig(args.out)
 
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -104,6 +104,9 @@ params {
         'mag_depths' {
             publish_files  = false
         }
+        'mag_depths_plot' {
+            publish_dir    = "GenomeBinning"
+        }
         'mag_depths_summary' {
             publish_dir    = "GenomeBinning"
         }

--- a/docs/output.md
+++ b/docs/output.md
@@ -222,6 +222,7 @@ For each genome bin the median sequencing depth is computed based on the corresp
 
 * `GenomeBinning/`
   * `bin_depths_summary.tsv`: Summary of bin sequencing depths for all samples. Depths are available for samples mapped against the corresponding assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
+  * `[assembler]-[sample/group]-binDepths.heatmap.png`: Clustered heatmap showing bin abundances of the assembly across samples. Bin depths are transformed to centered log-ratios and bins as well as samples are clustered by Euclidean distance. Again, sample depths are available according to the mapping strategy specified with `--binning_map_mode`.
 
 ### QC for metagenome assembled genomes with QUAST
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -216,7 +216,7 @@ Files in these two folders contain all contigs of an assembly.
 
 ### Bin sequencing depth
 
-For each genome bin the average sequencing depth is computed based on the corresponding contig depths given in `GenomeBinning/[assembler]-[sample/group]-depth.txt.gz`.
+For each genome bin the median sequencing depth is computed based on the corresponding contig depths given in `GenomeBinning/[assembler]-[sample/group]-depth.txt.gz`.
 
 **Output files:**
 

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -64,3 +64,11 @@ def saveFiles(Map args) {
 def hasExtension(it, extension) {
     it.toString().toLowerCase().endsWith(extension.toLowerCase())
 }
+
+/*
+ * Get number of columns in file (first line)
+ */
+def getColNo(filename) {
+    lines  = file(filename).readLines()
+    return lines[0].split('\t').size()
+}

--- a/modules/local/mag_depths_plot.nf
+++ b/modules/local/mag_depths_plot.nf
@@ -1,0 +1,33 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options    = initOptions(params.options)
+
+process MAG_DEPTHS_PLOT {
+    tag "${meta.assembler}-${meta.id}"
+
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:"${meta.assembler}-${meta.id}") }
+
+    conda (params.enable_conda ? "conda-forge::python=3.9 conda-forge::pandas=1.3.0 anaconda::seaborn=0.11.0" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/mulled-v2-d14219255233ee6cacc427e28a7caf8ee42e8c91:0a22c7568e4a509925048454dad9ab37fa8fe776-0"
+    } else {
+        container "quay.io/biocontainers/mulled-v2-d14219255233ee6cacc427e28a7caf8ee42e8c91:0a22c7568e4a509925048454dad9ab37fa8fe776-0"
+    }
+
+    input:
+    tuple val(meta), path(depths)
+
+    output:
+    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
+
+    script:
+    def software = getSoftwareName(task.process)
+    """
+    plot_mag_depths.py --bin_depths ${depths} \
+                       --out "${meta.assembler}-${meta.id}-binDepths.heatmap.png"
+    """
+}

--- a/modules/local/mag_depths_plot.nf
+++ b/modules/local/mag_depths_plot.nf
@@ -20,6 +20,7 @@ process MAG_DEPTHS_PLOT {
 
     input:
     tuple val(meta), path(depths)
+    path(sample_groups)
 
     output:
     tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
@@ -28,6 +29,7 @@ process MAG_DEPTHS_PLOT {
     def software = getSoftwareName(task.process)
     """
     plot_mag_depths.py --bin_depths ${depths} \
+                       --groups ${sample_groups} \
                        --out "${meta.assembler}-${meta.id}-binDepths.heatmap.png"
     """
 }

--- a/subworkflows/local/metabat2_binning.nf
+++ b/subworkflows/local/metabat2_binning.nf
@@ -6,12 +6,14 @@ params.bowtie2_build_options      = [:]
 params.bowtie2_align_options      = [:]
 params.metabat2_options           = [:]
 params.mag_depths_options         = [:]
+params.mag_depths_plot_options    = [:]
 params.mag_depths_summary_options = [:]
 
 include { BOWTIE2_ASSEMBLY_BUILD    } from '../../modules/local/bowtie2_assembly_build'   addParams( options: params.bowtie2_build_options      )
 include { BOWTIE2_ASSEMBLY_ALIGN    } from '../../modules/local/bowtie2_assembly_align'   addParams( options: params.bowtie2_align_options      )
 include { METABAT2                  } from '../../modules/local/metabat2'                 addParams( options: params.metabat2_options           )
 include { MAG_DEPTHS                } from '../../modules/local/mag_depths'               addParams( options: params.mag_depths_options         )
+include { MAG_DEPTHS_PLOT           } from '../../modules/local/mag_depths_plot'          addParams( options: params.mag_depths_plot_options    )
 include { MAG_DEPTHS_SUMMARY        } from '../../modules/local/mag_depths_summary'       addParams( options: params.mag_depths_summary_options )
 
 workflow METABAT2_BINNING {
@@ -56,7 +58,9 @@ workflow METABAT2_BINNING {
     MAG_DEPTHS (
         METABAT2.out.bins,
         METABAT2.out.depths
-     )
+    )
+    // Plot bin depths heatmap for each assembly and mapped samples (according to `binning_map_mode`)
+    MAG_DEPTHS_PLOT ( MAG_DEPTHS.out.depths )
     MAG_DEPTHS_SUMMARY ( MAG_DEPTHS.out.depths.map{it[1]}.collect() )
 
     emit:

--- a/subworkflows/local/metabat2_binning.nf
+++ b/subworkflows/local/metabat2_binning.nf
@@ -60,7 +60,13 @@ workflow METABAT2_BINNING {
         METABAT2.out.depths
     )
     // Plot bin depths heatmap for each assembly and mapped samples (according to `binning_map_mode`)
-    MAG_DEPTHS_PLOT ( MAG_DEPTHS.out.depths )
+    ch_sample_groups = reads
+        .collectFile(name:'sample_groups.tsv'){ meta, reads -> meta.id + '\t' + meta.group + '\n' }
+    MAG_DEPTHS_PLOT (
+        MAG_DEPTHS.out.depths,
+        ch_sample_groups.collect()
+    )
+
     MAG_DEPTHS_SUMMARY ( MAG_DEPTHS.out.depths.map{it[1]}.collect() )
 
     emit:

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -86,7 +86,7 @@ include { MULTIQC                                             } from '../modules
 
 // Local: Sub-workflows
 include { INPUT_CHECK         } from '../subworkflows/local/input_check'
-include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2'], mag_depths_options: modules['mag_depths'], mag_depths_summary_options: modules['mag_depths_summary'])
+include { METABAT2_BINNING    } from '../subworkflows/local/metabat2_binning'      addParams( bowtie2_align_options: modules['bowtie2_assembly_align'], metabat2_options: modules['metabat2'], mag_depths_options: modules['mag_depths'], mag_depths_plot_options: modules['mag_depths_plot'], mag_depths_summary_options: modules['mag_depths_summary'])
 include { BUSCO_QC            } from '../subworkflows/local/busco_qc'              addParams( busco_db_options: modules['busco_db_preparation'], busco_options: modules['busco'], busco_save_download_options: modules['busco_save_download'], busco_plot_options: modules['busco_plot'], busco_summary_options: modules['busco_summary'])
 include { GTDBTK              } from '../subworkflows/local/gtdbtk'                addParams( gtdbtk_classify_options: modules['gtdbtk_classify'], gtdbtk_summary_options: modules['gtdbtk_summary'])
 


### PR DESCRIPTION
- add clustered heat map with bin depths across samples (using centred log-ratios)

- for each assembly, across all samples according to `binning_map_mode`

- currently samples and bins are clustered using euclidean distances

- changed estimating the bin abundance by using the mean depths of all contigs to using the median

Todos:

- [x] create heat map only if # samples > 2 in total or if `binning_map_mode != own` 
- [x] center color gradient?
- [x] add description of heat map to `output.md`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
