### PR TITLE
Fix bug in assembly input code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#429](https://github.com/nf-core/mag/pull/429) - Replaced hardcoded CheckM database auto-download URL to a parameter (reported by @erikrikarddaniel, fix by @jfy133)
 - [#434](https://github.com/nf-core/mag/pull/434) - Fix location of samplesheet for AWS full tests (reported by @Lfulcrum, fix by @jfy133)
 - [#438](https://github.com/nf-core/mag/pull/438) - Fixed version inconsistency between conda and containers for GTDBTK_CLASSIFYWF (by @jfy133)
+- [#439](https://github.com/nf-core/mag/pull/445) - Fix bug in assembly input (by @prototaxites)
+
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#438](https://github.com/nf-core/mag/pull/438) - Fixed version inconsistency between conda and containers for GTDBTK_CLASSIFYWF (by @jfy133)
 - [#439](https://github.com/nf-core/mag/pull/445) - Fix bug in assembly input (by @prototaxites)
 
-
 ### `Dependencies`
 
 | Tool     | Previous version | New version |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,44 +72,38 @@ It is also possible to run nf-core/mag on pre-computed assemblies, by supplying 
 
 The assembly CSV file should contain the following columns:
 
-`id,assembler,fasta`
+`id,group,assembler,fasta`
 
-Where `id` is the ID of the assembly, `assembler` is the assembler used to produce the assembly (one of `MEGAHIT`, `SPAdes`, or `SPAdesHybrid`), and `fasta` is the path to the assembly fasta file.
-
-The value of the `id` column should be set depending on the desired `--binning_map_mode`. If `--binning_map_mode` is set to "own", then the values should match those in the `id` column of the `--input` CSV. If `--binning_map_mode` is set to "group", then the values should match those in the `group` column of a `--input` CSV.
-
-For the below `--input` CSV, valid options could be:
+Where `id` is the ID of the assembly, group is the assembly/binning group (see samplesheet information section for more details), `assembler` is the assembler used to produce the assembly (one of `MEGAHIT`, `SPAdes`, or `SPAdesHybrid`), and `fasta` is the path to the assembly fasta file. The exact information required for each supplied assembly depends on whether the assemblies provided are single assemblies or group-wise co-assemblies. For the following example `--input` CSV:
 
 ```bash
 sample,group,short_reads_1,short_reads_2,long_reads
-sample1,group0,data/sample1_R1.fastq.gz,data/sample1_R2.fastq.gz,data/sample1.fastq.gz
-sample2,group0,data/sample2_R1.fastq.gz,data/sample2_R2.fastq.gz,data/sample2.fastq.gz
-sample3,group1,data/sample3_R1.fastq.gz,data/sample3_R2.fastq.gz,
+sample1,0,data/sample1_R1.fastq.gz,data/sample1_R2.fastq.gz,
+sample2,0,data/sample2_R1.fastq.gz,data/sample2_R2.fastq.gz,
+sample3,1,data/sample3_R1.fastq.gz,data/sample3_R2.fastq.gz,
 ```
 
-If using `--binning_map_mode "own"`:
+If the assemblies are single assemblies, then the `id` and `group` columns should match those supplied in the `-input` read CSV files for each read set:
 
 ```bash
-id,assembler,fasta
-sample1,MEGAHIT,MEGAHIT-sample1_contigs.fa.gz
-sample1,SPAdes,SPAdes-sample1_contigs.fasta.gz
-sample2,MEGAHIT,MEGAHIT-sample2.contigs.fa.gz
-sample2,SPAdes,SPAdes-sample2_contigs.fasta.gz
-sample3,MEGAHIT,MEGAHIT-sample3.contigs.fa.gz
-sample3,SPAdes,SPAdes-sample3_contigs.fasta.gz
+id,group,assembler,fasta
+sample1,0,MEGAHIT,MEGAHIT-sample1.contigs.fa.gz
+sample1,0,SPAdes,SPAdes-sample1.fasta.gz
+sample2,0,MEGAHIT,MEGAHIT-sample2.contigs.fa.gz
+sample2,0,SPAdes,SPAdes-sample2.contigs.fasta.gz
+sample3,1,MEGAHIT,MEGAHIT-sample3.contigs.fa.gz
+sample3,1,SPAdes,SPAdes-sample3.contigs.fasta.gz
 ```
 
-If using `--binning_map_mode "group"`:
+If the assemblies are co-assemblies, the parameter `--coassemble_group` should additionally be specified. In this case, the `id` column should uniquely identify the assembly, while `group` should match those specified in the `--input` CSV file:
 
 ```bash
-id,assembler,fasta
-group0,MEGAHIT,MEGAHIT-group0_contigs.fa.gz
-group0,SPAdes,SPAdes-group0_contigs.fasta.gz
-group1,MEGAHIT,MEGAHIT-group1.contigs.fa.gz
-group1,SPAdes,SPAdes-group1_contigs.fasta.gz
+id,group,assembler,fasta
+group-0,0,MEGAHIT,MEGAHIT-group-0.contigs.fa.gz
+group-0,0,SPAdes,SPAdes-group-0.contigs.fasta.gz
+group-1,1,MEGAHIT,MEGAHIT-group-1.contigs.fa.gz
+group-1,1,SPAdes,SPAdes-group-1.contigs.fasta.gz
 ```
-
-If using `--binning_map_mode "all"`, either of the above formats is fine.
 
 When supplying pre-computed assemblies, reads **must** also be provided in the CSV input format to `--input`, and should be the reads used to build the assemblies. As long reads are only used for assembly, any long read fastq files listed in the reads CSV are ignored.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -289,6 +289,7 @@ profiles {
     test_busco_auto     { includeConfig 'conf/test_busco_auto.config'     }
     test_ancient_dna    { includeConfig 'conf/test_ancient_dna.config'    }
     test_adapterremoval { includeConfig 'conf/test_adapterremoval.config' }
+    test_binning_entry  { includeConfig 'conf/test_binning_entry.config'  }
     test_binrefinement  { includeConfig 'conf/test_binrefinement.config'  }
     test_no_clipping    { includeConfig 'conf/test_no_clipping.config'    }
     test_bbnorm         { includeConfig 'conf/test_bbnorm.config'         }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -31,7 +31,7 @@
                     "mimetype": "text/csv",
                     "format": "file-path",
                     "description": "Additional input CSV samplesheet containing information about pre-computed assemblies. When set, both read pre-processing and assembly are skipped and the pipeline begins at the binning stage.",
-                    "help_text": "If you have pre-computed assemblies from another source, it is possible to jump straight to the binning stage of the pipeline by supplying these assemblies in a CSV file. This CSV file should have three columns and the following header: `id,assembler,fasta`. Short reads must still be supplied in to `--input` in CSV format. See [usage docs](https://nf-co.re/mag/usage#input-specifications) for further details.",
+                    "help_text": "If you have pre-computed assemblies from another source, it is possible to jump straight to the binning stage of the pipeline by supplying these assemblies in a CSV file. This CSV file should have three columns and the following header: `id,group,assembler,fasta`. Short reads must still be supplied in to `--input` in CSV format. See [usage docs](https://nf-co.re/mag/usage#input-specifications) for further details.",
                     "default": null,
                     "fa_icon": "fas fa-file-csv"
                 },


### PR DESCRIPTION
Realised right after merging that there was a pretty catastrophic bug in the assembly input code 🤦‍♂️ I thought I had figured out the distinction between `meta.id` and `meta.group` for the input, but there were filename collisions for a couple of combinations of `--binning_map_mode` and `--coasssemble_group` which I had missed...

Fix separates the `id` and `group` columns for the assembly input CSV, which should ensure collisions cannot happen, and updated docs accordingly.

Also adds `test_binning_entry` to `nextflow.config`, which I had forgotten to do...

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
