### PR TITLE
Deactivate CONCOCT in most tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#353](https://github.com/nf-core/mag/pull/353) - Added the busco_clean parameter to optionally clean each BUSCO directory after a successful
-- [#361](https://github.com/nf-core/mag/pull/361) - Added the skip_clipping parameter to skip read preprocessing with fastp or adapterremoval. Running the pipeline with skip_clipping, keep_phix and without specifying a host genome or fasta file skips the FASTQC_TRIMMED process.
+- [#361](https://github.com/nf-core/mag/pull/361) - Added the skip_clipping parameter to skip read preprocessing with fastp or adapterremoval. Running the pipeline with skip_clipping, keep_phix and without specifying a host genome or fasta file skips the FASTQC_TRIMMED process
 - [#365](https://github.com/nf-core/mag/pull/365) - Adds CONCOCT as an additional (optional) binning tool
-- [#366](https://github.com/nf-core/mag/pull/366) - Added CAT_SUMMARISE process and cat_official_taxonomy parameter.
+- [#366](https://github.com/nf-core/mag/pull/366) - Added CAT_SUMMARISE process and cat_official_taxonomy parameter
 
 ### `Changed`
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -29,4 +29,5 @@ params {
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     busco_clean                   = true
     gtdb                          = false
+    skip_concoct                  = true
 }

--- a/conf/test_adapterremoval.config
+++ b/conf/test_adapterremoval.config
@@ -29,4 +29,5 @@ params {
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                        = false
     clip_tool                   = 'adapterremoval'
+    skip_concoct                = true
 }

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -35,4 +35,5 @@ params {
     bcftools_view_variant_quality = 0
     refine_bins_dastool           = true
     refine_bins_dastool_threshold = 0
+    skip_concoct                  = true
 }

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -20,20 +20,22 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                         = 'https://raw.githubusercontent.com/nf-core/test-datasets/mag/samplesheets/samplesheet.csv'
-    centrifuge_db                 = "https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_cf.tar.gz"
-    kraken2_db                    = "https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_kraken.tgz"
-    skip_krona                    = true
-    min_length_unbinned_contigs   = 1
-    max_unbinned_contigs          = 2
-    busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                          = false
-    ancient_dna                   = true
-    binning_map_mode              = 'own'
-    skip_spades                   = false
-    skip_spadeshybrid             = true
-    bcftools_view_variant_quality = 0
-    refine_bins_dastool           = true
-    refine_bins_dastool_threshold = 0
-    skip_concoct                  = true
+    input                                = 'https://raw.githubusercontent.com/nf-core/test-datasets/mag/samplesheets/samplesheet.csv'
+    centrifuge_db                        = "https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_cf.tar.gz"
+    kraken2_db                           = "https://raw.githubusercontent.com/nf-core/test-datasets/mag/test_data/minigut_kraken.tgz"
+    skip_krona                           = true
+    min_length_unbinned_contigs          = 1
+    max_unbinned_contigs                 = 2
+    busco_reference                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
+    gtdb                                 = false
+    ancient_dna                          = true
+    binning_map_mode                     = 'own'
+    skip_spades                          = false
+    skip_spadeshybrid                    = true
+    bcftools_view_high_variant_quality   = 0
+    bcftools_view_medium_variant_quality = 0
+    bcftools_view_minimal_allelesupport  = 3
+    refine_bins_dastool                  = true
+    refine_bins_dastool_threshold        = 0
+    skip_concoct                         = true
 }

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -26,4 +26,5 @@ params {
     max_unbinned_contigs        = 2
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                        = false
+    skip_concoct                = true
 }

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -25,4 +25,5 @@ params {
     max_unbinned_contigs        = 2
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                        = false
+    skip_concoct                = true
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -25,4 +25,5 @@ params {
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
     skip_busco                  = true
+    skip_concoct                = true
 }

--- a/conf/test_no_clipping.config
+++ b/conf/test_no_clipping.config
@@ -30,4 +30,5 @@ params {
     max_unbinned_contigs          = 2
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                          = false
+    skip_concoct                  = true
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -465,7 +465,7 @@
                 },
                 "gtdbtk_min_completeness": {
                     "type": "number",
-                    "default": 50,
+                    "default": 50.0,
                     "description": "Min. bin completeness (in %) required to apply GTDB-tk classification.",
                     "help_text": "Completeness assessed with BUSCO analysis (100% - %Missing). Must be greater than 0 (min. 0.01) to avoid GTDB-tk errors. If too low, GTDB-tk classification results can be impaired due to not enough marker genes!",
                     "minimum": 0.01,
@@ -473,7 +473,7 @@
                 },
                 "gtdbtk_max_contamination": {
                     "type": "number",
-                    "default": 10,
+                    "default": 10.0,
                     "description": "Max. bin contamination (in %) allowed to apply GTDB-tk classification.",
                     "help_text": "Contamination approximated based on BUSCO analysis (%Complete and duplicated). If too high, GTDB-tk classification results can be impaired due to contamination!",
                     "minimum": 0,
@@ -481,7 +481,7 @@
                 },
                 "gtdbtk_min_perc_aa": {
                     "type": "number",
-                    "default": 10,
+                    "default": 10.0,
                     "description": "Min. fraction of AA (in %) in the MSA for bins to be kept.",
                     "minimum": 0,
                     "maximum": 100
@@ -495,7 +495,7 @@
                 },
                 "gtdbtk_pplacer_cpus": {
                     "type": "number",
-                    "default": 1,
+                    "default": 1.0,
                     "description": "Number of CPUs used for the by GTDB-Tk run tool pplacer.",
                     "help_text": "A low number of CPUs helps to reduce the memory required/reported by GTDB-Tk. See also the [GTDB-Tk documentation](https://ecogenomics.github.io/GTDBTk/faq.html#gtdb-tk-reaches-the-memory-limit-pplacer-crashes)."
                 },
@@ -651,7 +651,7 @@
                     "type": "number",
                     "default": 0.5,
                     "description": "Specify single-copy gene score threshold for bin refinement.",
-                    "help_text": "Score threshold for single-copy gene selection algorithm to keep selecting bins, with a value ranging from 0-1.\n\nFor description of scoring algorithm, see: Sieber, Christian M. K., et al. 2018. Nature Microbiology 3 (7): 836–43. https://doi.org/10.1038/s41564-018-0171-1.\n\n> Modifies DAS Tool parameter --score_threshold\n"
+                    "help_text": "Score threshold for single-copy gene selection algorithm to keep selecting bins, with a value ranging from 0-1.\n\nFor description of scoring algorithm, see: Sieber, Christian M. K., et al. 2018. Nature Microbiology 3 (7): 836\u201343. https://doi.org/10.1038/s41564-018-0171-1.\n\n> Modifies DAS Tool parameter --score_threshold\n"
                 },
                 "postbinning_input": {
                     "type": "string",

--- a/subworkflows/local/binning_refinement.nf
+++ b/subworkflows/local/binning_refinement.nf
@@ -64,9 +64,10 @@ workflow BINNING_REFINEMENT {
                                             [ meta_new, fastatocontig2bin ]
                                     }
                                     .groupTuple(by: 0)
-                                    .dump(tag: "fastatocontigbin_for_dastool")
 
-    ch_input_for_dastool = ch_contigs_for_dastool.join(ch_fastatocontig2bin_for_dastool, by: 0, failOnMismatch: true)
+    // Note: do not `failOnMismatch` on join here, in some cases e.g. MAXBIN2 will fail if no bins, so cannot join!
+    // Only want to join for DAS_Tool on bins that 'exist'
+    ch_input_for_dastool = ch_contigs_for_dastool.dump(tag: "contigs_for_dastool").join(ch_fastatocontig2bin_for_dastool.dump(tag: "fastatocontig2bin_for_dastool"), by: 0)
 
     ch_versions = ch_versions.mix(DASTOOL_FASTATOCONTIG2BIN_METABAT2.out.versions.first())
     ch_versions = ch_versions.mix(DASTOOL_FASTATOCONTIG2BIN_MAXBIN2.out.versions.first())

--- a/subworkflows/local/binning_refinement.nf
+++ b/subworkflows/local/binning_refinement.nf
@@ -67,7 +67,7 @@ workflow BINNING_REFINEMENT {
 
     // Note: do not `failOnMismatch` on join here, in some cases e.g. MAXBIN2 will fail if no bins, so cannot join!
     // Only want to join for DAS_Tool on bins that 'exist'
-    ch_input_for_dastool = ch_contigs_for_dastool.dump(tag: "contigs_for_dastool").join(ch_fastatocontig2bin_for_dastool.dump(tag: "fastatocontig2bin_for_dastool"), by: 0)
+    ch_input_for_dastool = ch_contigs_for_dastool.join(ch_fastatocontig2bin_for_dastool, by: 0)
 
     ch_versions = ch_versions.mix(DASTOOL_FASTATOCONTIG2BIN_METABAT2.out.versions.first())
     ch_versions = ch_versions.mix(DASTOOL_FASTATOCONTIG2BIN_MAXBIN2.out.versions.first())


### PR DESCRIPTION
Except bin refinement, where it is anyway most relevent.

This will allow most tests not take ages to complete. We could also further separate this so we do an extremely minimal run and only run CONCOCT (no other downstream steps), if these tests remain too length.