### PR TITLE
Fix caching of binning input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#290](https://github.com/nf-core/mag/pull/290) - Fix caching of binning input
+
 ### `Dependencies`
 
 | Tool     | Previous version | New version |

--- a/subworkflows/local/binning_preparation.nf
+++ b/subworkflows/local/binning_preparation.nf
@@ -42,7 +42,7 @@ workflow BINNING_PREPARATION {
     // group mappings for one assembly
     ch_grouped_mappings = BOWTIE2_ASSEMBLY_ALIGN.out.mappings
         .groupTuple(by: 0)
-        .map { meta, assembly, bams, bais -> [ meta, assembly[0], bams, bais ] }     // multiple symlinks to the same assembly -> use first
+        .map { meta, assembly, bams, bais -> [ meta, assembly.sort()[0], bams, bais ] }     // multiple symlinks to the same assembly -> use first of sorted list
 
     emit:
     bowtie2_assembly_multiqc = BOWTIE2_ASSEMBLY_ALIGN.out.log.map { assembly_meta, reads_meta, log -> if (assembly_meta.id == reads_meta.id) {return [ log ]} }


### PR DESCRIPTION
Solves https://github.com/nf-core/mag/issues/280. When the mappings are grouped for one assembly as preparation for the binning step, different symlinks to the same assembly are given and the first of the list was used. This led to different files as input for the binning causing caching problems, although the underlying assembly is the same. Fixed by sorting the list first. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
