### PR TITLE
Make ancient DNA damage correction optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#395](https://github.com/nf-core/mag/pull/395) - Add support for fast domain-level classification of bins using Tiara, to allow bins to be separated into eukaryotic and prokaryotic-specific processes.
 - [#422](https://github.com/nf-core/mag/pull/422) - Adds support for normalization of read depth with BBNorm (added by @erikrikarddaniel and @fabianegli)
 - [#439](https://github.com/nf-core/mag/pull/439) - Adds ability to enter the pipeline at the binning stage by providing a CSV of pre-computed assemblies (by @prototaxites)
+- [#459](https://github.com/nf-core/mag/pull/459) - Adds ability to skip damage correction step in the ancient DNA workflow and just run pyDamage (by @jfy133)
 
 ### `Changed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -521,7 +521,7 @@ process {
     withName: PYDAMAGE_ANALYZE {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/"${meta.assembler}-${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }
@@ -530,7 +530,7 @@ process {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/"${meta.assembler}-${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -521,7 +521,7 @@ process {
     withName: PYDAMAGE_ANALYZE {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/"${meta.assembler}-${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.assembler}-${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }
@@ -530,7 +530,7 @@ process {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/"${meta.assembler}-${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.assembler}-${meta.id}" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -29,7 +29,6 @@ params {
     busco_reference                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                                 = false
     ancient_dna                          = true
-    run_ancient_damagecorrection         = true
     binning_map_mode                     = 'own'
     skip_spades                          = false
     skip_spadeshybrid                    = true

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -29,6 +29,7 @@ params {
     busco_reference                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2020-03-06.tar.gz"
     gtdb                                 = false
     ancient_dna                          = true
+    run_ancient_damagecorrection         = true
     binning_map_mode                     = 'own'
     skip_spades                          = false
     skip_spadeshybrid                    = true

--- a/docs/output.md
+++ b/docs/output.md
@@ -641,7 +641,7 @@ Optional, only running when parameter `-profile ancient_dna` is specified.
 
 ### `variant_calling`
 
-Because of aDNA damage, _de novo_ assemblers sometimes struggle to call a correct consensus on the contig sequence. To avoid this situation, the consensus is re-called with a variant calling software using the reads aligned back to the contigs
+Because of aDNA damage, _de novo_ assemblers sometimes struggle to call a correct consensus on the contig sequence. To avoid this situation, the consensus is optionally re-called with a variant calling software using the reads aligned back to the contigs when `--run_ancient_damagecorrection` is supplied.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/modules.json
+++ b/modules.json
@@ -176,13 +176,14 @@
                         "git_sha": "371eff7748d769c2ddc8bd593773523a364a52fe",
                         "installed_by": ["modules"]
                     },
-                    "tiara/tiara": {
-                        "branch": "master",
-                        "git_sha": "d91e3d3d4806179065b087b91ff36c11976bf233"
-                    },
                     "seqtk/mergepe": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "installed_by": ["modules"]
+                    },
+                    "tiara/tiara": {
+                        "branch": "master",
+                        "git_sha": "d91e3d3d4806179065b087b91ff36c11976bf233",
                         "installed_by": ["modules"]
                     }
                 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,13 +61,14 @@ params {
 
     // ancient DNA assembly validation options
     ancient_dna                          = false
+    pydamage_accuracy                    = 0.5
+    run_ancient_damagecorrection         = false
     freebayes_ploidy                     = 1
     freebayes_min_basequality            = 20
     freebayes_minallelefreq              = 0.33
     bcftools_view_high_variant_quality   = 30
     bcftools_view_medium_variant_quality = 20
     bcftools_view_minimal_allelesupport  = 3
-    pydamage_accuracy                    = 0.5
 
     // taxonomy options
     centrifuge_db                        = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     // ancient DNA assembly validation options
     ancient_dna                          = false
     pydamage_accuracy                    = 0.5
-    run_ancient_damagecorrection         = false
+    skip_ancient_damagecorrection         = false
     freebayes_ploidy                     = 1
     freebayes_min_basequality            = 20
     freebayes_minallelefreq              = 0.33

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -785,9 +785,9 @@
                     "default": 0.5,
                     "description": "PyDamage accuracy threshold"
                 },
-                "run_ancient_damagecorrection": {
+                "skip_ancient_damagecorrection": {
                     "type": "boolean",
-                    "description": "activate damage correction of ancient contigs using variant and consensus calling"
+                    "description": "deactivate damage correction of ancient contigs using variant and consensus calling"
                 },
                 "freebayes_ploidy": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -32,7 +32,7 @@
                     "format": "file-path",
                     "description": "Additional input CSV samplesheet containing information about pre-computed assemblies. When set, both read pre-processing and assembly are skipped and the pipeline begins at the binning stage.",
                     "help_text": "If you have pre-computed assemblies from another source, it is possible to jump straight to the binning stage of the pipeline by supplying these assemblies in a CSV file. This CSV file should have three columns and the following header: `id,group,assembler,fasta`. Short reads must still be supplied in to `--input` in CSV format. See [usage docs](https://nf-co.re/mag/usage#input-specifications) for further details.",
-                    "default": null,
+                    "default": "None",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "outdir": {
@@ -740,7 +740,7 @@
                     "type": "number",
                     "default": 0.5,
                     "description": "Specify single-copy gene score threshold for bin refinement.",
-                    "help_text": "Score threshold for single-copy gene selection algorithm to keep selecting bins, with a value ranging from 0-1.\n\nFor description of scoring algorithm, see: Sieber, Christian M. K., et al. 2018. Nature Microbiology 3 (7): 836–43. https://doi.org/10.1038/s41564-018-0171-1.\n\n> Modifies DAS Tool parameter --score_threshold\n"
+                    "help_text": "Score threshold for single-copy gene selection algorithm to keep selecting bins, with a value ranging from 0-1.\n\nFor description of scoring algorithm, see: Sieber, Christian M. K., et al. 2018. Nature Microbiology 3 (7): 836\u201343. https://doi.org/10.1038/s41564-018-0171-1.\n\n> Modifies DAS Tool parameter --score_threshold\n"
                 },
                 "postbinning_input": {
                     "type": "string",
@@ -780,6 +780,15 @@
                     "type": "boolean",
                     "description": "Turn on/off the ancient DNA subworfklow"
                 },
+                "pydamage_accuracy": {
+                    "type": "number",
+                    "default": 0.5,
+                    "description": "PyDamage accuracy threshold"
+                },
+                "run_ancient_damagecorrection": {
+                    "type": "boolean",
+                    "description": "activate damage correction of ancient contigs using variant and consensus calling"
+                },
                 "freebayes_ploidy": {
                     "type": "integer",
                     "default": 1,
@@ -809,11 +818,6 @@
                     "type": "integer",
                     "default": 3,
                     "description": "minimum number of bases supporting the alternative allele"
-                },
-                "pydamage_accuracy": {
-                    "type": "number",
-                    "default": 0.5,
-                    "description": "PyDamage accuracy threshold"
                 }
             }
         }

--- a/subworkflows/local/ancient_dna.nf
+++ b/subworkflows/local/ancient_dna.nf
@@ -16,11 +16,11 @@ workflow ANCIENT_DNA_ASSEMBLY_VALIDATION {
         PYDAMAGE_FILTER(PYDAMAGE_ANALYZE.out.csv)
         ch_versions = ch_versions.mix(PYDAMAGE_ANALYZE.out.versions.first())
 
-        if ( !params.run_ancient_damagecorrection ) {
+        if ( params.skip_ancient_damagecorrection ) {
             ch_corrected_contigs = Channel.empty()
         }
 
-        if ( params.run_ancient_damagecorrection ) {
+        if ( !params.skip_ancient_damagecorrection ) {
             FAIDX(input.map { item -> [ item[0], item[1] ] })
             freebayes_input = input.join(FAIDX.out.fai) // [val(meta), path(contigs), path(bam), path(bam_index), path(fai)]
             FREEBAYES (freebayes_input.map { item -> [item[0], item[2], item[3], [], [], []] },

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -647,7 +647,7 @@ workflow MAG {
 
     if (!params.skip_binning){
 
-        if (params.ancient_dna) {
+        if (params.ancient_dna && params.run_ancient_damagecorrection) {
             BINNING (
                 BINNING_PREPARATION.out.grouped_mappings
                     .join(ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled)


### PR DESCRIPTION
This makes the damage correction subworkflow optional, i.e. ytou can run just pyDamage, and optionally turn on damage correction using freebayes and bcftools.

@alexhbnr please can you test, and let me know if you would refer to have it opt in (rather than opt out).

Also note this _does not yet_ include the hotfix in the patch for #449 , I will add that later as it requires more thinking due to the more complex inputs to bin refinement since domain classification has come in.

fixes #456

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
