### PR TITLE
Fix typo and remove ugly warn

### DIFF
--- a/subworkflows/local/ancient_dna.nf
+++ b/subworkflows/local/ancient_dna.nf
@@ -6,7 +6,7 @@ include { PYDAMAGE_ANALYZE }                                                    
 include { PYDAMAGE_FILTER }                                                              from '../../modules/nf-core/pydamage/filter/main'
 include { SAMTOOLS_FAIDX as FAIDX}                                                       from '../../modules/nf-core/samtools/faidx/main'
 
-workflow ANCIENT_DNA_ASSEMLY_VALIDATION {
+workflow ANCIENT_DNA_ASSEMBLY_VALIDATION {
     take:
         input //channel: [val(meta), path(contigs), path(bam), path(bam_index)]
     main:

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -98,7 +98,7 @@ include { BINNING_REFINEMENT  } from '../subworkflows/local/binning_refinement'
 include { BUSCO_QC            } from '../subworkflows/local/busco_qc'
 include { CHECKM_QC           } from '../subworkflows/local/checkm_qc'
 include { GTDBTK              } from '../subworkflows/local/gtdbtk'
-include { ANCIENT_DNA_ASSEMLY_VALIDATION } from '../subworkflows/local/ancient_dna'
+include { ANCIENT_DNA_ASSEMBLY_VALIDATION } from '../subworkflows/local/ancient_dna'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -537,8 +537,8 @@ workflow MAG {
     */
 
     if (params.ancient_dna){
-        ANCIENT_DNA_ASSEMLY_VALIDATION(BINNING_PREPARATION.out.grouped_mappings)
-        ch_versions = ch_versions.mix(ANCIENT_DNA_ASSEMLY_VALIDATION.out.versions.first())
+        ANCIENT_DNA_ASSEMBLY_VALIDATION(BINNING_PREPARATION.out.grouped_mappings)
+        ch_versions = ch_versions.mix(ANCIENT_DNA_ASSEMBLY_VALIDATION.out.versions.first())
     }
 
     /*
@@ -552,7 +552,7 @@ workflow MAG {
         if (params.ancient_dna) {
             BINNING (
                 BINNING_PREPARATION.out.grouped_mappings
-                    .join(ANCIENT_DNA_ASSEMLY_VALIDATION.out.contigs_recalled)
+                    .join(ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled)
                     .map{ it -> [ it[0], it[4], it[2], it[3] ] }, // [meta, contigs_recalled, bam, bais]
                 ch_short_reads
             )
@@ -675,7 +675,7 @@ workflow MAG {
             CAT.out.tax_classification.collect()
         )
         ch_versions = ch_versions.mix(CAT.out.versions.first())
-        ch_versions = ch_versions.mix(CAT_SUMMARY.out.versions.first())
+        ch_versions = ch_versions.mix(CAT_SUMMARY.out.versions)
 
         /*
          * GTDB-tk: taxonomic classifications using GTDB reference


### PR DESCRIPTION
This is a little clean up PR to fix a couple of minor  things I noticed, namely:

- Typo in the aDNA subworkflow names
- An 'ugly' warn that came from using `.first()` on a one-time executed process's versions

    ```
    WARN: The operator `first` is useless when applied to a value channel which returns a single value by definition
    ```

   This WARN should now be gone :)
   
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
