### PR TITLE
Fix parsing of GTDB-Tk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#290](https://github.com/nf-core/mag/pull/290) - Fix caching of binning input
+- [#307](https://github.com/nf-core/mag/pull/307) - Fix retrieval of GTDB-Tk version (note about newer version caused error in `CUSTOM_DUMPSOFTWAREVERSIONS`)
 
 ### `Dependencies`
 

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -47,7 +47,7 @@ process GTDBTK_CLASSIFY {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gtdbtk: \$(gtdbtk --version | sed "s/gtdbtk: version //; s/ Copyright.*//")
+        gtdbtk: \$(gtdbtk --version | head -n 1 | sed "s/gtdbtk: version //; s/ Copyright.*//")
     END_VERSIONS
     """
 }

--- a/modules/local/gtdbtk_classify.nf
+++ b/modules/local/gtdbtk_classify.nf
@@ -47,7 +47,7 @@ process GTDBTK_CLASSIFY {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gtdbtk: \$(gtdbtk --version | head -n 1 | sed "s/gtdbtk: version //; s/ Copyright.*//")
+        gtdbtk: \$(gtdbtk --version | sed -n 1p | sed "s/gtdbtk: version //; s/ Copyright.*//")
     END_VERSIONS
     """
 }


### PR DESCRIPTION
Fix parsing of GTDB-Tk version: only process first line, i.e. avoid new line containing "Note: There is a newer version of GTDB-Tk available: v2.1.0". Caused error in `CUSTOM_DUMPSOFTWAREVERSIONS`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
