### PR TITLE
Patch release: Fix #449 (wrong contigs from aDNA workflow going to binning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.3.1 - [2023-06-19]
+
+### `Fixed`
+
+- [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
+
 ## v2.3.0 - [2023/03/02]
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
+- [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue in ancient DNA workflow of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
 
 ## v2.3.0 - [2023/03/02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue in ancient DNA workflow of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
+- [#449](https://github.com/nf-core/mag/pull/447) - Fix results file overwriting in Ancient DNA workflow (reported by @alexhbnr, fix by @jfy133, and integrated by @maxibor in [#458](https://github.com/nf-core/mag/pull/458) )
 
 ## v2.3.0 - [2023/03/02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue in ancient DNA workflow of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
-- [#449](https://github.com/nf-core/mag/pull/447) - Fix results file overwriting in Ancient DNA workflow (reported by @alexhbnr, fix by @jfy133, and integrated by @maxibor in [#458](https://github.com/nf-core/mag/pull/458) )
+- [#451](https://github.com/nf-core/mag/pull/451) - Fix results file overwriting in Ancient DNA workflow (reported by @alexhbnr, fix by @jfy133, and integrated by @maxibor in [#458](https://github.com/nf-core/mag/pull/458) )
 
 ## v2.3.0 - [2023/03/02]
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -455,6 +455,7 @@ process {
     }
 
     withName: FREEBAYES {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-p ${params.freebayes_ploidy} -q ${params.freebayes_min_basequality} -F ${params.freebayes_minallelefreq}"
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/variant_calling/freebayes" },
@@ -464,8 +465,8 @@ process {
     }
 
     withName: BCFTOOLS_VIEW {
+        ext.prefix = { "${meta.assembler}-${meta.id}.filtered" }
         ext.args   = "-v snps,mnps -i 'QUAL>=${params.bcftools_view_high_variant_quality} || (QUAL>=${params.bcftools_view_medium_variant_quality} && FORMAT/AO>=${params.bcftools_view_minimal_allelesupport})'"
-        ext.prefix = { "${meta.id}.filtered" }
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/variant_calling/filtered" },
             mode: params.publish_dir_mode,
@@ -474,6 +475,7 @@ process {
     }
 
     withName: BCFTOOLS_CONSENSUS {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
             path: {"${params.outdir}/Ancient_DNA/variant_calling/consensus" },
             mode: params.publish_dir_mode,
@@ -482,6 +484,7 @@ process {
     }
 
     withName: BCFTOOLS_INDEX {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t"
         publishDir = [
             path: {"${params.outdir}/Ancient_DNA/variant_calling/index" },
@@ -491,21 +494,24 @@ process {
     }
 
     withName: PYDAMAGE_ANALYZE {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/" },
             mode: params.publish_dir_mode
         ]
     }
 
     withName: PYDAMAGE_FILTER {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/" },
             mode: params.publish_dir_mode
         ]
     }
 
     withName: SAMTOOLS_FAIDX {
+        ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
             path: {"${params.outdir}/Ancient_DNA/samtools/faidx" },
             mode: params.publish_dir_mode,

--- a/docs/output.md
+++ b/docs/output.md
@@ -602,9 +602,9 @@ Optional, only running when parameter `-profile ancient_dna` is specified.
 <summary>Output files</summary>
 
 - `Ancient_DNA/pydamage/analyze`
-  - `[sample/group]/pydamage_results/pydamage_results.csv`: PyDamage raw result tabular file in `.csv` format. Format described here: [pydamage.readthedocs.io/en/0.62/output.html](https://pydamage.readthedocs.io/en/0.62/output.html)
+  - `[assembler]_[sample/group]/pydamage_results/pydamage_results.csv`: PyDamage raw result tabular file in `.csv` format. Format described here: [pydamage.readthedocs.io/en/0.62/output.html](https://pydamage.readthedocs.io/en/0.62/output.html)
 - `Ancient_DNA/pydamage/filter`
-  - `[sample/group]/pydamage_results/pydamage_results.csv`: PyDamage filtered result tabular file in `.csv` format. Format described here: [pydamage.readthedocs.io/en/0.62/output.html](https://pydamage.readthedocs.io/en/0.62/output.html)
+  - `[assembler]_[sample/group]/pydamage_results/pydamage_results.csv`: PyDamage filtered result tabular file in `.csv` format. Format described here: [pydamage.readthedocs.io/en/0.62/output.html](https://pydamage.readthedocs.io/en/0.62/output.html)
 
 </details>
 
@@ -616,11 +616,11 @@ Because of aDNA damage, _de novo_ assemblers sometimes struggle to call a correc
 <summary>Output files</summary>
 
 - `variant_calling/consensus`
-  - `[sample/group].fa`: contigs sequence with re-called consensus from read-to-contig alignment
+  - `[assembler]_[sample/group].fa`: contigs sequence with re-called consensus from read-to-contig alignment
 - `variant_calling/unfiltered`
-  - `[sample/group].vcf.gz`: raw variant calls of the reads aligned back to the contigs.
+  - `[assembler]_[sample/group].vcf.gz`: raw variant calls of the reads aligned back to the contigs.
 - `variant_calling/filtered`
-  - `[sample/group].filtered.vcf.gz`: quality filtered variant calls of the reads aligned back to the contigs.
+  - `[assembler]_[sample/group].filtered.vcf.gz`: quality filtered variant calls of the reads aligned back to the contigs.
 
 </details>
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -308,7 +308,7 @@ manifest {
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version = '2.3.0'
+    version = '2.3.1'
     doi             = '10.1093/nargab/lqac007'
 }
 

--- a/subworkflows/local/binning_refinement.nf
+++ b/subworkflows/local/binning_refinement.nf
@@ -22,21 +22,13 @@ def getColNo(filename) {
 
 workflow BINNING_REFINEMENT {
     take:
-    contigs
+    ch_contigs_for_dastool // channel: [ val(meta), path(contigs) ]
     bins           // channel: [ val(meta), path(bins) ]
     depths
     reads
 
     main:
     ch_versions = Channel.empty()
-
-    // Drop unnecessary files
-    ch_contigs_for_dastool = contigs
-                                .map {
-                                    meta, assembly, bams, bais ->
-                                        def meta_new = meta.clone()
-                                        [ meta_new, assembly ]
-                                }
 
     ch_bins_for_fastatocontig2bin = RENAME_PREDASTOOL(bins).renamed_bins
                                         .branch {

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -582,13 +582,13 @@ workflow MAG {
         if ( params.refine_bins_dastool ) {
 
             if (params.ancient_dna) {
-                contigs_ch = ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled
+                ch_contigs_for_binrefinement = ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled
             } else {
-                contigs_ch = BINNING_PREPARATION.out.grouped_mappings
+                ch_contigs_for_binrefinement = BINNING_PREPARATION.out.grouped_mappings
                     .map{ meta, contigs, bam, bai -> [ meta, contigs ] }
             }
 
-            BINNING_REFINEMENT ( contigs_ch, BINNING.out.bins, BINNING.out.metabat2depths, ch_short_reads )
+            BINNING_REFINEMENT ( ch_contigs_for_binrefinement, BINNING.out.bins, BINNING.out.metabat2depths, ch_short_reads )
             ch_versions = ch_versions.mix(BINNING_REFINEMENT.out.versions)
 
             if ( params.postbinning_input == 'raw_bins_only' ) {

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -581,7 +581,14 @@ workflow MAG {
         // If any two of the binners are both skipped at once, do not run because DAS_Tool needs at least one
         if ( params.refine_bins_dastool ) {
 
-            BINNING_REFINEMENT ( BINNING_PREPARATION.out.grouped_mappings, BINNING.out.bins, BINNING.out.metabat2depths, ch_short_reads )
+            if (params.ancient_dna) {
+                contigs_ch = ANCIENT_DNA_ASSEMLY_VALIDATION.out.contigs_recalled
+            } else {
+                contigs_ch = BINNING_PREPARATION.out.grouped_mappings
+                    .map{ meta, contigs, bam, bai -> [ meta, contigs ] }
+            }
+
+            BINNING_REFINEMENT ( contigs_ch, BINNING.out.bins, BINNING.out.metabat2depths, ch_short_reads )
             ch_versions = ch_versions.mix(BINNING_REFINEMENT.out.versions)
 
             if ( params.postbinning_input == 'raw_bins_only' ) {

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -582,7 +582,7 @@ workflow MAG {
         if ( params.refine_bins_dastool ) {
 
             if (params.ancient_dna) {
-                contigs_ch = ANCIENT_DNA_ASSEMLY_VALIDATION.out.contigs_recalled
+                contigs_ch = ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled
             } else {
                 contigs_ch = BINNING_PREPARATION.out.grouped_mappings
                     .map{ meta, contigs, bam, bai -> [ meta, contigs ] }


### PR DESCRIPTION
Fixing #449 
- fix Genome binning is performed on uncorrected contigs when selecting the ancient DNA subworkflow #449

<!--
# nf-core/mag pull request

Many thanks for contributing to nf-core/mag!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
