### PR TITLE
Fix: adjust MaxBin2 extension to avoid GTDB-Tk error

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -407,11 +407,6 @@ process {
     withName: MAXBIN2 {
         publishDir = [
             [
-                path: { "${params.outdir}/GenomeBinning/MaxBin2/bins/" },
-                mode: params.publish_dir_mode,
-                pattern: '*.*[0-9].fasta.gz'
-            ],
-            [
                 path: { "${params.outdir}/GenomeBinning/MaxBin2/discarded" },
                 mode: params.publish_dir_mode,
                 pattern: '*.tooshort.gz'
@@ -421,6 +416,16 @@ process {
         // if no gene found, will crash so allow ignore so rest of pipeline
         // completes but without MaxBin2 results
         errorStrategy = { task.exitStatus in [ 1, 255 ] ? 'ignore' : 'retry' }
+    }
+
+    withName: ADJUST_MAXBIN2_EXT {
+        publishDir = [
+            [
+                path: { "${params.outdir}/GenomeBinning/MaxBin2/bins/" },
+                mode: params.publish_dir_mode,
+                pattern: '*.fa.gz'
+            ],
+        ]
     }
 
     withName: SPLIT_FASTA {

--- a/docs/output.md
+++ b/docs/output.md
@@ -305,7 +305,7 @@ Files in these two folders contain all contigs of an assembly.
 <summary>Output files</summary>
 
 - `GenomeBinning/MaxBin2/`
-  - `bins/[assembler]-[binner]-[sample/group].*.fasta.gz`: Genome bins retrieved from input assembly
+  - `bins/[assembler]-[binner]-[sample/group].*.fa.gz`: Genome bins retrieved from input assembly
   - `unbinned/[assembler]-[binner]-[sample/group].noclass.[1-9]*.fa.gz`: Contigs that were not binned with other contigs but considered interesting. By default, these are at least 1 Mbp (`--min_length_unbinned_contigs`) in length and at most the 100 longest contigs (`--max_unbinned_contigs`) are reported.
 
 </details>

--- a/docs/output.md
+++ b/docs/output.md
@@ -305,7 +305,7 @@ Files in these two folders contain all contigs of an assembly.
 <summary>Output files</summary>
 
 - `GenomeBinning/MaxBin2/`
-  - `bins/[assembler]-[binner]-[sample/group].*.fa.gz`: Genome bins retrieved from input assembly
+  - `bins/[assembler]-[binner]-[sample/group].*.fasta.gz`: Genome bins retrieved from input assembly
   - `unbinned/[assembler]-[binner]-[sample/group].noclass.[1-9]*.fa.gz`: Contigs that were not binned with other contigs but considered interesting. By default, these are at least 1 Mbp (`--min_length_unbinned_contigs`) in length and at most the 100 longest contigs (`--max_unbinned_contigs`) are reported.
 
 </details>
@@ -316,7 +316,7 @@ All the files and contigs in these folders will be assessed by QUAST and BUSCO.
 <summary>Output files</summary>
 
 - `GenomeBinning/MaxBin2/discarded/`
-  - `*.tooshort.fa.gz`: Too short contigs that are filtered by MaxBin2
+  - `*.tooshort.gz`: Too short contigs that are filtered by MaxBin2
 - `GenomeBinning/MaxBin2/unbinned/discarded/`
   - `*.noclass.pooled.fa.gz`: Pooled unbinned contigs equal or above `--min_contig_size`, by default 1500 bp.
   - `*.noclass.remaining.fa.gz`: Remaining unbinned contigs below `--min_contig_size`, by default 1500 bp, but not in any other file.

--- a/modules/local/adjust_maxbin2_ext.nf
+++ b/modules/local/adjust_maxbin2_ext.nf
@@ -1,0 +1,28 @@
+process ADJUST_MAXBIN2_EXT {
+    tag "${meta.assembler}-${meta.id}"
+    label 'process_low'
+
+    // Using container from multiqc since it'll be included anyway
+    conda (params.enable_conda ? "bioconda::multiqc=1.12" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(bins)
+
+    output:
+    tuple val(meta), path("*.fa.gz"), emit: renamed_bins
+
+    script:
+    """
+    if [ -n "${bins}" ]
+    then
+        for file in ${bins}; do
+            [[ \${file} =~ (.*).fasta.gz ]];
+            bin="\${BASH_REMATCH[1]}"
+            mv \${file} \${bin}.fa.gz
+        done
+    fi
+    """
+}

--- a/subworkflows/local/binning.nf
+++ b/subworkflows/local/binning.nf
@@ -13,6 +13,7 @@ include { GUNZIP as GUNZIP_BINS                 } from '../../modules/nf-core/mo
 include { GUNZIP as GUNZIP_UNBINS               } from '../../modules/nf-core/modules/gunzip/main'
 
 include { CONVERT_DEPTHS                        } from '../../modules/local/convert_depths'
+include { ADJUST_MAXBIN2_EXT                    } from '../../modules/local/adjust_maxbin2_ext'
 include { SPLIT_FASTA                           } from '../../modules/local/split_fasta'
 include { MAG_DEPTHS                            } from '../../modules/local/mag_depths'               addParams( options: params.mag_depths_options         )
 include { MAG_DEPTHS_PLOT                       } from '../../modules/local/mag_depths_plot'          addParams( options: params.mag_depths_plot_options    )
@@ -93,8 +94,9 @@ workflow BINNING {
     }
     if ( !params.skip_maxbin2 ) {
         MAXBIN2 ( ch_maxbin2_input )
-        ch_final_bins_for_gunzip = ch_final_bins_for_gunzip.mix( MAXBIN2.out.binned_fastas.transpose() )
-        ch_binning_results_gzipped_final = ch_binning_results_gzipped_final.mix( MAXBIN2.out.binned_fastas )
+        ADJUST_MAXBIN2_EXT ( MAXBIN2.out.binned_fastas )
+        ch_final_bins_for_gunzip = ch_final_bins_for_gunzip.mix( ADJUST_MAXBIN2_EXT.out.renamed_bins.transpose() )
+        ch_binning_results_gzipped_final = ch_binning_results_gzipped_final.mix( ADJUST_MAXBIN2_EXT.out.renamed_bins )
         ch_versions = ch_versions.mix(MAXBIN2.out.versions)
     }
 


### PR DESCRIPTION
Adjust MaxBin2 output bins extension from "fasta" to "fa" to avoid GTDB-Tk and CAT errors due to wrong expected genome file extension. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
