### PR TITLE
Update error codes for retrying SPAdes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#345](https://github.com/nf-core/mag/pull/345) - Bowtie2 mode changed to global alignment for ancient DNA mode (`--very-sensitive` mode) to prevent soft clipping at the end of reads when running in local mode.
 - [#349](https://github.com/nf-core/mag/pull/349) - Add a warning that pipeline will reset minimum contig size to 1500 specifically MetaBAT2 process, if a user supplies below this threshold.
 - [#352](https://github.com/nf-core/mag/pull/352) - Escape the case in the BUSCO module that BUSCO can just detect a root lineage but is not able to find any marker genes
-- [#???](???) - Include error code 21 for retrying with higher memory for SPAdes and hybridSPAdes
+- [#355](https://github.com/nf-core/mag/pull/355) - Include error code 21 for retrying with higher memory for SPAdes and hybridSPAdes
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#345](https://github.com/nf-core/mag/pull/345) - Bowtie2 mode changed to global alignment for ancient DNA mode (`--very-sensitive` mode) to prevent soft clipping at the end of reads when running in local mode.
 - [#349](https://github.com/nf-core/mag/pull/349) - Add a warning that pipeline will reset minimum contig size to 1500 specifically MetaBAT2 process, if a user supplies below this threshold.
 - [#352](https://github.com/nf-core/mag/pull/352) - Escape the case in the BUSCO module that BUSCO can just detect a root lineage but is not able to find any marker genes
+- [#???](???) - Include error code 21 for retrying with higher memory for SPAdes and hybridSPAdes
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -135,14 +135,14 @@ process {
         cpus          = { check_spades_cpus (10, task.attempt) }
         memory        = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
         time          = { check_max (24.h  * (2**(task.attempt-1)), 'time'   ) }
-        errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in [143,137,21,1] ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     withName: SPADESHYBRID {
         cpus          = { check_spadeshybrid_cpus (10, task.attempt) }
         memory        = { check_max (64.GB * (2**(task.attempt-1)), 'memory' ) }
         time          = { check_max (24.h  * (2**(task.attempt-1)), 'time'   ) }
-        errorStrategy = { task.exitStatus in [143,137,1] ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in [143,137,21,1] ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     //returns exit code 247 when running out of memory


### PR DESCRIPTION
Spades can also raise error 21 if it fails due to lack of memory. Currently, this is not caught in ErrorStrategy, so it won't automatically retry with more memory. I've added error 21 to the error code list so that it will be included

Relevant error code information:
```
Counting (kmer_data.cpp : 349) The reads contain too many k-mers to fit into available memory. You need approx. 68.1699GB of free RAM to assemble your dataset

  == Error ==  system call for: "['/usr/local/bin/spades-hammer', 'spades/corrected/configs/config.info']" finished abnormally, OS return value: 21
```

<!--
# nf-core/mag pull request

Many thanks for contributing to nf-core/mag!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
