### PR TITLE
Adds --krona_db parameter to point at a local copy of the db needed for Krona. Suggested in Issue #404. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#X](https://github.com/nf-core/mag/pull/X) - Adds support for pointing at a local db for krona, using the parameter `--krona_db` (by @willros).
 - [#395](https://github.com/nf-core/mag/pull/395) - Adds support for fast domain-level classification of bins using Tiara, to allow bins to be separated into eukaryotic and prokaryotic-specific processes.
 - [#422](https://github.com/nf-core/mag/pull/422) - Adds support for normalization of read depth with BBNorm (added by @erikrikarddaniel and @fabianegli)
 - [#439](https://github.com/nf-core/mag/pull/439) - Adds ability to enter the pipeline at the binning stage by providing a CSV of pre-computed assemblies (by @prototaxites)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#X](https://github.com/nf-core/mag/pull/X) - Adds support for pointing at a local db for krona, using the parameter `--krona_db` (by @willros).
+- [#497](https://github.com/nf-core/mag/pull/#497) - Adds support for pointing at a local db for krona, using the parameter `--krona_db` (by @willros).
 - [#395](https://github.com/nf-core/mag/pull/395) - Adds support for fast domain-level classification of bins using Tiara, to allow bins to be separated into eukaryotic and prokaryotic-specific processes.
 - [#422](https://github.com/nf-core/mag/pull/422) - Adds support for normalization of read depth with BBNorm (added by @erikrikarddaniel and @fabianegli)
 - [#439](https://github.com/nf-core/mag/pull/439) - Adds ability to enter the pipeline at the binning stage by providing a CSV of pre-computed assemblies (by @prototaxites)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#497](https://github.com/nf-core/mag/pull/#497) - Adds support for pointing at a local db for krona, using the parameter `--krona_db` (by @willros).
+- [#497](https://github.com/nf-core/mag/pull/497) - Adds support for pointing at a local db for krona, using the parameter `--krona_db` (by @willros).
 - [#395](https://github.com/nf-core/mag/pull/395) - Adds support for fast domain-level classification of bins using Tiara, to allow bins to be separated into eukaryotic and prokaryotic-specific processes.
 - [#422](https://github.com/nf-core/mag/pull/422) - Adds support for normalization of read depth with BBNorm (added by @erikrikarddaniel and @fabianegli)
 - [#439](https://github.com/nf-core/mag/pull/439) - Adds ability to enter the pipeline at the binning stage by providing a CSV of pre-computed assemblies (by @prototaxites)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,6 +191,8 @@ To allow also reproducible bin QC with BUSCO, run BUSCO providing already downlo
 
 For the taxonomic bin classification with [CAT](https://github.com/dutilh/CAT), when running the pipeline with `--cat_db_generate` the parameter `--save_cat_db` can be used to also save the generated database to allow reproducibility in future runs. Note that when specifying a pre-built database with `--cat_db`, currently the database can not be saved.
 
+When it comes to visualizing taxonomic data using [Krona](https://github.com/marbl/Krona), you have the option to provide a taxonomy file, such as `taxonomy.tab`, using the `--krona_db` parameter. If you don't supply a taxonomy file, Krona is designed to automatically download the required taxonomy data for visualization. If you choose to provide a pre-existing taxonomy file using the `--krona_db` parameter, Krona will use that file for visualization. On the other hand, if you omit the `--krona_db` parameter, Krona will download the necessary taxonomy information automatically to enable visualization.
+
 The taxonomic classification of bins with GTDB-Tk is not guaranteed to be reproducible, since the placement of bins in the reference tree is non-deterministic. However, the authors of the GTDB-Tk article examined the reproducibility on a set of 100 genomes across 50 trials and did not observe any difference (see [https://doi.org/10.1093/bioinformatics/btz848](https://doi.org/10.1093/bioinformatics/btz848)).
 
 ## Core Nextflow arguments

--- a/modules/local/krona.nf
+++ b/modules/local/krona.nf
@@ -15,7 +15,7 @@ process KRONA {
     path "versions.yml"             , emit: versions
 
     script:
-    taxonomy_folder = taxonomy_file.toRealPath().getParent()
+    taxonomy_folder = taxonomy_file.getParent()
     """
     ktImportTaxonomy "$report" -tax ${taxonomy_folder}
 

--- a/modules/local/krona.nf
+++ b/modules/local/krona.nf
@@ -8,16 +8,17 @@ process KRONA {
 
     input:
     tuple val(meta), path(report)
-    path(taxonomy_file)
+    path(taxonomy_file), stageAs: 'taxonomy.tab'
 
     output:
     tuple val(meta), path("*.html") , emit: html
     path "versions.yml"             , emit: versions
 
     script:
-    taxonomy_folder = taxonomy_file.getParent()
     """
-    ktImportTaxonomy "$report" -tax ${taxonomy_folder}
+    TAXONOMY=\$(find -L . -name '*.tab' -exec dirname {} \\;)
+
+    ktImportTaxonomy ${report} -tax \$TAXONOMY/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/krona.nf
+++ b/modules/local/krona.nf
@@ -8,16 +8,14 @@ process KRONA {
 
     input:
     tuple val(meta), path(report)
-    path(taxonomy)
+    path(taxonomy_file)
 
     output:
-    path "*.html"       , emit: html
-    path "versions.yml" , emit: versions
+    tuple val(meta), path("*.html") , emit: html
+    path "versions.yml"             , emit: versions
 
     script:
-    taxonomy_folder = taxonomy.toRealPath().getParent()
-    // if the path is a list, perhaps take the first item?
-    //taxonomy_folder = taxonomy[0].toRealPath().getParent()
+    taxonomy_folder = taxonomy_file.toRealPath().getParent()
     """
     ktImportTaxonomy "$report" -tax ${taxonomy_folder}
 

--- a/modules/local/krona.nf
+++ b/modules/local/krona.nf
@@ -8,15 +8,18 @@ process KRONA {
 
     input:
     tuple val(meta), path(report)
-    path  "taxonomy/taxonomy.tab"
+    path(taxonomy)
 
     output:
     path "*.html"       , emit: html
     path "versions.yml" , emit: versions
 
     script:
+    taxonomy_folder = taxonomy.toRealPath().getParent()
+    // if the path is a list, perhaps take the first item?
+    //taxonomy_folder = taxonomy[0].toRealPath().getParent()
     """
-    ktImportTaxonomy "$report" -tax taxonomy
+    ktImportTaxonomy "$report" -tax ${taxonomy_folder}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,6 +81,7 @@ params {
     centrifuge_db                        = null
     kraken2_db                           = null
     skip_krona                           = false
+    krona_db                             = null
     cat_db                               = null
     cat_db_generate                      = false
     cat_official_taxonomy                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -491,7 +491,7 @@
                 "krona_db": {
                     "type": "string",
                     "description": "Database for taxonomic binning with krona",
-                    "help_text": "Local `taxonomy.tab` file for Krona, instead of downloading. Point at the `.tab` file."
+                    "help_text": "Path to `taxonomy.tab` file for Krona, instead of downloading the default file. Point at the `.tab` file."
                 },
                 "skip_krona": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -488,6 +488,11 @@
                     "description": "Database for taxonomic binning with kraken2.",
                     "help_text": "The database file must be a compressed tar archive that contains at least the three files `hash.k2d`, `opts.k2d` and `taxo.k2d`. E.g. ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken_8GB_202003.tgz."
                 },
+                "krona_db": {
+                    "type": "string",
+                    "description": "Database for taxonomic binning with krona",
+                    "help_text": "The folder must contain the file \"taxonomy.tab\""
+                },
                 "skip_krona": {
                     "type": "boolean",
                     "description": "Skip creating a krona plot for taxonomic binning."

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -491,7 +491,7 @@
                 "krona_db": {
                     "type": "string",
                     "description": "Database for taxonomic binning with krona",
-                    "help_text": "The folder must contain the file \"taxonomy.tab\""
+                    "help_text": "Local `taxonomy.tab` file for Krona, instead of downloading. Point at the `.tab` file."
                 },
                 "skip_krona": {
                     "type": "boolean",

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -481,18 +481,15 @@ workflow MAG {
     ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
 
     if (( params.centrifuge_db || params.kraken2_db ) && !params.skip_krona){
-
         if (params.krona_db){
-            ch_cat_db = ch_krona_db_file
+            ch_krona_db = ch_krona_db_file
         } else {
             KRONA_DB ()
             ch_krona_db = KRONA_DB.out.db
-            // KRONA_DB.out.db.collect()
-            // collect or not?
         }
         ch_tax_classifications = CENTRIFUGE.out.results_for_krona.mix(KRAKEN2.out.results_for_krona)
             . map { classifier, meta, report ->
-                def meta_new = meta + [classifer: classifier]
+                def meta_new = meta + [classifier: classifier]
                 [ meta_new, report ]
             }
         KRONA (

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -31,7 +31,7 @@ log.info logo + paramsSummaryLog(workflow) + citation
 WorkflowMag.initialise(params, log, hybrid)
 
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.phix_reference, params.host_fasta, params.centrifuge_db, params.kraken2_db, params.cat_db, params.gtdb_db, params.lambda_reference, params.busco_reference ]
+def checkPathParamList = [ params.input, params.multiqc_config, params.phix_reference, params.host_fasta, params.centrifuge_db, params.kraken2_db, params.cat_db, params.krona_db, params.gtdb_db, params.lambda_reference, params.busco_reference ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 /*
@@ -187,6 +187,13 @@ if(params.cat_db){
         .value(file( "${params.cat_db}" ))
 } else {
     ch_cat_db_file = Channel.empty()
+}
+
+if(params.krona_db){
+    ch_krona_db_file = Channel
+        .value(file( "${params.krona_db}" ))
+} else {
+    ch_krona_db_file = Channel.empty()
 }
 
 if(!params.keep_phix) {
@@ -474,7 +481,15 @@ workflow MAG {
     ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
 
     if (( params.centrifuge_db || params.kraken2_db ) && !params.skip_krona){
-        KRONA_DB ()
+
+        if (params.krona_db){
+            ch_cat_db = ch_krona_db_file
+        } else {
+            KRONA_DB ()
+            ch_krona_db = KRONA_DB.out.db
+            // KRONA_DB.out.db.collect()
+            // collect or not?
+        }
         ch_tax_classifications = CENTRIFUGE.out.results_for_krona.mix(KRAKEN2.out.results_for_krona)
             . map { classifier, meta, report ->
                 def meta_new = meta + [classifer: classifier]
@@ -482,7 +497,7 @@ workflow MAG {
             }
         KRONA (
             ch_tax_classifications,
-            KRONA_DB.out.db.collect()
+            ch_krona_db
         )
         ch_versions = ch_versions.mix(KRONA.out.versions.first())
     }


### PR DESCRIPTION
closes #404 

The user can now point at a local copy of the the taxonomy.tab file needed for running Krona. 


## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x ] Make sure your code lints (`nf-core lint`).
- [ x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x ] Usage Documentation in `docs/usage.md` is updated.
- [ x] Output Documentation in `docs/output.md` is updated.
- [ x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
