### PR TITLE
Fix BUSCO_PLOT output naming

### DIFF
--- a/modules/local/busco_plot.nf
+++ b/modules/local/busco_plot.nf
@@ -1,5 +1,5 @@
 process BUSCO_PLOT {
-    tag "${meta.assembler}-${meta.id}"
+    tag "${meta.assembler}-${meta.binner}-${meta.id}"
 
     conda (params.enable_conda ? "bioconda::busco=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -10,8 +10,8 @@ process BUSCO_PLOT {
     tuple val(meta), path(summaries)
 
     output:
-    path("${meta.assembler}-${meta.id}.*.busco_figure.png") , optional:true, emit: png
-    path("${meta.assembler}-${meta.id}.*.busco_figure.R")   , optional:true, emit: rscript
+    path("${meta.assembler}-${meta.binner}-${meta.id}.*.busco_figure.png") , optional:true, emit: png
+    path("${meta.assembler}-${meta.binner}-${meta.id}.*.busco_figure.R")   , optional:true, emit: rscript
     path "versions.yml"                                                    , emit: versions
 
     script:

--- a/subworkflows/local/busco_qc.nf
+++ b/subworkflows/local/busco_qc.nf
@@ -37,7 +37,7 @@ workflow BUSCO_QC {
         ch_downloads = BUSCO.out.busco_downloads.groupTuple().map{lin,downloads -> downloads[0]}.toSortedList().flatten()
         BUSCO_SAVE_DOWNLOAD ( ch_downloads )
     }
-    // group by assembler and sample name for plotting
+    // group by assembler, binner and sample name for plotting
     // note: failed bins and bins with no domain, i.e. with viral lineages selected, will not be represented in these plots
     ch_results_busco_plot = BUSCO.out.summary_specific.groupTuple(by: 0)
     if (!params.busco_reference){


### PR DESCRIPTION
Fix naming of BUSCO_PLOT output files (optional, so no error occurred).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
