### PR TITLE
Fix publishing of BUSCO downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#290](https://github.com/nf-core/mag/pull/290) - Fix caching of binning input
 - [#305](https://github.com/nf-core/mag/pull/305) - Add missing Bowtie2 version for process `BOWTIE2_PHIX_REMOVAL_ALIGN` to `software_versions.yml`
 - [#307](https://github.com/nf-core/mag/pull/307) - Fix retrieval of GTDB-Tk version (note about newer version caused error in `CUSTOM_DUMPSOFTWAREVERSIONS`)
+- [#309](https://github.com/nf-core/mag/pull/309) - Fix publishing of BUSCO `busco_downloads/` folder, i.e. publish only when `--save_busco_reference` is specified
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -225,11 +225,11 @@ process {
         ]
     }
 
-    withName: 'BUSCO|BUSCO_PLOT' {
+    withName: 'BUSCO' {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/BUSCO" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            pattern: "*.{log,err,faa.gz,fna.gz,gff,txt}"
         ]
     }
 
@@ -238,6 +238,14 @@ process {
             path: { "${params.outdir}/GenomeBinning/QC/BUSCO" },
             mode: params.publish_dir_mode,
             overwrite: false,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'BUSCO_PLOT' {
+        publishDir = [
+            path: { "${params.outdir}/GenomeBinning/QC/BUSCO" },
+            mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }


### PR DESCRIPTION
Publish BUSCO `busco_downloads/` folder only via dedicated `BUSCO_SAVE_DOWNLOADS` process, not from actual `BUSCO` process to avoid overwriting in results directory from multiple processes and to prevent warning.

Changed to use `pattern: "..."`to specify what exactly should be published.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
