### PR TITLE
Fix SPLIT_FASTA output

### DIFF
--- a/modules/local/split_fasta.nf
+++ b/modules/local/split_fasta.nf
@@ -12,10 +12,10 @@ process SPLIT_FASTA {
     tuple val(meta), path(unbinned)
 
     output:
-    tuple val(meta), path("*.[0-9]*.fa.gz")     , optional:true, emit: unbinned
-    tuple val(meta), path("*.pooled.fa.gz")     , optional:true, emit: pooled
-    tuple val(meta), path("*.remaining.fa.gz")  , optional:true, emit: remaining
-    path "versions.yml"                                 , emit: versions
+    tuple val(meta), path("${meta.assembler}-${meta.binner}-${meta.id}.*.[1-9]*.fa.gz")   , optional:true, emit: unbinned
+    tuple val(meta), path("${meta.assembler}-${meta.binner}-${meta.id}.*.pooled.fa.gz")   , optional:true, emit: pooled
+    tuple val(meta), path("${meta.assembler}-${meta.binner}-${meta.id}.*.remaining.fa.gz"), optional:true, emit: remaining
+    path "versions.yml"                                                                   , emit: versions
 
     script:
     """


### PR DESCRIPTION
When adding MAxBin2, the glob pattern used for filtering the output files was relaxed (from `"*unbinned.[0-9]*.fa.gz"` to `"*.[0-9]*.fa.gz"` for the `unbinned` output), which causes errors when sample names contain numbers. I changed this and made this as specific as possible. When adding a new binner, I guess the output file naming would anyway have to follow the same naming scheme.

And the `unbinned` output files are named enumerated within `split_fasta.py` with `[1-9]*` not `[0-9]*`, right?

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
