### PR TITLE
Remove default: None from parameter schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#434](https://github.com/nf-core/mag/pull/434) - Fix location of samplesheet for AWS full tests (reported by @Lfulcrum, fix by @jfy133)
 - [#438](https://github.com/nf-core/mag/pull/438) - Fixed version inconsistency between conda and containers for GTDBTK_CLASSIFYWF (by @jfy133)
 - [#439](https://github.com/nf-core/mag/pull/445) - Fix bug in assembly input (by @prototaxites)
+- [#447](https://github.com/nf-core/mag/pull/447) - Remove `default: None` from parameter schema (by @drpatelh)
 
 ### `Dependencies`
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -708,7 +708,6 @@
                 },
                 "checkm_db": {
                     "type": "string",
-                    "default": "None",
                     "description": "Path to local folder containing already downloaded and uncompressed CheckM database.",
                     "help_text": "The pipeline can also download this for you if not specified, and you can save the resulting directory into your output directory by specifying `--save_checkm_data`. You should move this directory to somewhere else on your machine (and supply back to the pipeline in future runs again with `--checkm_db`."
                 },
@@ -740,7 +739,6 @@
                 },
                 "gunc_db": {
                     "type": "string",
-                    "default": "None",
                     "description": "Specify a path to a pre-downloaded GUNC dmnd database file"
                 },
                 "gunc_database_type": {


### PR DESCRIPTION
Remove default entries specified as `None` in the parameter schema.

Latest release is failing in the `community/showcase` on Tower with the following error:
https://tower.nf/orgs/community/workspaces/showcase/watch/55hIP0xdXS2O0W

```
ERROR ~ No such file or directory: s3://nf-tower-bucket/scratch/55hIP0xdXS2O0W/None
 -- Check script '.nextflow/assets/nf-core/mag/./workflows/mag.nf' at line: 155 or see 'nf-55hIP0xdXS2O0W.log' file for more details
Saving cache: .nextflow/cache/64a85618-bd4a-4773-a875-f4a47a570a5d => s3://nf-tower-bucket/scratch/55hIP0xdXS2O0W/.nextflow/cache/64a85618-bd4a-4773-a875-f4a47a570a5d
```

Testing via the branch seems to bypass this. Pipeline is still running 🤞🏽 
https://tower.nf/orgs/community/workspaces/showcase/watch/35RGI2TFVk34bb