### PR TITLE
Pull in recent patch release changes from master into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.3.1dev - [date]
+## 3.0.0dev - [date]
 
 ### `Added`
 
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | -------- | ---------------- | ----------- |
 | BCFtools | 1.16             | 1.17        |
 | SAMtools | 1.16.1           | 1.17        |
+
+## v2.3.2 - [2023-06-23]
+
+### `Fixed`
+
+- [#461](https://github.com/nf-core/mag/pull/461) - Fix full-size AWS test profile paths (by @jfy133)
+- [#461](https://github.com/nf-core/mag/pull/461) - Fix pyDamage results being overwritten (reported by @alexhbnr, fix by @jfy133)
+
+## v2.3.1 - [2023-06-19]
+
+### `Fixed`
+
+- [#458](https://github.com/nf-core/mag/pull/458) - Correct the major issue in ancient DNA workflow of binning refinement being performed on uncorrected contigs instead of aDNA consensus recalled contigs (issue [#449](https://github.com/nf-core/mag/issues/449))
+- [#451](https://github.com/nf-core/mag/pull/451) - Fix results file overwriting in Ancient DNA workflow (reported by @alexhbnr, fix by @jfy133, and integrated by @maxibor in [#458](https://github.com/nf-core/mag/pull/458) )
 
 ## v2.3.0 - [2023/03/02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.0.0dev - [date]
+## 2.4.0dev - [date]
 
 ### `Added`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -490,8 +490,8 @@ process {
     }
 
     withName: BCFTOOLS_VIEW {
-        ext.args   = "-v snps,mnps -i 'QUAL>=${params.bcftools_view_high_variant_quality} || (QUAL>=${params.bcftools_view_medium_variant_quality} && FORMAT/AO>=${params.bcftools_view_minimal_allelesupport})'"
         ext.prefix = { "${meta.assembler}-${meta.id}.filtered" }
+        ext.args   = "-v snps,mnps -i 'QUAL>=${params.bcftools_view_high_variant_quality} || (QUAL>=${params.bcftools_view_medium_variant_quality} && FORMAT/AO>=${params.bcftools_view_minimal_allelesupport})'"
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/variant_calling/filtered" },
             mode: params.publish_dir_mode,
@@ -521,7 +521,7 @@ process {
     withName: PYDAMAGE_ANALYZE {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.assembler}-${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.assembler}-${meta.id}/" },
             mode: params.publish_dir_mode
         ]
     }
@@ -530,7 +530,7 @@ process {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
-            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.assembler}-${meta.id}" },
+            path: {"${params.outdir}/Ancient_DNA/pydamage/filter/${meta.assembler}-${meta.id}/" },
             mode: params.publish_dir_mode
         ]
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -348,7 +348,7 @@ manifest {
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '2.3.1dev'
+    version         = '3.0.0dev'
     doi             = '10.1093/nargab/lqac007'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -348,7 +348,7 @@ manifest {
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '3.0.0dev'
+    version         = '2.4.0dev'
     doi             = '10.1093/nargab/lqac007'
 }
 

--- a/subworkflows/local/binning_refinement.nf
+++ b/subworkflows/local/binning_refinement.nf
@@ -30,14 +30,7 @@ workflow BINNING_REFINEMENT {
             [meta_new, bins]
         }
 
-    // Drop unnecessary contig files, and prepare bins
-    ch_contigs_for_dastool = contigs
-                                .map {
-                                    meta, assembly, bams, bais ->
-                                        def meta_new = meta.clone()
-                                        [ meta_new, assembly ]
-                                }
-
+    // prepare bins
     ch_bins_for_fastatocontig2bin = RENAME_PREDASTOOL(ch_bins).renamed_bins
                                         .branch {
                                             metabat2: it[0]['binner'] == 'MetaBAT2'

--- a/subworkflows/local/binning_refinement.nf
+++ b/subworkflows/local/binning_refinement.nf
@@ -15,7 +15,7 @@ include { RENAME_POSTDASTOOL                                              } from
 
 workflow BINNING_REFINEMENT {
     take:
-    contigs
+    ch_contigs_for_dastool // channel: [ val(meta), path(contigs) ]
     bins           // channel: [ val(meta), path(bins) ]
 
     main:
@@ -25,12 +25,12 @@ workflow BINNING_REFINEMENT {
     // everything here is either unclassified or a prokaryote
     ch_bins = bins
         .map { meta, bins ->
-            meta_new = meta.clone()
-            meta_new.remove('domain')
+            def meta_new = meta.clone()
+            def meta_new = meta - meta.subMap('domain')
             [meta_new, bins]
         }
 
-    // Drop unnecessary files
+    // Drop unnecessary contig files, and prepare bins
     ch_contigs_for_dastool = contigs
                                 .map {
                                     meta, assembly, bams, bais ->

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -662,10 +662,14 @@ workflow MAG {
         }
 
         if ( params.bin_domain_classification ) {
+
+            // TODO QUESTION ch_Assemblies here should be damage corrected if aDNA?
             DOMAIN_CLASSIFICATION ( ch_assemblies, BINNING.out.bins, BINNING.out.unbinned )
             ch_binning_results_bins   = DOMAIN_CLASSIFICATION.out.classified_bins
             ch_binning_results_unbins = DOMAIN_CLASSIFICATION.out.classified_unbins
             ch_versions               = ch_versions.mix(DOMAIN_CLASSIFICATION.out.versions)
+
+
         } else {
             ch_binning_results_bins = BINNING.out.bins
                 .map { meta, bins ->
@@ -701,7 +705,14 @@ workflow MAG {
                     meta.domain == "eukarya"
                 }
 
-            BINNING_REFINEMENT ( BINNING_PREPARATION.out.grouped_mappings, ch_prokarya_bins_dastool )
+            if (params.ancient_dna) {
+                ch_contigs_for_binrefinement = ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled
+            } else {
+                ch_contigs_for_binrefinement = BINNING_PREPARATION.out.grouped_mappings
+                    .map{ meta, contigs, bam, bai -> [ meta, contigs ] }
+            }
+
+            BINNING_REFINEMENT ( ch_contigs_for_binrefinement, ch_prokarya_bins_dastool )
 
             ch_refined_bins = ch_eukarya_bins_dastool.mix(BINNING_REFINEMENT.out.refined_bins)
             ch_refined_unbins = BINNING_REFINEMENT.out.refined_unbins


### PR DESCRIPTION
This pulls in the changes from the two patch releases into the `dev` branch (essentially a manual merge conflict resolution)

It also includes the version bumped as proposed on slack to make the upcoming  2.4.

It would be great if the following people could check this pull:

- @maxibor that I've correctly incorporated your changes
- @prototaxites that I've not messed up your tweaks around this area (mainly domain classification)
- @alexhbnr @maxibor that we should also send damage-corrected contigs to domain classification, if both activated (and not just the 'raw' assemblies in both cases)

Note I've not yet tested the following combinations in this PR yet(!)! Just want to make sure the logic is OK.

## PR checklist

- [xz] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
