### PR TITLE
Patch 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.3.2 - [2023-06-21]
+## v2.3.2 - [2023-06-22]
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.3.2 - [2023-06-22]
+## v2.3.2 - [2023-06-23]
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.3.2 - [2023-06-21]
+
+### `Fixed`
+
+- [#461](https://github.com/nf-core/mag/pull/461) - Fix full-size AWS test profile paths (by @jfy133)
+- [#461](https://github.com/nf-core/mag/pull/461) - Fix pyDamage results being overwritten (reported by @alexhbnr, fix by @jfy133)
+
 ## v2.3.1 - [2023-06-19]
 
 ### `Fixed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -496,7 +496,7 @@ process {
     withName: PYDAMAGE_ANALYZE {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.assembler}-${meta.id}/" },
             mode: params.publish_dir_mode
         ]
     }
@@ -505,7 +505,7 @@ process {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.assembler}-${meta.id}/" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,19 +10,21 @@
 ----------------------------------------------------------------------------------------
 */
 
+cleanup = true
+
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
     // hg19 reference with highly conserved and low-complexity regions masked by Brian Bushnell
-    host_fasta    = "s3://nf-core-awsmegatests/mag/input_data/hg19_main_mask_ribo_animal_allplant_allfungus.fa.gz"
-    input         = "s3://nf-core-awsmegatests/mag/input_data/samplesheets/samplesheet.full.csv"
+    host_fasta    = "s3://ngi-igenomes/test-data/mag/hg19_main_mask_ribo_animal_allplant_allfungus.fa.gz"
+    input         = "s3://ngi-igenomes/test-data/mag/samplesheets/samplesheet.full.csv"
 
-    centrifuge_db = "s3://nf-core-awsmegatests/mag/input_data/p_compressed+h+v.tar.gz"
-    kraken2_db    = "s3://nf-core-awsmegatests/mag/input_data/minikraken_8GB_202003.tgz"
-    cat_db        = "s3://nf-core-awsmegatests/mag/input_data/CAT_prepare_20210107.tar.gz"
-    gtdb          = "s3://nf-core-awsmegatests/mag/input_data/gtdbtk_r202_data.tar.gz"
+    centrifuge_db = "s3://ngi-igenomes/test-data/mag/p_compressed+h+v.tar.gz"
+    kraken2_db    = "s3://ngi-igenomes/test-data/mag/minikraken_8GB_202003.tgz"
+    cat_db        = "s3://ngi-igenomes/test-data/mag/CAT_prepare_20210107.tar.gz"
+    gtdb          = "s3://ngi-igenomes/test-data/mag/gtdbtk_r202_data.tar.gz"
 
     // reproducibility options for assembly
     spades_fix_cpus       = 10
@@ -33,4 +35,7 @@ params {
 
     // test CAT with official taxonomic ranks only
     cat_official_taxonomy         = true
+
+    // Skip CONCOCT due to timeout issues
+    skip_concoct                  = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -308,7 +308,7 @@ manifest {
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version = '2.3.1'
+    version = '2.3.2'
     doi             = '10.1093/nargab/lqac007'
 }
 


### PR DESCRIPTION
Fixes two things:

1. AWS megatest paths so the tests will actually run
2. Apparently I was overzealous with the output renaming in the aDNA workflow, the pyDamage doesn't actually use a prefix even though it was in the modules config, therefore the 'prefix' needs to actually go into the publishDir directive

Again I'll be responsible for upstream pulls (1 is already integrated, 2 in https://github.com/nf-core/mag/actions/runs/5330953133/jobs/9658192844?pr=459)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
