### PR TITLE
Fix MEGAHIT process on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails.
+
 ### `Dependencies`
 
 ## 2.4.0 - 2023-09-26

--- a/modules/local/megahit.nf
+++ b/modules/local/megahit.nf
@@ -21,6 +21,11 @@ process MEGAHIT {
     mem = task.memory.toBytes()
     if ( !params.megahit_fix_cpu_1 || task.cpus == 1 )
         """
+        ## Check if we're in the same work directory as a previous failed MEGAHIT run
+        if [[ -d MEGAHIT ]]; then
+            rm -r MEGAHIT/
+        fi
+
         megahit $args -t "${task.cpus}" -m $mem $input -o MEGAHIT --out-prefix "MEGAHIT-${meta.id}"
 
         gzip -c "MEGAHIT/MEGAHIT-${meta.id}.contigs.fa" > "MEGAHIT/MEGAHIT-${meta.id}.contigs.fa.gz"


### PR DESCRIPTION
It turns out that when resuming a Nextflow pipeline, a work directory will be re-used if all the same input conditions (file names, sizes, timestamps, parameters, etc.) are met: https://training.nextflow.io/basic_training/cache_and_resume/#how-resume-works

When run, Megahit creates a directory called MEGAHIT. Occasionally, when resuming the pipeline after a Megahit failure, the same work directory is used. As it has previously been used, the directory still exists. The Megahit process then fails as it detects this directory, which it wants not to exist. 

MEGAHIT has a force overwrite option, but I think just deleting the MEGAHIT directory on detection at the start of the script is more robust and less likely to result in some error I haven't thought of.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
