### PR TITLE
Use correct meta for depth plot input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#514](https://github.com/nf-core/mag/pull/514) - Fix missing CONCOCT files in downstream output (reported by @maxibor, fix by @jfy133)
 - [#515](https://github.com/nf-core/mag/pull/515) - Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
 - [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails (reported by @husensofteng, fix by @prototaxites)
+- [#521](https://github.com/nf-core/mag/pull/521) - Fix 'nulls' in depth plot PNG files (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/subworkflows/local/depths.nf
+++ b/subworkflows/local/depths.nf
@@ -29,8 +29,7 @@ workflow DEPTHS {
         }
         .combine( depths, by: 0 )
         .map { meta_join, meta, bins, contig_depths_file ->
-            def meta_new = meta - meta.subMap('domain')
-            [ meta_new, bins, contig_depths_file ]
+            [ meta, bins, contig_depths_file ]
         }
         .transpose()
         .groupTuple(by: [0,2])


### PR DESCRIPTION
The wrong meta was specified after the combine, so the input to MAG_DEPTHS_PLOT had the reduced joining-'key' meta , not with the domain info

closes #518 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
