### PR TITLE
Fix --skip_busco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#232](https://github.com/nf-core/mag/issues/232) - Fix `--skip_busco`.
 - [#236](https://github.com/nf-core/mag/pull/236) - Fix large assemblies (> 4 billion nucleotides in length).
 
 ## v2.1.0 - 2021/07/29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#256](https://github.com/nf-core/mag/pull/256) - Fix `--skip_busco`.
 - [#236](https://github.com/nf-core/mag/pull/236) - Fix large assemblies (> 4 billion nucleotides in length).
-- [#253](https://github.com/nf-core/mag/issues/253) - Fix MetaBAT2 error with nextflow version 21.10.x (21.04.03 is the latest functional version for nf-core/mag 2.1.0).
+- [#254](https://github.com/nf-core/mag/pull/254) - Fix MetaBAT2 error with nextflow version 21.10.x (21.04.03 is the latest functional version for nf-core/mag 2.1.0).
 
 ## v2.1.0 - 2021/07/29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#232](https://github.com/nf-core/mag/issues/232) - Fix `--skip_busco`.
+- [#256](https://github.com/nf-core/mag/pull/256) - Fix `--skip_busco`.
 - [#236](https://github.com/nf-core/mag/pull/236) - Fix large assemblies (> 4 billion nucleotides in length).
 
 ## v2.1.0 - 2021/07/29

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -24,6 +24,5 @@ params {
     input                       = 'https://raw.githubusercontent.com/nf-core/test-datasets/mag/samplesheets/samplesheet.hybrid_host_rm.csv'
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
-    busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                        = false
+    skip_busco                  = true
 }

--- a/lib/WorkflowMag.groovy
+++ b/lib/WorkflowMag.groovy
@@ -104,7 +104,7 @@ class WorkflowMag {
         }
 
         if (params.skip_busco && params.gtdb) {
-            log.warn "--skip_busco and --gtdb are specififed! GTDB-tk will be omitted! Because GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
+            log.warn "--skip_busco and --gtdb are specified! GTDB-tk will be omitted because GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
         }
 
         // Check if CAT parameters are valid

--- a/lib/WorkflowMag.groovy
+++ b/lib/WorkflowMag.groovy
@@ -104,8 +104,7 @@ class WorkflowMag {
         }
 
         if (params.skip_busco && params.gtdb) {
-            log.error "Invalid combination of parameters --skip_busco and --gtdb are specififed! GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
-            System.exit(1)
+            log.warn "--skip_busco and --gtdb are specififed! GTDB-tk will be omitted! Because GTDB-tk bin classification requires bin filtering based on BUSCO QC results to avoid GTDB-tk errors."
         }
 
         // Check if CAT parameters are valid

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ params {
     cat_db                     = null
     cat_db_generate            = false
     save_cat_db                = false
-    gtdb                       = "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
+    gtdb                       = "https://data.ace.uq.edu.au/public/gtdb/data/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
     gtdbtk_min_completeness    = 50.0
     gtdbtk_max_contamination   = 10.0
     gtdbtk_min_perc_aa         = 10

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -183,9 +183,10 @@ if (!params.keep_lambda) {
         .set { ch_nanolyse_db }
 }
 
-if (params.gtdb) {
+gtdb = params.skip_busco ? false : params.gtdb
+if (gtdb) {
     Channel
-        .value(file( "${params.gtdb}" ))
+        .value(file( gtdb ))
         .set { ch_gtdb }
 } else {
     ch_gtdb = Channel.empty()
@@ -549,7 +550,7 @@ workflow MAG {
          * GTDB-tk: taxonomic classifications using GTDB reference
          */
         ch_gtdbtk_summary = Channel.empty()
-        if ( params.gtdb ){
+        if ( gtdb ){
             GTDBTK (
                 METABAT2_BINNING.out.bins,
                 ch_busco_summary,
@@ -559,7 +560,7 @@ workflow MAG {
             ch_gtdbtk_summary = GTDBTK.out.summary
         }
 
-        if (!params.skip_busco || !params.skip_quast || params.gtdb){
+        if (!params.skip_busco || !params.skip_quast || gtdb){
             BIN_SUMMARY (
                 METABAT2_BINNING.out.depths_summary,
                 ch_busco_summary.ifEmpty([]),

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -186,7 +186,7 @@ if (!params.keep_lambda) {
 gtdb = params.skip_busco ? false : params.gtdb
 if (gtdb) {
     Channel
-        .value(file( gtdb ))
+        .value(file( "${gtdb}" ))
         .set { ch_gtdb }
 } else {
     ch_gtdb = Channel.empty()


### PR DESCRIPTION
Closes https://github.com/nf-core/mag/issues/232
Currently the gtdb database `"https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"` is not accessible, the mirror `"https://data.ace.uq.edu.au/public/gtdb/data/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"` works however.
I changed the default from `data.gtdb.ecogenomic.org` to `data.ace.uq.edu.au` now.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
