### PR TITLE
Fix ugly warn introduce in Nextflow 22.10

### DIFF
--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -74,7 +74,7 @@ include { KRAKEN2_DB_PREPARATION                              } from '../modules
 include { KRAKEN2                                             } from '../modules/local/kraken2'
 include { KRONA_DB                                            } from '../modules/local/krona_db'
 include { KRONA                                               } from '../modules/local/krona'
-include { POOL_SINGLE_READS as POOL_SINGLE_SHORT_READS        } from '../modules/local/pool_single_reads'
+include { POOL_SINGLE_READS as POOL_SHORT_SINGLE_READS        } from '../modules/local/pool_single_reads'
 include { POOL_PAIRED_READS                                   } from '../modules/local/pool_paired_reads'
 include { POOL_SINGLE_READS as POOL_LONG_READS                } from '../modules/local/pool_single_reads'
 include { MEGAHIT                                             } from '../modules/local/megahit'
@@ -433,8 +433,8 @@ workflow MAG {
         // short reads
         if (!params.single_end && (!params.skip_spades || !params.skip_spadeshybrid)){
             if (params.single_end){
-                POOL_SINGLE_SHORT_READS ( ch_short_reads_grouped )
-                ch_short_reads_spades = POOL_SINGLE_SHORT_READS.out.reads
+                POOL_SHORT_SINGLE_READS ( ch_short_reads_grouped )
+                ch_short_reads_spades = POOL_SHORT_SINGLE_READS.out.reads
             } else {
                 POOL_PAIRED_READS ( ch_short_reads_grouped )
                 ch_short_reads_spades = POOL_PAIRED_READS.out.reads

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -74,7 +74,7 @@ include { KRAKEN2_DB_PREPARATION                              } from '../modules
 include { KRAKEN2                                             } from '../modules/local/kraken2'
 include { KRONA_DB                                            } from '../modules/local/krona_db'
 include { KRONA                                               } from '../modules/local/krona'
-include { POOL_SINGLE_READS                                   } from '../modules/local/pool_single_reads'
+include { POOL_SINGLE_READS as POOL_SINGLE_SHORT_READS        } from '../modules/local/pool_single_reads'
 include { POOL_PAIRED_READS                                   } from '../modules/local/pool_paired_reads'
 include { POOL_SINGLE_READS as POOL_LONG_READS                } from '../modules/local/pool_single_reads'
 include { MEGAHIT                                             } from '../modules/local/megahit'
@@ -433,8 +433,8 @@ workflow MAG {
         // short reads
         if (!params.single_end && (!params.skip_spades || !params.skip_spadeshybrid)){
             if (params.single_end){
-                POOL_SINGLE_READS ( ch_short_reads_grouped )
-                ch_short_reads_spades = POOL_SINGLE_READS.out.reads
+                POOL_SINGLE_SHORT_READS ( ch_short_reads_grouped )
+                ch_short_reads_spades = POOL_SINGLE_SHORT_READS.out.reads
             } else {
                 POOL_PAIRED_READS ( ch_short_reads_grouped )
                 ch_short_reads_spades = POOL_PAIRED_READS.out.reads


### PR DESCRIPTION
Since 22.10, if you include a module multiple times, but only rename one (via `as`), you get an ugly warning message such as:

```
 A process with name 'POOL_LONG_READS' is defined more than once in module script: /home/jfellows/Documents/git/nf-core/mag/./workflows/mag.nf -- Make sure to not define the same function as process
```

This is not good to expose to the user, as they may worry. This PR gives both `pool_single_read` processes distinct `as` names (rather than onl renaming the longread one), to stop the `WARN` message.

Note: too small to be worth a changelog ;)