### PR TITLE
Change var names

### DIFF
--- a/subworkflows/local/binning.nf
+++ b/subworkflows/local/binning.nf
@@ -57,26 +57,26 @@ workflow BINNING {
 
     // combine depths back with assemblies
     ch_metabat2_input = assemblies
-        .map { meta, contigs, reads, indicies ->
+        .map { meta, assembly, bams, bais ->
             def meta_new = meta.clone()
             meta_new['binner'] = 'MetaBAT2'
 
-            [ meta_new, contigs, reads, indicies ]
+            [ meta_new, assembly, bams, bais ]
         }
         .join( ch_metabat_depths, by: 0 )
-        .map { meta, contigs, reads, indicies, depths ->
-            [ meta, contigs, depths ]
+        .map { meta, assembly, bams, bais, depths ->
+            [ meta, assembly, depths ]
         }
 
     // conver metabat2 depth files to maxbin2
     if ( !params.skip_maxbin2 ) {
         CONVERT_DEPTHS ( ch_metabat2_input )
         CONVERT_DEPTHS.out.output
-            .map { meta, contigs, reads, depth ->
+            .map { meta, assembly, reads, depth ->
                     def meta_new = meta.clone()
                     meta_new['binner'] = 'MaxBin2'
 
-                [ meta_new, contigs, reads, depth ]
+                [ meta_new, assembly, reads, depth ]
             }
             .set { ch_maxbin2_input }
     }


### PR DESCRIPTION
Hi,

I stumbled over the variable names when looking at the binning part again. The first ["reads"](https://github.com/nf-core/mag/blob/51fce169596842f849e9cd722aa4f5fdd4ff4d5a/subworkflows/local/binning.nf#L60) is referring to BAM files , in contrast to the ["reads"](https://github.com/nf-core/mag/blob/51fce169596842f849e9cd722aa4f5fdd4ff4d5a/subworkflows/local/binning.nf#L75) below (FastQ?) if I understand it correctly? Maybe we can adjust the naming, also to keep it consistently to the names used to create [the `ch_summarizedepth_input` channel](https://github.com/nf-core/mag/blob/51fce169596842f849e9cd722aa4f5fdd4ff4d5a/subworkflows/local/binning.nf#L40)?


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
