### PR TITLE
Bowtie2 local to global alignment for ancient DNA mode for BOWTIE2_ASSEMBLY_ALIGN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#345](https://github.com/nf-core/mag/pull/345) Bowtie2 mode changed to global alignment for ancient DNA mode (`--very-sensitive` mode) to prevent soft clipping at the end of reads when running in local mode.
+
 ### `Dependencies`
 
 ## v2.2.1 - 2022/08/25

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -195,7 +195,7 @@ process {
     }
 
     withName: BOWTIE2_ASSEMBLY_ALIGN {
-        ext.args = params.bowtie2_mode ? params.bowtie2_mode : params.ancient_dna ? '--very-sensitive-local -N 1' : ''
+        ext.args = params.bowtie2_mode ? params.bowtie2_mode : params.ancient_dna ? '--very-sensitive -N 1' : ''
         publishDir = [
             path: { "${params.outdir}/Assembly/${assembly_meta.assembler}/QC/${assembly_meta.id}" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
After some testing, I realized that the local alignemnt mode of bowtie2 in the ancient mode is posing problem as it soft-trim the ends of the reads, thus preventing the damage detection.
Going to global alignment mode solves this issue.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
