### PR TITLE
fix metabat 2 with nextflow version 21.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#236](https://github.com/nf-core/mag/pull/236) - Fix large assemblies (> 4 billion nucleotides in length).
+- [#253](https://github.com/nf-core/mag/issues/253) - Fix MetaBAT2 error with nextflow version 21.10.x (21.04.03 is the latest functional version for nf-core/mag 2.1.0).
 
 ## v2.1.0 - 2021/07/29
 

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -73,11 +73,3 @@ def saveFiles(Map args) {
 def hasExtension(it, extension) {
     it.toString().toLowerCase().endsWith(extension.toLowerCase())
 }
-
-/*
- * Get number of columns in file (first line)
- */
-def getColNo(filename) {
-    lines  = file(filename).readLines()
-    return lines[0].split('\t').size()
-}

--- a/subworkflows/local/metabat2_binning.nf
+++ b/subworkflows/local/metabat2_binning.nf
@@ -16,7 +16,13 @@ include { MAG_DEPTHS                } from '../../modules/local/mag_depths'     
 include { MAG_DEPTHS_PLOT           } from '../../modules/local/mag_depths_plot'          addParams( options: params.mag_depths_plot_options    )
 include { MAG_DEPTHS_SUMMARY        } from '../../modules/local/mag_depths_summary'       addParams( options: params.mag_depths_summary_options )
 
-include { getColNo } from '../../modules/local/functions'
+/*
+ * Get number of columns in file (first line)
+ */
+def getColNo(filename) {
+    lines  = file(filename).readLines()
+    return lines[0].split('\t').size()
+}
 
 workflow METABAT2_BINNING {
     take:


### PR DESCRIPTION
Closes https://github.com/nf-core/mag/issues/253
Succeeds now with nextflow versions 21.04.x and 21.10.x!

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
