### PR TITLE
Fix handling of BUSCO output with auto lineage selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#218](https://github.com/nf-core/mag/pull/218) - Update to nf-core 2.0.1 `TEMPLATE` (DSL2)
 
+### `Fixed`
+
+- [#226](https://github.com/nf-core/mag/pull/226) - Fix handling of `BUSCO` output when run in auto lineage selection mode and selected specific lineage is the same as the generic one.
+
 ## v2.0.0 - 2021/06/01
 
 ### `Added`

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -111,15 +111,18 @@ process BUSCO {
                 echo "Domain and specific lineage could be selected by BUSCO."
                 cp BUSCO/short_summary.specific.\${db_name_spec}.BUSCO.txt short_summary.specific_lineage.\${db_name_spec}.${bin}.txt
 
+                db_name_gen=""
                 summaries_gen=(BUSCO/short_summary.generic.*.BUSCO.txt)
-                if [ \${#summaries_gen[@]} -ne 1 ]; then
-                    echo "ERROR: none or multiple 'BUSCO/short_summary.generic.*.BUSCO.txt' files found. Expected one."
-                    exit 1
+                if [ \${#summaries_gen[@]} -lt 1 ]; then
+                    echo "No 'BUSCO/short_summary.generic.*.BUSCO.txt' file found. Assuming selected domain and specific lineages are the same."
+                    cp BUSCO/short_summary.specific.\${db_name_spec}.BUSCO.txt short_summary.domain.\${db_name_spec}.${bin}.txt
+                    db_name_gen=\${db_name_spec}
+                else
+                    [[ \$summaries_gen =~ BUSCO/short_summary.generic.(.*).BUSCO.txt ]];
+                    db_name_gen="\${BASH_REMATCH[1]}"
+                    echo "Used generic lineage dataset: \${db_name_gen}"
+                    cp BUSCO/short_summary.generic.\${db_name_gen}.BUSCO.txt short_summary.domain.\${db_name_gen}.${bin}.txt
                 fi
-                [[ \$summaries_gen =~ BUSCO/short_summary.generic.(.*).BUSCO.txt ]];
-                db_name_gen="\${BASH_REMATCH[1]}"
-                echo "Used generic lineage dataset: \${db_name_gen}"
-                cp BUSCO/short_summary.generic.\${db_name_gen}.BUSCO.txt short_summary.domain.\${db_name_gen}.${bin}.txt
 
                 for f in BUSCO/run_\${db_name_gen}/busco_sequences/single_copy_busco_sequences/*faa; do
                     cat BUSCO/run_\${db_name_gen}/busco_sequences/single_copy_busco_sequences/*faa | gzip >${bin}_buscos.\${db_name_gen}.faa.gz


### PR DESCRIPTION
Fix handling of BUSCO output with `auto lineage selection` for the case that both domain and specific linear could be selected successfully, i.e. without error or problems due to missing marker genes, and that the specific lineage is still the same as the generic one. In this case there is no `short_summary.generic.*` file produced by BUSCO.

-> used results for `specific` lineage also for `domain`. Thus, in this case, the lineage `bacteria_odb10` would be listed as `specific lineage dataset` and only when the specific lineage could not be selected (i.e. BUSCO errors occur) due to failed placements the results for the `specific lineage dataset` would be `NA`.



## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
