### PR TITLE
Activate institutional configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#263](https://github.com/nf-core/mag/pull/263) - Add MaxBin2 as second contig binning tool
 - [#285](https://github.com/nf-core/mag/pull/285) - Add AdapterRemoval2 as an alternative read trimmer
 - [#291](https://github.com/nf-core/mag/pull/291) - Add DAS Tool for bin refinement
+- [#319](https://github.com/nf-core/mag/pull/319) - Activate pipeline-specific institutional nf-core/configs
 
 ### `Changed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -155,11 +155,11 @@ try {
 
 // Load nf-core/mag custom profiles from different institutions.
 // Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
-// try {
-//   includeConfig "${params.custom_config_base}/pipeline/mag.config"
-// } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/mag profiles: ${params.custom_config_base}/pipeline/mag.config")
-// }
+try {
+  includeConfig "${params.custom_config_base}/pipeline/mag.config"
+} catch (Exception e) {
+  System.err.println("WARNING: Could not load nf-core/config/mag profiles: ${params.custom_config_base}/pipeline/mag.config")
+}
 
 
 profiles {


### PR DESCRIPTION
## PR checklist

This activates pipeline-specific institutional nf-core/configs, to allow customisation of pipeline resources on a pipeline-tuned per-cluster basis.

An EVA specific config for mag has been created on nf-core/configs https://github.com/nf-core/configs/pull/380

To close https://github.com/nf-core/mag/issues/318

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
