### PR TITLE
Add sample name to PyDamage output directory

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -368,7 +368,7 @@ process {
 
     withName: PYDAMAGE_ANALYZE {
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }
@@ -376,7 +376,7 @@ process {
     withName: PYDAMAGE_FILTER {
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }


### PR DESCRIPTION
Up to now, all samples were published in the same result directory, and overwritten for each new sample as:
- `results/assembly/results/Ancient_DNA/pydamage/analyze/pydamage_results.csv`
- `results/assembly/results/Ancient_DNA/pydamage/filter/pydamage_results/pydamage_filtered_results.csv`
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
