### PR TITLE
Make GTDB downloading skippable using standard parameter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#428](https://github.com/nf-core/mag/pull/428) - Update to nf-core 2.8 `TEMPLATE` (by @jfy133)
 - [#429](https://github.com/nf-core/mag/pull/429) - Replaced hardcoded CheckM database auto-download URL to a parameter (reported by @erikrikarddaniel and fixed by @jfy133)
 - [#436](https://github.com/nf-core/mag/pull/429) - `--gtdb` parameter is split into `--skip_gtdb` and `--gtdb_db` to allow finer control over GTDB database retrieval (by @jfy133)
+- [#436](https://github.com/nf-core/mag/pull/429) - `--skip_gtdb` can also support directory input of an pre-uncompressed GTDB archive (by @jfy133)
+
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#436](https://github.com/nf-core/mag/pull/429) - `--gtdb` parameter is split into `--skip_gtdb` and `--gtdb_db` to allow finer control over GTDB database retrieval (by @jfy133)
 - [#436](https://github.com/nf-core/mag/pull/429) - `--skip_gtdb` can also support directory input of an pre-uncompressed GTDB archive (by @jfy133)
 
-
 ### `Fixed`
 
 - [#400](https://github.com/nf-core/mag/pull/400) - Fix duplicated Zenodo badge in README (by @jfy133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#428](https://github.com/nf-core/mag/pull/428) - Update to nf-core 2.8 `TEMPLATE` (by @jfy133)
 - [#429](https://github.com/nf-core/mag/pull/429) - Replaced hardcoded CheckM database auto-download URL to a parameter (reported by @erikrikarddaniel and fixed by @jfy133)
+- [#436](https://github.com/nf-core/mag/pull/429) - `--gtdb` parameter is split into `--skip_gtdb` and `--gtdb_db` to allow finer control over GTDB database retrieval (by @jfy133)
 
 ### `Fixed`
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,6 +28,6 @@ params {
     max_unbinned_contigs          = 2
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     busco_clean                   = true
-    gtdb                          = false
+    skip_gtdb                     = true
     skip_concoct                  = true
 }

--- a/conf/test_adapterremoval.config
+++ b/conf/test_adapterremoval.config
@@ -27,7 +27,7 @@ params {
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                        = false
+    skip_gtdb                   = true
     clip_tool                   = 'adapterremoval'
     skip_concoct                = true
 }

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -27,7 +27,7 @@ params {
     min_length_unbinned_contigs          = 1
     max_unbinned_contigs                 = 2
     busco_reference                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                                 = false
+    skip_gtdb                            = true
     ancient_dna                          = true
     binning_map_mode                     = 'own'
     skip_spades                          = false

--- a/conf/test_bbnorm.config
+++ b/conf/test_bbnorm.config
@@ -34,7 +34,7 @@ params {
     max_unbinned_contigs          = 2
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     busco_clean                   = true
-    gtdb                          = false
+    skip_gtdb                     = true
     bbnorm                        = true
     coassemble_group              = true
 }

--- a/conf/test_binrefinement.config
+++ b/conf/test_binrefinement.config
@@ -27,7 +27,7 @@ params {
     min_length_unbinned_contigs   = 1
     max_unbinned_contigs          = 2
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                          = false
+    skip_gtdb                     = true
     refine_bins_dastool           = true
     refine_bins_dastool_threshold = 0
     postbinning_input             = 'both'

--- a/conf/test_busco_auto.config
+++ b/conf/test_busco_auto.config
@@ -24,7 +24,7 @@ params {
     skip_spades                 = true
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
-    gtdb                        = false
+    skip_gtdb                   = true
     skip_prokka                 = true
     skip_prodigal               = true
     skip_quast                  = true

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -24,7 +24,7 @@ params {
     centrifuge_db = "s3://ngi-igenomes/test-data/mag/p_compressed+h+v.tar.gz"
     kraken2_db    = "s3://ngi-igenomes/test-data/mag/minikraken_8GB_202003.tgz"
     cat_db        = "s3://ngi-igenomes/test-data/mag/CAT_prepare_20210107.tar.gz"
-    gtdb          = "s3://ngi-igenomes/test-data/mag/gtdbtk_r202_data.tar.gz"
+    gtdb_db      = "s3://ngi-igenomes/test-data/mag/gtdbtk_r202_data.tar.gz"
 
     // reproducibility options for assembly
     spades_fix_cpus       = 10

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -25,6 +25,6 @@ params {
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                        = false
+    skip_gtdb                   = true
     skip_concoct                = true
 }

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -24,6 +24,6 @@ params {
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
     busco_reference             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                        = false
+    skip_gtdb                   = true
     skip_concoct                = true
 }

--- a/conf/test_no_clipping.config
+++ b/conf/test_no_clipping.config
@@ -29,6 +29,6 @@ params {
     min_length_unbinned_contigs   = 1
     max_unbinned_contigs          = 2
     busco_reference               = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
-    gtdb                          = false
+    skip_gtdb                     = true
     skip_concoct                  = true
 }

--- a/lib/WorkflowMag.groovy
+++ b/lib/WorkflowMag.groovy
@@ -115,8 +115,8 @@ class WorkflowMag {
             Nextflow.error('Both --busco_auto_lineage_prok and --busco_reference are specified! Invalid combination, please specify either --busco_auto_lineage_prok or --busco_reference.')
         }
 
-        if (params.skip_binqc && params.gtdb) {
-            log.warn '--skip_binqc and --gtdb are specified! GTDB-tk will be omitted because GTDB-tk bin classification requires bin filtering based on BUSCO or CheckM QC results to avoid GTDB-tk errors.'
+        if (params.skip_binqc && !params.skip_gtdb) {
+            log.warn '--skip_binqc is specified! GTDB-tk will also be omitted because GTDB-tk bin classification requires bin filtering based on BUSCO or CheckM QC results to avoid GTDB-tk errors.'
         }
 
         // Check if CAT parameters are valid

--- a/modules/local/gtdbtk_db_preparation.nf
+++ b/modules/local/gtdbtk_db_preparation.nf
@@ -10,7 +10,7 @@ process GTDBTK_DB_PREPARATION {
     path(database)
 
     output:
-    tuple val("${database.toString().replace(".tar.gz", "")}"), path("database/*")
+    tuple val("${database.toString().replace(".tar.gz", "")}"), path("database/*"), emit: db
 
     script:
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,7 +76,8 @@ params {
     cat_db_generate                      = false
     cat_official_taxonomy                = false
     save_cat_db                          = false
-    gtdb                                 = "https://data.ace.uq.edu.au/public/gtdb/data/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
+    skip_gtdb                            = false
+    gtdb_db                             = "https://data.ace.uq.edu.au/public/gtdb/data/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
     gtdbtk_min_completeness              = 50.0
     gtdbtk_max_contamination             = 10.0
     gtdbtk_min_perc_aa                   = 10

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -500,7 +500,7 @@
                 "gtdb_db": {
                     "type": "string",
                     "default": "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz",
-                    "description": "GTDB database for taxonomic classification of bins with GTDB-tk.",
+                    "description": "GTDB database for taxonomic classification of bins with GTDB-tk. Can be either uncompressed directory, local .tar.gz archive, or URL",
                     "help_text": "For information which GTDB reference databases are compatible with the used GTDB-tk version see https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
                 },
                 "gtdbtk_min_completeness": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -493,7 +493,11 @@
                     "type": "boolean",
                     "description": "Only return official taxonomic ranks (Kingdom, Phylum, etc.) when running CAT."
                 },
-                "gtdb": {
+                "skip_gtdb": {
+                    "type": "boolean",
+                    "description": "Turns off GTDB classification of bins.",
+                },
+                "gtdb_db": {
                     "type": "string",
                     "default": "https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz",
                     "description": "GTDB database for taxonomic classification of bins with GTDB-tk.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -495,7 +495,7 @@
                 },
                 "skip_gtdb": {
                     "type": "boolean",
-                    "description": "Turns off GTDB classification of bins.",
+                    "description": "Turns off GTDB classification of bins."
                 },
                 "gtdb_db": {
                     "type": "string",

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -59,10 +59,16 @@ workflow GTDBTK {
                 return [it[0], it[1]]
         }
 
-    GTDBTK_DB_PREPARATION ( gtdb )
+    if ( gtdb.isDirectory ) {
+        ch_gtdb_dir = gtdb
+    } else {
+        GTDBTK_DB_PREPARATION ( gtdb )
+        ch_gtdb_dir = GTDBTK_DB_PREPARATION.out
+    }
+
     GTDBTK_CLASSIFYWF (
         ch_filtered_bins.passed.groupTuple(),
-        GTDBTK_DB_PREPARATION.out
+        ch_gtdb_dir
     )
 
     GTDBTK_SUMMARY (

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -59,7 +59,8 @@ workflow GTDBTK {
                 return [it[0], it[1]]
         }
 
-    if ( gtdb.isDirectory() ) {
+
+    if ( gtdb && gtdb.isDirectory() ) {
         // Extract a database name based on input path to ensure cardinality matching for classifywf
         ch_gtdb_dir = Channel
                         .fromPath(gtdb, checkIfExists: true)
@@ -67,9 +68,11 @@ workflow GTDBTK {
                             [ it.toString().split('/').last(), it ]
                         }
                         .collect()
-    } else {
+    } else if ( gtdb && gtdb.isFile() ) {
         GTDBTK_DB_PREPARATION ( gtdb )
         ch_gtdb_dir = GTDBTK_DB_PREPARATION.out.db
+    } else {
+        ch_gtdb_dir = []
     }
 
     GTDBTK_CLASSIFYWF (

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -194,7 +194,7 @@ if (!params.keep_lambda) {
 }
 
 if ( params.skip_binqc || params.skip_gtdb ) {
-    ch_gtdb = Channel.empty()
+    gtdb_db = Channel.empty()
 } else {
     // Don't check if exists, as can be URL
     gtdb_db = file(params.gtdb_db)

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -194,7 +194,7 @@ if (!params.keep_lambda) {
 }
 
 if ( params.skip_binqc || params.skip_gtdb ) {
-    gtdb_db = Channel.empty()
+    gtdb_db = null
 } else {
     // Don't check if exists, as can be URL
     gtdb_db = file(params.gtdb_db)

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -196,8 +196,8 @@ if (!params.keep_lambda) {
 if ( params.skip_binqc || params.skip_gtdb ) {
     ch_gtdb = Channel.empty()
 } else {
-    ch_gtdb = Channel
-                .value(file(params.gtdb_db))
+    // Don't check if exists, as can be URL
+    gtdb_db = file(params.gtdb_db)
 }
 
 /*
@@ -738,7 +738,7 @@ workflow MAG {
                 ch_input_for_postbinning_bins_unbins,
                 ch_busco_summary,
                 ch_checkm_summary,
-                ch_gtdb
+                gtdb_db,
             )
             ch_versions = ch_versions.mix(GTDBTK.out.versions.first())
             ch_gtdbtk_summary = GTDBTK.out.summary

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -194,11 +194,8 @@ if (!params.keep_lambda) {
 }
 
 if ( params.skip_binqc || params.skip_gtdb ) {
-    print("SHOULDN'T BE DOWNLOADING")
     ch_gtdb = Channel.empty()
 } else {
-    println( !params.skip_binqc || !params.skip_gtdb )
-    println("DOWNLOADING")
     ch_gtdb = Channel
                 .value(file(params.gtdb_db))
 }


### PR DESCRIPTION
To explicitly skip GTDB downloading, you would have to supply `--gtdb false`. This is not inline with other skipping parameters in the pipeline, and uses a nextflow specific method (supplying `false` to an otherwise string parameter) that may not be logical to a user.

This PR separates the 'activation' (or rather skipping) of the module from the URL,  so one can explicitly turn skip that step. This is benefitial as the GTDB file can be large and take a long time to download (78GB from a server in Australia, which can be quite far for many users).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
