### PR TITLE
Fix: separate bin depths heatmaps for binners

### DIFF
--- a/bin/get_mag_depths_summary.py
+++ b/bin/get_mag_depths_summary.py
@@ -7,8 +7,8 @@ import pandas as pd
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--depths'       , required=True, nargs="+", metavar='FILE'                             , help="TSV file for each assembly containing bin depths for samples: bin, sample1, ....")
-    parser.add_argument('-o', "--out"          , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depths for all assemblies and all samples.")
+    parser.add_argument('-d', '--depths'       , required=True, nargs="+", metavar='FILE'                             , help="TSV file for each assembly and binning method containing bin depths for samples: bin, sample1, ....")
+    parser.add_argument('-o', "--out"          , required=True           , metavar='FILE', type=argparse.FileType('w'), help="Output file containing depths for all assemblies, binning methods and all samples.")
     return parser.parse_args(args)
 
 def main(args=None):

--- a/bin/plot_mag_depths.py
+++ b/bin/plot_mag_depths.py
@@ -11,7 +11,7 @@ from scipy import stats
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--bin_depths'   , required=True, metavar='FILE'          , help="Bin depths file in TSV format (for one assembly): bin, sample1_depth, sample2_depth, ....")
+    parser.add_argument('-d', '--bin_depths'   , required=True, metavar='FILE'          , help="Bin depths file in TSV format (for one assembly and binning method): bin, sample1_depth, sample2_depth, ....")
     parser.add_argument('-g', '--groups'       , required=True, metavar='FILE'          , help="File in TSV format containing group information for samples: sample, group")
     parser.add_argument('-o', "--out"          , required=True, metavar='FILE', type=str, help="Output file.")
     return parser.parse_args(args)

--- a/docs/output.md
+++ b/docs/output.md
@@ -336,7 +336,7 @@ For each genome bin the median sequencing depth is computed based on the corresp
 
 - `GenomeBinning/`
   - `bin_depths_summary.tsv`: Summary of bin sequencing depths for all samples. Depths are available for samples mapped against the corresponding assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
-  - `[assembler]-[sample/group]-binDepths.heatmap.png`: Clustered heatmap showing bin abundances of the assembly across samples. Bin depths are transformed to centered log-ratios and bins as well as samples are clustered by Euclidean distance. Again, sample depths are available according to the mapping strategy specified with `--binning_map_mode`.
+  - `[assembler]-[binner]-[sample/group]-binDepths.heatmap.png`: Clustered heatmap showing bin abundances of the assembly across samples. Bin depths are transformed to centered log-ratios and bins as well as samples are clustered by Euclidean distance. Again, sample depths are available according to the mapping strategy specified with `--binning_map_mode`.
 
 </details>
 

--- a/modules/local/mag_depths.nf
+++ b/modules/local/mag_depths.nf
@@ -11,15 +11,15 @@ process MAG_DEPTHS {
     tuple val(meta), path(bins), path(contig_depths)
 
     output:
-    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.tsv"), emit: depths
-    path "versions.yml"                                                , emit: versions
+    tuple val(meta), path("${meta.assembler}-*-${meta.id}-binDepths.tsv"), emit: depths
+    path "versions.yml"                                                  , emit: versions
 
     script:
     """
     get_mag_depths.py --bins ${bins} \\
                     --depths ${contig_depths} \\
-                    --assembly_name "${meta.assembler}-${meta.id}" \\
-                    --out "${meta.assembler}-${meta.id}-binDepths.tsv"
+                    --assembler ${meta.assembler} \\
+                    --id ${meta.id}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/mag_depths_plot.nf
+++ b/modules/local/mag_depths_plot.nf
@@ -1,5 +1,5 @@
 process MAG_DEPTHS_PLOT {
-    tag "${meta.assembler}-${meta.id}"
+    tag "${meta.assembler}-${meta.binner}-${meta.id}"
 
     conda (params.enable_conda ? "conda-forge::python=3.9 conda-forge::pandas=1.3.0 anaconda::seaborn=0.11.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -11,14 +11,14 @@ process MAG_DEPTHS_PLOT {
     path(sample_groups)
 
     output:
-    tuple val(meta), path("${meta.assembler}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
-    path "versions.yml"                                                        , emit: versions
+    tuple val(meta), path("${meta.assembler}-${meta.binner}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
+    path "versions.yml"                                                                       , emit: versions
 
     script:
     """
     plot_mag_depths.py --bin_depths ${depths} \
                     --groups ${sample_groups} \
-                    --out "${meta.assembler}-${meta.id}-binDepths.heatmap.png"
+                    --out "${meta.assembler}-${meta.binner}-${meta.id}-binDepths.heatmap.png"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/binning.nf
+++ b/subworkflows/local/binning.nf
@@ -129,7 +129,8 @@ workflow BINNING {
         .mix(ch_splitfasta_results_gunzipped )
         .map { meta, results ->
             def meta_new = meta.clone()
-            [ [ 'id': meta_new['id'], 'group': meta_new['group'], 'single_end': meta_new['single_end'], 'assembler': meta_new['assembler'] ], results ]
+            meta_new.remove('binner')
+            [ meta_new, results ]
         }
         .groupTuple (by: 0 )
         .join( METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth, by: 0 )


### PR DESCRIPTION
Separated intermediate bin depth files for different binning methods to allow separate plotting of depth heatmaps. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
