### PR TITLE
Fix null in depth PNG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#515](https://github.com/nf-core/mag/pull/515) - Fix overwriting of GUNC output directories when running with domain classification (reported by @maxibor, fix by @jfy133)
 - [#516](https://github.com/nf-core/mag/pull/516) - Fix edge-case bug where MEGAHIT re-uses previous work directory on resume and fails (reported by @husensofteng, fix by @prototaxites)
 - [#520](https://github.com/nf-core/mag/pull/520) - Fix missing Tiara output files (fix by @jfy133)
+- [#522](https://github.com/nf-core/mag/pull/522) - Fix 'nulls' in depth plot PNG files (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/modules/local/mag_depths_plot.nf
+++ b/modules/local/mag_depths_plot.nf
@@ -11,14 +11,14 @@ process MAG_DEPTHS_PLOT {
     path(sample_groups)
 
     output:
-    tuple val(meta), path("${meta.assembler}-${meta.domain}-${meta.binner}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
+    tuple val(meta), path("${meta.assembler}-${meta.binner}-${meta.id}-binDepths.heatmap.png"), emit: heatmap
     path "versions.yml"                                                                       , emit: versions
 
     script:
     """
     plot_mag_depths.py --bin_depths ${depths} \
                     --groups ${sample_groups} \
-                    --out "${meta.assembler}-${meta.domain}-${meta.binner}-${meta.id}-binDepths.heatmap.png"
+                    --out "${meta.assembler}-${meta.binner}-${meta.id}-binDepths.heatmap.png"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Replaces #521 I got confused and thought that the bins going into depths were technically separated by domain - but that is not the case.

closes #518 

IN this case you essentially want to aggregate by sample/assembler/binner and display all these within the heatmap. The Tiara/domain info at this stage just acts as an indicator which bins are more likely eukarotyic, which is ireelevant for the depth heatmaps.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
