### PR TITLE
Fix busco_clean parameter being enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix duplicated Zenodo badge in README (by @jfy133)
 - Fix CheckM database always downloading, regardless if CheckM is selected (by @jfy133)
+- Fix bug with busco_clean parameter, where it is always activated (by @prototaxites)
 
 ### `Dependencies`
 

--- a/conf/test_binrefinement.config
+++ b/conf/test_binrefinement.config
@@ -31,4 +31,5 @@ params {
     refine_bins_dastool           = true
     refine_bins_dastool_threshold = 0
     postbinning_input             = 'both'
+    busco_clean                   = true
 }

--- a/modules/local/busco.nf
+++ b/modules/local/busco.nf
@@ -178,7 +178,7 @@ process BUSCO {
     fi
 
     # if needed delete temporary BUSCO files
-    if [ ${busco_clean} ]; then
+    if [ ${busco_clean} = "Y" ]; then
         find . -depth -type d -name "augustus_config" -execdir rm -rf "{}" \\;
         find . -depth -type d -name "auto_lineage" -execdir rm -rf "{}" \\;
         find . -depth -type d -name "run_*" -execdir rm -rf "{}" +


### PR DESCRIPTION
`busco_clean` was enabled by default due to an error in the script to check if it is set. 

Fixes the check, but also enables it in the binrefinement test because it fails without it due to space limitations. I expect this PR will fail this test due to this.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
