### PR TITLE
Fix Tiara publishing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#514](https://github.com/nf-core/mag/pull/514) - Fix missing CONCOCT files in downstream output (reported by @maxibor, fix by @jfy133)
 - [#515](https://github.com/nf-core/mag/pull/515) - Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
 - [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails (reported by @husensofteng, fix by @prototaxites)
-- [#517](https://github.com/nf-core/mag/pull/517) - Fix missing Tiara output files (fix by @jfy133)
+- [#520](https://github.com/nf-core/mag/pull/520) - Fix missing Tiara output files (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#514](https://github.com/nf-core/mag/pull/514) - Fix missing CONCOCT files in downstream output (reported by @maxibor, fix by @jfy133)
 - [#515](https://github.com/nf-core/mag/pull/515) - Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
 - [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails (reported by @husensofteng, fix by @prototaxites)
-- [#517](https://github.com/nf-core/mag/pull/517) - Fix broken publishing of Tiara output files (fix by @jfy133)
+- [#517](https://github.com/nf-core/mag/pull/517) - Fix missing Tiara output files (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#514](https://github.com/nf-core/mag/pull/514) - Fix missing CONCOCT files in downstream output (reported by @maxibor, fix by @jfy133)
 - [#515](https://github.com/nf-core/mag/pull/515) - Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
 - [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails (reported by @husensofteng, fix by @prototaxites)
+- [#517](https://github.com/nf-core/mag/pull/517) - Fix broken publishing of Tiara output files (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -698,17 +698,10 @@ process {
 
     withName: TIARA_TIARA {
         publishDir = [
-            [
-                path: { "${params.outdir}/Taxonomy/Tiara" },
+                path: { "${params.outdir}/Taxonomy/Tiara/" },
                 mode: params.publish_dir_mode,
-                pattern: { "${meta.assembler}-${meta.id}.tiara.{txt}" }
-            ],
-            [
-                path: { "${params.outdir}/Taxonomy/Tiara/log" },
-                mode: params.publish_dir_mode,
-                pattern: { "log_${meta.assembler}-${meta.id}.tiara.{txt}" }
+                pattern: "*.txt"
             ]
-        ]
         ext.args = { "--min_len ${params.tiara_min_length} --probabilities" }
         ext.prefix = { "${meta.assembler}-${meta.id}.tiara" }
     }
@@ -720,7 +713,7 @@ process {
 
     withName: TIARA_SUMMARY {
         publishDir = [
-            path: { "${params.outdir}/Taxonomy/" },
+            path: { "${params.outdir}/GenomeBinning/Tiara" },
             mode: params.publish_dir_mode,
             pattern: "tiara_summary.tsv"
         ]

--- a/docs/output.md
+++ b/docs/output.md
@@ -439,7 +439,7 @@ Tiara is a contig classifier that identifies the domain (prokarya, eukarya) of c
 
 </details>
 
-Typically, you would use `tiara_summary.tsv` as the primary file to see which bins or unbins have been classified to which domains at a glance, whereas the files in `Taxonomy/Tiara` provides classifications for each contig.
+Typically, you would use `tiara_summary.tsv` as the primary file to see which bins or unbins have been classified to which domains at a glance, whereas the files in `Taxonomy/Tiara` provide classifications for each contig.
 
 ### Bin sequencing depth
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -434,12 +434,12 @@ Tiara is a contig classifier that identifies the domain (prokarya, eukarya) of c
 
 - `Taxonomy/Tiara/`
   - `[assembler]-[sample/group].tiara.txt` - Tiara output classifications (with probabilities) for all contigs within the specified sample/group assembly
-  - `log/log_[assembler]-[sample/group].txt` - log file detailing the parameters used by the Tiara model for contig classification.
+  - `log_[assembler]-[sample/group].txt` - log file detailing the parameters used by the Tiara model for contig classification.
 - `GenomeBinning/tiara_summary.tsv` - Summary of Tiara domain classification for all bins.
 
 </details>
 
-Typically, you would use `tiara_summary.tsv` as the primary file to see which bins or unbins have been classified to which domains at a glance, whereas `[assembler]-[sample/group].tiara.txt` provides classifications for each contig.
+Typically, you would use `tiara_summary.tsv` as the primary file to see which bins or unbins have been classified to which domains at a glance, whereas the files in `Taxonomy/Tiara` provides classifications for each contig.
 
 ### Bin sequencing depth
 


### PR DESCRIPTION
I couldn't get the globs working for some reason for the log files, so I put them next to the actual files. I assume it will be clear from the file name what is is and that it's not the main output files.

Output now looks like this

![image](https://github.com/nf-core/mag/assets/17950287/6ed323c2-0772-43d8-9da1-11846cb492c6)

![image](https://github.com/nf-core/mag/assets/17950287/c2e66de0-151f-4c69-b164-52e7c99c5878)

to close #519  (see issue for screenshot of the bugged output)

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
