### PR TITLE
Version bump for 2.3 release and remove remaining TODOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## dev
+## v2.3.0 - [XXXX/XX/XX]
 
 ### `Added`
 
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#361](https://github.com/nf-core/mag/pull/361) - Added the skip_clipping parameter to skip read preprocessing with fastp or adapterremoval. Running the pipeline with skip_clipping, keep_phix and without specifying a host genome or fasta file skips the FASTQC_TRIMMED process (by @prototaxites)
 - [#365](https://github.com/nf-core/mag/pull/365) - Added CONCOCT as an additional (optional) binning tool (by @jfy133)
 - [#366](https://github.com/nf-core/mag/pull/366) - Added CAT_SUMMARISE process and cat_official_taxonomy parameter (by @prototaxites)
-- [#372](https://github.com/nf-core/mag/pull/372) - Allow CAT_DB to take an extracted database as well as a tar.gz file.
+- [#372](https://github.com/nf-core/mag/pull/372) - Allow CAT_DB to take an extracted database as well as a tar.gz file (by @prototaxites).
 - [#380](https://github.com/nf-core/mag/pull/380) - Added support for saving processed reads (clipped, host removed etc.) to results directory (by @jfy133)
 
 ### `Changed`

--- a/assets/methods_description_template.yml
+++ b/assets/methods_description_template.yml
@@ -7,13 +7,14 @@ plot_type: "html"
 ## You inject any metadata in the Nextflow '${workflow}' object
 data: |
   <h4>Methods</h4>
-  <p>Data was processed using nf-core/mag v${workflow.manifest.version} ${doi_text} of the nf-core collection of workflows (<a href="https://doi.org/10.1038/s41587-020-0439-x">Ewels <em>et al.</em>, 2020</a>).</p>
+  <p>Data was processed using nf-core/mag v${workflow.manifest.version} (${doi_text}; <a href="https://doi.org/10.1093/nargab/lqac007">Krakau <em>et al.</em>, 2022</a>) of the nf-core collection of workflows (<a href="https://doi.org/10.1038/s41587-020-0439-x">Ewels <em>et al.</em>, 2020</a>).</p>
   <p>The pipeline was executed with Nextflow v${workflow.nextflow.version} (<a href="https://doi.org/10.1038/nbt.3820">Di Tommaso <em>et al.</em>, 2017</a>) with the following command:</p>
   <pre><code>${workflow.commandLine}</code></pre>
   <h4>References</h4>
   <ul>
     <li>Di Tommaso, P., Chatzou, M., Floden, E. W., Barja, P. P., Palumbo, E., & Notredame, C. (2017). Nextflow enables reproducible computational workflows. Nature Biotechnology, 35(4), 316-319. <a href="https://doi.org/10.1038/nbt.3820">https://doi.org/10.1038/nbt.3820</a></li>
     <li>Ewels, P. A., Peltzer, A., Fillinger, S., Patel, H., Alneberg, J., Wilm, A., Garcia, M. U., Di Tommaso, P., & Nahnsen, S. (2020). The nf-core framework for community-curated bioinformatics pipelines. Nature Biotechnology, 38(3), 276-278. <a href="https://doi.org/10.1038/s41587-020-0439-x">https://doi.org/10.1038/s41587-020-0439-x</a></li>
+    <li>Krakau, S., Straub, D., Gourlé, H., Gabernet, G., & Nahnsen, S. (2022). nf-core/mag: a best-practice pipeline for metagenome hybrid assembly and binning. NAR Genomics and Bioinformatics, 4(1). <a href="https://doi.org/10.1093/nargab/lqac007">https://doi.org/10.1038/s41587-020-0439-x</a></li>
   </ul>
   <div class="alert alert-info">
     <h5>Notes:</h5>

--- a/nextflow.config
+++ b/nextflow.config
@@ -304,7 +304,7 @@ manifest {
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '2.3.0dev'
+    version = '2.3.0'
     doi             = '10.1093/nargab/lqac007'
 }
 

--- a/subworkflows/local/checkm_qc.nf
+++ b/subworkflows/local/checkm_qc.nf
@@ -9,7 +9,7 @@ include { COMBINE_TSV as COMBINE_CHECKM_TSV } from '../../modules/local/combine_
 workflow CHECKM_QC {
     take:
     bins       // channel: [ val(meta), path(bin) ]
-    checkm_db  // TODO do proper input checks in mag.nf! Add to checkParams etc.,
+    checkm_db
 
     main:
     ch_versions = Channel.empty()
@@ -34,8 +34,6 @@ workflow CHECKM_QC {
 
     CHECKM_QA ( ch_checkmqa_input, [] )
     ch_versions = ch_versions.mix(CHECKM_QA.out.versions)
-
-    // TODO Check output files published correctly
 
     COMBINE_CHECKM_TSV ( CHECKM_QA.out.output.map{it[1]}.collect() )
 


### PR DESCRIPTION
Note as you use a local MultiQC module, the methods description won't be displayed even if I've added the info. (see comment on mag.nf for ref)

This can be used in the future once we replace the local MultiQC module with the 'official' one.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
