### PR TITLE
Code cleanup: replace .set{} with `=` everywhere 

### DIFF
--- a/subworkflows/local/ancient_dna.nf
+++ b/subworkflows/local/ancient_dna.nf
@@ -13,8 +13,7 @@ workflow ANCIENT_DNA_ASSEMLY_VALIDATION {
         PYDAMAGE_ANALYZE(input.map {item -> [item[0], item[2], item[3]]})
         PYDAMAGE_FILTER(PYDAMAGE_ANALYZE.out.csv)
         FAIDX(input.map { item -> [ item[0], item[1] ] })
-        input.join(FAIDX.out.fai)
-            .set { freebayes_input } // [val(meta), path(contigs), path(bam), path(bam_index), path(fai)]
+        freebayes_input = input.join(FAIDX.out.fai) // [val(meta), path(contigs), path(bam), path(bam_index), path(fai)]
         FREEBAYES (freebayes_input.map { item -> [item[0], item[2], item[3], [], [], []] },
                     freebayes_input.map { item -> item[1] },
                     freebayes_input.map { item -> item[4] },

--- a/subworkflows/local/binning.nf
+++ b/subworkflows/local/binning.nf
@@ -44,14 +44,13 @@ workflow BINNING {
 
     METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS ( ch_summarizedepth_input )
 
-    METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth
+    ch_metabat_depths = METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth
         .map { meta, depths ->
             def meta_new = meta.clone()
             meta_new['binner'] = 'MetaBAT2'
 
             [ meta_new, depths ]
         }
-        .set { ch_metabat_depths }
 
     ch_versions = ch_versions.mix(METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.versions)
 
@@ -71,14 +70,13 @@ workflow BINNING {
     // conver metabat2 depth files to maxbin2
     if ( !params.skip_maxbin2 ) {
         CONVERT_DEPTHS ( ch_metabat2_input )
-        CONVERT_DEPTHS.out.output
+        ch_maxbin2_input = CONVERT_DEPTHS.out.output
             .map { meta, assembly, reads, depth ->
                     def meta_new = meta.clone()
                     meta_new['binner'] = 'MaxBin2'
 
                 [ meta_new, assembly, reads, depth ]
             }
-            .set { ch_maxbin2_input }
     }
 
     // run binning
@@ -106,31 +104,28 @@ workflow BINNING {
     // decompress main bins (and large unbinned contigs from SPLIT_FASTA) for
     // MAG_DEPTHS, first have to separate and re-group due to limitation of
     // GUNZIP module
-    METABAT2_METABAT2.out.fasta.transpose().set { ch_metabat2_results_transposed }
-    MAXBIN2.out.binned_fastas.transpose().set { ch_maxbin2_results_transposed }
+    ch_metabat2_results_transposed = METABAT2_METABAT2.out.fasta.transpose()
+    ch_maxbin2_results_transposed = MAXBIN2.out.binned_fastas.transpose()
 
-    SPLIT_FASTA.out.unbinned.transpose().set { ch_split_fasta_results_transposed }
+    ch_split_fasta_results_transposed = SPLIT_FASTA.out.unbinned.transpose()
     ch_versions = ch_versions.mix(SPLIT_FASTA.out.versions)
 
     // mix all bins together
-    ch_metabat2_results_transposed
+    ch_final_bins_for_gunzip = ch_metabat2_results_transposed
         .mix( ch_maxbin2_results_transposed )
-        .set { ch_final_bins_for_gunzip }
 
     GUNZIP_BINS ( ch_final_bins_for_gunzip )
-    GUNZIP_BINS.out.gunzip
-        .set{ ch_binning_results_gunzipped }
+    ch_binning_results_gunzipped = GUNZIP_BINS.out.gunzip
     ch_versions = ch_versions.mix(GUNZIP_BINS.out.versions)
 
     GUNZIP_UNBINS ( ch_split_fasta_results_transposed )
-    GUNZIP_UNBINS.out.gunzip
-        .set{ ch_splitfasta_results_gunzipped }
+    ch_splitfasta_results_gunzipped = GUNZIP_UNBINS.out.gunzip
     ch_versions = ch_versions.mix(GUNZIP_UNBINS.out.versions)
 
     // Compute bin depths for different samples (according to `binning_map_mode`)
     // Have to remove binner meta for grouping to mix back with original depth
     // files, as required for MAG_DEPTHS
-    ch_binning_results_gunzipped
+    ch_depth_input = ch_binning_results_gunzipped
         .mix(ch_splitfasta_results_gunzipped )
         .map { meta, results ->
             def meta_new = meta.clone()
@@ -138,7 +133,6 @@ workflow BINNING {
         }
         .groupTuple (by: 0 )
         .join( METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth, by: 0 )
-        .set { ch_depth_input }
 
     MAG_DEPTHS ( ch_depth_input )
     ch_versions = ch_versions.mix(MAG_DEPTHS.out.versions)
@@ -158,13 +152,11 @@ workflow BINNING {
     ch_versions = ch_versions.mix(MAG_DEPTHS_SUMMARY.out.versions)
 
     // Group final binned contigs per sample for final output
-    ch_binning_results_gunzipped
+    ch_binning_results_gunzipped_final = ch_binning_results_gunzipped
         .groupTuple(by: 0)
-        .set{ ch_binning_results_gunzipped_final }
 
-    METABAT2_METABAT2.out.fasta.mix(MAXBIN2.out.binned_fastas)
+    ch_binning_results_gzipped_final = METABAT2_METABAT2.out.fasta.mix(MAXBIN2.out.binned_fastas)
         .groupTuple(by: 0)
-        .set{ ch_binning_results_gzipped_final }
 
     SPLIT_FASTA.out.unbinned
 

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -19,7 +19,7 @@ workflow GTDBTK {
     // Filter bins: classify only medium & high quality MAGs
     // Collect completness and contamination metrics from busco summary
     def bin_metrics = [:]
-    busco_summary
+    ch_busco_metrics = busco_summary
         .splitCsv(header: true, sep: '\t')
         .map { row ->
                     def completeness  = -1
@@ -36,10 +36,9 @@ workflow GTDBTK {
                     if (duplicated != '') contamination = Double.parseDouble(duplicated)
                     [row.'GenomeBin', completeness, contamination]
         }
-        .set { ch_busco_metrics }
 
     // Filter bins based on collected metrics: completeness, contamination
-    bins
+    ch_filtered_bins = bins
         .transpose()
         .map { meta, bin -> [bin.getName(), bin, meta]}
         .join(ch_busco_metrics, failOnDuplicate: true, failOnMismatch: true)
@@ -50,7 +49,6 @@ workflow GTDBTK {
             discarded: (it[2] == -1 || it[2] < params.gtdbtk_min_completeness || it[3] == -1 || it[3] > params.gtdbtk_max_contamination)
                 return [it[0], it[1]]
         }
-        .set { ch_filtered_bins }
 
     GTDBTK_DB_PREPARATION ( gtdb )
     GTDBTK_CLASSIFY (

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -10,7 +10,7 @@ workflow INPUT_CHECK {
     main:
     if(hasExtension(params.input, "csv")){
         // extracts read files from samplesheet CSV and distribute into channels
-        Channel
+        ch_input_rows = Channel
             .from(file(params.input))
             .splitCsv(header: true)
             .map { row ->
@@ -30,9 +30,9 @@ workflow INPUT_CHECK {
                         exit 1, "Input samplesheet contains row with ${row.size()} column(s). Expects 5."
                     }
                 }
-            .set { ch_input_rows }
+
         // separate short and long reads
-        ch_input_rows
+        ch_raw_short_reads = ch_input_rows
             .map { id, group, sr1, sr2, lr ->
                         def meta = [:]
                         meta.id           = id
@@ -43,8 +43,7 @@ workflow INPUT_CHECK {
                         else
                             return [ meta, [ sr1, sr2 ] ]
                 }
-            .set { ch_raw_short_reads }
-        ch_input_rows
+        ch_raw_long_reads = ch_input_rows
             .map { id, group, sr1, sr2, lr ->
                         if (lr) {
                             def meta = [:]
@@ -53,9 +52,8 @@ workflow INPUT_CHECK {
                             return [ meta, lr ]
                         }
                 }
-            .set { ch_raw_long_reads }
     } else {
-        Channel
+        ch_raw_short_reads = Channel
             .fromFilePairs(params.input, size: params.single_end ? 1 : 2)
             .ifEmpty { exit 1, "Cannot find any reads matching: ${params.input}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --single_end on the command line." }
             .map { row ->
@@ -65,7 +63,6 @@ workflow INPUT_CHECK {
                         meta.single_end   = params.single_end
                         return [ meta, row[1] ]
                 }
-            .set { ch_raw_short_reads }
         ch_input_rows = Channel.empty()
         ch_raw_long_reads = Channel.empty()
     }

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -117,78 +117,66 @@ include { CUSTOM_DUMPSOFTWAREVERSIONS            } from '../modules/nf-core/modu
 
 if ( params.host_genome ) {
     host_fasta = params.genomes[params.host_genome].fasta ?: false
-    Channel
+    ch_host_fasta = Channel
         .value(file( "${host_fasta}" ))
-        .set { ch_host_fasta }
-
     host_bowtie2index = params.genomes[params.host_genome].bowtie2 ?: false
-    Channel
+    ch_host_bowtie2index = Channel
         .value(file( "${host_bowtie2index}/*" ))
-        .set { ch_host_bowtie2index }
 } else if ( params.host_fasta ) {
-    Channel
+    ch_host_fasta = Channel
         .value(file( "${params.host_fasta}" ))
-        .set { ch_host_fasta }
 } else {
     ch_host_fasta = Channel.empty()
 }
 
 if(params.busco_reference){
-    Channel
+    ch_busco_db_file = Channel
         .value(file( "${params.busco_reference}" ))
-        .set { ch_busco_db_file }
 } else {
     ch_busco_db_file = Channel.empty()
 }
 if (params.busco_download_path) {
-    Channel
+    ch_busco_download_folder = Channel
         .value(file( "${params.busco_download_path}" ))
-        .set { ch_busco_download_folder }
 } else {
     ch_busco_download_folder = Channel.empty()
 }
 
 if(params.centrifuge_db){
-    Channel
+    ch_centrifuge_db_file = Channel
         .value(file( "${params.centrifuge_db}" ))
-        .set { ch_centrifuge_db_file }
 } else {
     ch_centrifuge_db_file = Channel.empty()
 }
 
 if(params.kraken2_db){
-    Channel
+    ch_kraken2_db_file = Channel
         .value(file( "${params.kraken2_db}" ))
-        .set { ch_kraken2_db_file }
 } else {
     ch_kraken2_db_file = Channel.empty()
 }
 
 if(params.cat_db){
-    Channel
+    ch_cat_db_file = Channel
         .value(file( "${params.cat_db}" ))
-        .set { ch_cat_db_file }
 } else {
     ch_cat_db_file = Channel.empty()
 }
 
 if(!params.keep_phix) {
-    Channel
+    ch_phix_db_file = Channel
         .value(file( "${params.phix_reference}" ))
-        .set { ch_phix_db_file }
 }
 
 if (!params.keep_lambda) {
-    Channel
+    ch_nanolyse_db = Channel
         .value(file( "${params.lambda_reference}" ))
-        .set { ch_nanolyse_db }
 }
 
 gtdb = params.skip_busco ? false : params.gtdb
 if (gtdb) {
-    Channel
+    ch_gtdb = Channel
         .value(file( "${gtdb}" ))
-        .set { ch_gtdb }
 } else {
     ch_gtdb = Channel.empty()
 }
@@ -325,15 +313,13 @@ workflow MAG {
     }
 
     // join long and short reads by sample name
-    ch_short_reads
+    ch_short_reads_tmp = ch_short_reads
         .map { meta, sr -> [ meta.id, meta, sr ] }
-        .set {ch_short_reads_tmp}
 
-    ch_long_reads
+    ch_short_and_long_reads = ch_long_reads
         .map { meta, lr -> [ meta.id, meta, lr ] }
         .join(ch_short_reads_tmp, by: 0)
         .map { id, meta_lr, lr, meta_sr, sr -> [ meta_lr, lr, sr[0], sr[1] ] }  // should not occur for single-end, since SPAdes (hybrid) does not support single-end
-        .set{ ch_short_and_long_reads }
 
     FILTLONG (
         ch_short_and_long_reads
@@ -368,13 +354,12 @@ workflow MAG {
 
     if (( params.centrifuge_db || params.kraken2_db ) && !params.skip_krona){
         KRONA_DB ()
-        CENTRIFUGE.out.results_for_krona.mix(KRAKEN2.out.results_for_krona)
+        ch_tax_classifications = CENTRIFUGE.out.results_for_krona.mix(KRAKEN2.out.results_for_krona)
             . map { classifier, meta, report ->
                 def meta_new = meta.clone()
                 meta_new.classifier  = classifier
                 [ meta_new, report ]
             }
-            .set { ch_tax_classifications }
         KRONA (
             ch_tax_classifications,
             KRONA_DB.out.db.collect()
@@ -392,7 +377,7 @@ workflow MAG {
     if (params.coassemble_group) {
         // short reads
         // group and set group as new id
-        ch_short_reads
+        ch_short_reads_grouped = ch_short_reads
             .map { meta, reads -> [ meta.group, meta, reads ] }
             .groupTuple(by: 0)
             .map { group, metas, reads ->
@@ -403,10 +388,9 @@ workflow MAG {
                     if (!params.single_end) [ meta, reads.collect { it[0] }, reads.collect { it[1] } ]
                     else [ meta, reads.collect { it }, [] ]
             }
-            .set { ch_short_reads_grouped }
         // long reads
         // group and set group as new id
-        ch_long_reads
+        ch_long_reads_grouped = ch_long_reads
             .map { meta, reads -> [ meta.group, meta, reads ] }
             .groupTuple(by: 0)
             .map { group, metas, reads ->
@@ -415,25 +399,22 @@ workflow MAG {
                 meta.group       = group
                 [ meta, reads.collect { it } ]
             }
-            .set { ch_long_reads_grouped }
     } else {
-        ch_short_reads
+        ch_short_reads_grouped = ch_short_reads
             .map { meta, reads ->
                     if (!params.single_end){ [ meta, [reads[0]], [reads[1]] ] }
                     else [ meta, [reads], [] ] }
-            .set { ch_short_reads_grouped }
     }
 
     ch_assemblies = Channel.empty()
     if (!params.skip_megahit){
         MEGAHIT ( ch_short_reads_grouped )
-        MEGAHIT.out.assembly
+        ch_megahit_assemblies = MEGAHIT.out.assembly
             .map { meta, assembly ->
                 def meta_new = meta.clone()
                 meta_new.assembler  = "MEGAHIT"
                 [ meta_new, assembly ]
             }
-            .set { ch_megahit_assemblies }
         ch_assemblies = ch_assemblies.mix(ch_megahit_assemblies)
         ch_versions = ch_versions.mix(MEGAHIT.out.versions.first())
     }
@@ -457,41 +438,36 @@ workflow MAG {
         }
     } else {
         ch_short_reads_spades = ch_short_reads
-        ch_long_reads
+        ch_long_reads_spades = ch_long_reads
             .map { meta, reads -> [ meta, [reads] ] }
-            .set { ch_long_reads_spades }
     }
 
     if (!params.single_end && !params.skip_spades){
         SPADES ( ch_short_reads_spades )
-        SPADES.out.assembly
+        ch_spades_assemblies = SPADES.out.assembly
             .map { meta, assembly ->
                 def meta_new = meta.clone()
                 meta_new.assembler  = "SPAdes"
                 [ meta_new, assembly ]
             }
-            .set { ch_spades_assemblies }
         ch_assemblies = ch_assemblies.mix(ch_spades_assemblies)
         ch_versions = ch_versions.mix(SPADES.out.versions.first())
     }
 
     if (!params.single_end && !params.skip_spadeshybrid){
-        ch_short_reads_spades
+        ch_short_reads_spades_tmp = ch_short_reads_spades
             .map { meta, reads -> [ meta.id, meta, reads ] }
-            .set {ch_short_reads_spades_tmp}
-        ch_long_reads_spades
+        ch_reads_spadeshybrid = ch_long_reads_spades
             .map { meta, reads -> [ meta.id, meta, reads ] }
             .combine(ch_short_reads_spades_tmp, by: 0)
             .map { id, meta_long, long_reads, meta_short, short_reads -> [ meta_short, long_reads, short_reads ] }
-            .set { ch_reads_spadeshybrid }
         SPADESHYBRID ( ch_reads_spadeshybrid )
-        SPADESHYBRID.out.assembly
+        ch_spadeshybrid_assemblies = SPADESHYBRID.out.assembly
             .map { meta, assembly ->
                 def meta_new = meta.clone()
                 meta_new.assembler  = "SPAdesHybrid"
                 [ meta_new, assembly ]
             }
-            .set { ch_spadeshybrid_assemblies }
         ch_assemblies = ch_assemblies.mix(ch_spadeshybrid_assemblies)
         ch_versions = ch_versions.mix(SPADESHYBRID.out.versions.first())
     }
@@ -651,13 +627,12 @@ workflow MAG {
         /*
          * Prokka: Genome annotation
          */
-        BINNING.out.bins.mix(BINNING.out.unbinned).transpose()
+        ch_bins_for_prokka = BINNING.out.bins.mix(BINNING.out.unbinned).transpose()
             .map { meta, bin ->
                 def meta_new = meta.clone()
                 meta_new.id  = bin.getBaseName()
                 [ meta_new, bin ]
             }
-            .set { ch_bins_for_prokka }
 
         if (!params.skip_prokka){
             PROKKA (


### PR DESCRIPTION
for consistency and readability

Slack poll reference: https://nfcore.slack.com/archives/CE56GDKN0/p1649076826657989

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
