### PR TITLE
Fix missing GUNC overwriting #514 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#515](https://github.com/nf-core/mag/pull/515) Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
+
 ### `Dependencies`
 
 ## 2.4.0 - 2023-09-26

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -417,7 +417,7 @@ process {
     // Make sure to keep directory in sync with gunc_qc.nf
     withName: 'GUNC_RUN' {
         publishDir = [
-            path: { "${params.outdir}/GenomeBinning/QC/GUNC/raw/${meta.assembler}-${meta.binner}-${meta.id}" },
+            path: { "${params.outdir}/GenomeBinning/QC/GUNC/raw/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -426,7 +426,7 @@ process {
     // Make sure to keep directory in sync with gunc_qc.nf
     withName: 'GUNC_MERGECHECKM' {
         publishDir = [
-            path: { "${params.outdir}/GenomeBinning/QC/GUNC/checkmmerged/${meta.assembler}-${meta.binner}-${meta.id}" },
+            path: { "${params.outdir}/GenomeBinning/QC/GUNC/checkmmerged/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/docs/output.md
+++ b/docs/output.md
@@ -557,7 +557,7 @@ If the parameter `--save_checkm_reference` is set, additionally the used the Che
 <summary>Output files</summary>
 
 - `GenomeBinning/QC/gunc_summary.tsv`
-- `GenomeBinning/QC/gunc_checkm_GUNCmmary.tsv`
+- `GenomeBinning/QC/gunc_checkm_summary.tsv`
 - `[gunc-database].dmnd`
 - `GUNC/`
   - `raw/`

--- a/docs/output.md
+++ b/docs/output.md
@@ -557,13 +557,13 @@ If the parameter `--save_checkm_reference` is set, additionally the used the Che
 <summary>Output files</summary>
 
 - `GenomeBinning/QC/gunc_summary.tsv`
-- `GenomeBinning/QC/gunc_checkm_summary.tsv`
+- `GenomeBinning/QC/gunc_checkm_GUNCmmary.tsv`
 - `[gunc-database].dmnd`
 - `GUNC/`
   - `raw/`
-    - `[assembler]-[binner]-[sample/group]/GUNC_checkM.merged.tsv`: Per sample GUNC [output](https://grp-bork.embl-community.io/gunc/output.html) containing with taxonomic and completeness QC statistics.
+    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/GUNC_checkM.merged.tsv`: Per sample GUNC [output](https://grp-bork.embl-community.io/gunc/output.html) containing with taxonomic and completeness QC statistics.
   - `checkmmerged/`
-    - `[assembler]-[binner]-[sample/group]/GUNC.progenomes_2.1.maxCSS_level.tsv`: Per sample GUNC output merged with output from [CheckM](#checkm)
+    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/GUNC.progenomes_2.1.maxCSS_level.tsv`: Per sample GUNC output merged with output from [CheckM](#checkm)
 
 </details>
 


### PR DESCRIPTION
> Wait until https://github.com/nf-core/mag/pull/511 is merged! Then test before requesting review!

closes #502 to stop GUNC overwriting otuput directories when running with domain classification

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
