### PR TITLE
Fix use of undefined channel when skipping binners

### DIFF
--- a/subworkflows/local/binning.nf
+++ b/subworkflows/local/binning.nf
@@ -79,14 +79,22 @@ workflow BINNING {
             }
     }
 
+    // main bins for decompressing for MAG_DEPTHS
+    ch_final_bins_for_gunzip = Channel.empty()
+    // final gzipped bins
+    ch_binning_results_gzipped_final = Channel.empty()
     // run binning
     if ( !params.skip_metabat2 ) {
         METABAT2_METABAT2 ( ch_metabat2_input )
+        // before decompressing first have to separate and re-group due to limitation of GUNZIP module
+        ch_final_bins_for_gunzip = ch_final_bins_for_gunzip.mix( METABAT2_METABAT2.out.fasta.transpose() )
+        ch_binning_results_gzipped_final = ch_binning_results_gzipped_final.mix( METABAT2_METABAT2.out.fasta )
         ch_versions = ch_versions.mix(METABAT2_METABAT2.out.versions)
     }
-
     if ( !params.skip_maxbin2 ) {
         MAXBIN2 ( ch_maxbin2_input )
+        ch_final_bins_for_gunzip = ch_final_bins_for_gunzip.mix( MAXBIN2.out.binned_fastas.transpose() )
+        ch_binning_results_gzipped_final = ch_binning_results_gzipped_final.mix( MAXBIN2.out.binned_fastas )
         ch_versions = ch_versions.mix(MAXBIN2.out.versions)
     }
 
@@ -100,19 +108,10 @@ workflow BINNING {
     }
 
     SPLIT_FASTA ( ch_input_splitfasta )
-
-    // decompress main bins (and large unbinned contigs from SPLIT_FASTA) for
-    // MAG_DEPTHS, first have to separate and re-group due to limitation of
-    // GUNZIP module
-    ch_metabat2_results_transposed = METABAT2_METABAT2.out.fasta.transpose()
-    ch_maxbin2_results_transposed = MAXBIN2.out.binned_fastas.transpose()
-
+    // large unbinned contigs from SPLIT_FASTA for decompressing for MAG_DEPTHS,
+    // first have to separate and re-group due to limitation of GUNZIP module
     ch_split_fasta_results_transposed = SPLIT_FASTA.out.unbinned.transpose()
     ch_versions = ch_versions.mix(SPLIT_FASTA.out.versions)
-
-    // mix all bins together
-    ch_final_bins_for_gunzip = ch_metabat2_results_transposed
-        .mix( ch_maxbin2_results_transposed )
 
     GUNZIP_BINS ( ch_final_bins_for_gunzip )
     ch_binning_results_gunzipped = GUNZIP_BINS.out.gunzip
@@ -159,11 +158,8 @@ workflow BINNING {
     ch_versions = ch_versions.mix(MAG_DEPTHS_SUMMARY.out.versions)
 
     // Group final binned contigs per sample for final output
-    ch_binning_results_gunzipped_final = ch_binning_results_gunzipped
-        .groupTuple(by: 0)
-
-    ch_binning_results_gzipped_final = METABAT2_METABAT2.out.fasta.mix(MAXBIN2.out.binned_fastas)
-        .groupTuple(by: 0)
+    ch_binning_results_gunzipped_final = ch_binning_results_gunzipped.groupTuple(by: 0)
+    ch_binning_results_gzipped_final   = ch_binning_results_gzipped_final.groupTuple(by: 0)
 
     SPLIT_FASTA.out.unbinned
 


### PR DESCRIPTION
Fix use of undefined channel (`METABAT2_METABAT2.out`, `MAXBIN2.out`) in case of `--skip_metabat2` or `--skip_maxbin2` and restructured code.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
