### PR TITLE
Patch for 2.5.0 release

### DIFF
--- a/bin/combine_tables.py
+++ b/bin/combine_tables.py
@@ -87,7 +87,8 @@ def main(args=None):
 
     if args.gtdbtk_summary:
         gtdbtk_results = pd.read_csv(args.gtdbtk_summary, sep="\t")
-        if not bins.equals(gtdbtk_results["user_genome"].sort_values().reset_index(drop=True)):
+        # if there are bins in GTDB-Tk not in Depths summary, exit
+        if len(set(gtdbtk_results["user_genome"].to_list()).difference(set(bins))) > 0:
             sys.exit("Bins in GTDB-Tk summary do not match bins in bin depths summary!")
         results = pd.merge(
             results, gtdbtk_results, left_on="bin", right_on="user_genome", how="outer"

--- a/modules/local/cat.nf
+++ b/modules/local/cat.nf
@@ -11,7 +11,7 @@ process CAT {
     tuple val(db_name), path("database/*"), path("taxonomy/*")
 
     output:
-    path("*.names.txt.gz")                 , emit: tax_classification
+    path("*.names.txt")                    , emit: tax_classification
     path("raw/*.ORF2LCA.txt.gz")           , emit: orf2lca
     path("raw/*.predicted_proteins.faa.gz"), emit: faa
     path("raw/*.predicted_proteins.gff.gz"), emit: gff
@@ -27,13 +27,14 @@ process CAT {
     CAT add_names -i "${meta.assembler}-${meta.binner}-${meta.id}.bin2classification.txt" -o "${meta.assembler}-${meta.binner}-${meta.id}.bin2classification.names.txt" -t taxonomy/ ${official_taxonomy}
 
     mkdir raw
-    mv *.ORF2LCA.txt *.predicted_proteins.faa *.predicted_proteins.gff *.log *.bin2classification.txt raw/
+    mv *.ORF2LCA.txt *.predicted_proteins.faa *.predicted_proteins.gff *.bin2classification.txt *.log raw/
+    cp *.bin2classification.names.txt raw/
+
     gzip "raw/${meta.assembler}-${meta.binner}-${meta.id}.ORF2LCA.txt" \
         "raw/${meta.assembler}-${meta.binner}-${meta.id}.concatenated.predicted_proteins.faa" \
         "raw/${meta.assembler}-${meta.binner}-${meta.id}.concatenated.predicted_proteins.gff" \
         "raw/${meta.assembler}-${meta.binner}-${meta.id}.bin2classification.txt" \
         "${meta.assembler}-${meta.binner}-${meta.id}.ORF2LCA.names.txt" \
-        "${meta.assembler}-${meta.binner}-${meta.id}.bin2classification.names.txt"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/cat_summary.nf
+++ b/modules/local/cat_summary.nf
@@ -16,8 +16,6 @@ process CAT_SUMMARY {
     script:
     def prefix = task.ext.prefix ?: "cat_summary"
     """
-    # use find as sometimes these are empty and need to fail gracefully
-    find -L -type f -name "*bin2classification.names.txt.gz" -exec sh -c 'for f do gunzip -c \$f > \${f%.*}; done' find-sh {} +
 
     bioawk '(NR == 1) || (FNR > 1)' *.txt > ${prefix}.tsv
 

--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -1,28 +1,29 @@
 process GTDBTK_CLASSIFYWF {
-    tag "${meta.assembler}-${meta.id}"
+    tag "${prefix}"
     label 'process_medium'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
-    conda "bioconda::gtdbtk=2.1.1"
+    conda "bioconda::gtdbtk=2.3.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gtdbtk:2.1.1--pyhdfd78af_1' :
-        'biocontainers/gtdbtk:2.1.1--pyhdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/gtdbtk:2.3.2--pyhdfd78af_0' :
+        'biocontainers/gtdbtk:2.3.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path("bins/*")
     tuple val(db_name), path("database/*")
+    // path(mash_db)
 
     output:
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.summary.tsv"        , emit: summary
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.classify.tree.gz"   , emit: tree
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.markers_summary.tsv", emit: markers
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.msa.fasta.gz"       , emit: msa
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.user_msa.fasta"     , emit: user_msa
-    path "gtdbtk.${meta.assembler}-${meta.id}.*.filtered.tsv"       , emit: filtered
-    path "gtdbtk.${meta.assembler}-${meta.id}.log"                  , emit: log
-    path "gtdbtk.${meta.assembler}-${meta.id}.warnings.log"         , emit: warnings
-    path "gtdbtk.${meta.assembler}-${meta.id}.failed_genomes.tsv"   , emit: failed
-    path "versions.yml"                                             , emit: versions
+    tuple val(meta), path("gtdbtk.${prefix}.*.summary.tsv")         , emit: summary
+    tuple val(meta), path("gtdbtk.${prefix}.*.classify.tree.gz")    , emit: tree, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.*.markers_summary.tsv") , emit: markers, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.*.msa.fasta.gz")        , emit: msa, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.*.user_msa.fasta.gz")   , emit: user_msa, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.*.filtered.tsv")        , emit: filtered, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.failed_genomes.tsv")    , emit: failed, optional: true
+    tuple val(meta), path("gtdbtk.${prefix}.log")                   , emit: log
+    tuple val(meta), path("gtdbtk.${prefix}.warnings.log")          , emit: warnings
+    path("versions.yml")                           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,6 +31,8 @@ process GTDBTK_CLASSIFYWF {
     script:
     def args = task.ext.args ?: ''
     def pplacer_scratch = params.gtdbtk_pplacer_scratch ? "--scratch_dir pplacer_tmp" : ""
+    // def mash_mode = mash_db ? "--mash_db ${mash_db}" : "--skip_ani_screen"
+    prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     export GTDBTK_DATA_PATH="\${PWD}/database"
@@ -40,17 +43,25 @@ process GTDBTK_CLASSIFYWF {
     gtdbtk classify_wf \\
         $args \\
         --genome_dir bins \\
-        --prefix "gtdbtk.${meta.assembler}-${meta.id}" \\
+        --prefix "gtdbtk.${prefix}" \\
         --out_dir "\${PWD}" \\
         --cpus $task.cpus \\
-        --pplacer_cpus $params.gtdbtk_pplacer_cpus \\
+        --skip_ani_screen \\
         $pplacer_scratch \\
         --min_perc_aa $params.gtdbtk_min_perc_aa \\
         --min_af $params.gtdbtk_min_af
 
-    gzip "gtdbtk.${meta.assembler}-${meta.id}".*.classify.tree "gtdbtk.${meta.assembler}-${meta.id}".*.msa.fasta
-    mv gtdbtk.log "gtdbtk.${meta.assembler}-${meta.id}.log"
-    mv gtdbtk.warnings.log "gtdbtk.${meta.assembler}-${meta.id}.warnings.log"
+    mv classify/* .
+
+    mv identify/* .
+
+    mv align/* .
+
+    mv gtdbtk.log "gtdbtk.${prefix}.log"
+
+    mv gtdbtk.warnings.log "gtdbtk.${prefix}.warnings.log"
+
+    find -name "gtdbtk.${prefix}.*.classify.tree" | xargs -r gzip # do not fail if .tree is missing
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -59,18 +70,18 @@ process GTDBTK_CLASSIFYWF {
     """
 
     stub:
-    def VERSION = '2.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
-
+    def VERSION = '2.3.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.summary.tsv
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.classify.tree.gz
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.markers_summary.tsv
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.msa.fasta.gz
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.user_msa.fasta
-    touch gtdbtk.${meta.assembler}-${meta.id}.stub.filtered.tsv
-    touch gtdbtk.${meta.assembler}-${meta.id}.log
-    touch gtdbtk.${meta.assembler}-${meta.id}.warnings.log
-    touch gtdbtk.${meta.assembler}-${meta.id}.failed_genomes.tsv
+    touch gtdbtk.${prefix}.stub.summary.tsv
+    touch gtdbtk.${prefix}.stub.classify.tree.gz
+    touch gtdbtk.${prefix}.stub.markers_summary.tsv
+    touch gtdbtk.${prefix}.stub.msa.fasta.gz
+    touch gtdbtk.${prefix}.stub.user_msa.fasta.gz
+    touch gtdbtk.${prefix}.stub.filtered.tsv
+    touch gtdbtk.${prefix}.log
+    touch gtdbtk.${prefix}.warnings.log
+    touch gtdbtk.${prefix}.failed_genomes.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/depths.nf
+++ b/subworkflows/local/depths.nf
@@ -51,7 +51,13 @@ workflow DEPTHS {
         }
 
     MAG_DEPTHS_PLOT ( ch_mag_depths_plot, ch_sample_groups.collect() )
-    MAG_DEPTHS_SUMMARY ( MAG_DEPTHS.out.depths.map{it[1]}.collect() )
+    //Depth files that are coming from bins and failed binning refinement are concatenated per meta
+    ch_mag_depth_out = MAG_DEPTHS.out.depths
+        .collectFile(keepHeader: true) {
+            meta, depth ->
+            [depth.getBaseName(), depth]
+        }
+    MAG_DEPTHS_SUMMARY ( ch_mag_depth_out.collect() )
     ch_versions = ch_versions.mix( MAG_DEPTHS_PLOT.out.versions )
     ch_versions = ch_versions.mix( MAG_DEPTHS_SUMMARY.out.versions )
 

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -24,7 +24,8 @@ workflow GTDBTK {
                         def completeness  = -1
                         def contamination = -1
                         def missing, duplicated
-                        if (params.busco_db.getBaseName().contains('odb10')) {
+                        def busco_db = file(params.busco_db)
+                        if (busco_db.getBaseName().contains('odb10')) {
                             missing    = row.'%Missing (specific)'      // TODO or just take '%Complete'?
                             duplicated = row.'%Complete and duplicated (specific)'
                         } else {
@@ -47,10 +48,11 @@ workflow GTDBTK {
     }
 
     // Filter bins based on collected metrics: completeness, contamination
+
     ch_filtered_bins = bins
         .transpose()
         .map { meta, bin -> [bin.getName(), bin, meta]}
-        .join(ch_bin_metrics, failOnDuplicate: true, failOnMismatch: true)
+        .join(ch_bin_metrics, failOnDuplicate: true, failOnMismatch: false)
         .map { bin_name, bin, meta, completeness, contamination -> [meta, bin, completeness, contamination] }
         .branch {
             passed: (it[2] != -1 && it[2] >= params.gtdbtk_min_completeness && it[3] != -1 && it[3] <= params.gtdbtk_max_contamination)
@@ -81,9 +83,9 @@ workflow GTDBTK {
 
     GTDBTK_SUMMARY (
         ch_filtered_bins.discarded.map{it[1]}.collect().ifEmpty([]),
-        GTDBTK_CLASSIFYWF.out.summary.collect().ifEmpty([]),
-        GTDBTK_CLASSIFYWF.out.filtered.collect().ifEmpty([]),
-        GTDBTK_CLASSIFYWF.out.failed.collect().ifEmpty([])
+        GTDBTK_CLASSIFYWF.out.summary.map{it[1]}.collect().ifEmpty([]),
+        GTDBTK_CLASSIFYWF.out.filtered.map{it[1]}.collect().ifEmpty([]),
+        GTDBTK_CLASSIFYWF.out.failed.map{it[1]}.collect().ifEmpty([])
     )
 
     emit:


### PR DESCRIPTION
This is a patch for the 2.5.0 release, adressing the following issues:

In `workflow/mag.nf` 55ca012a22fa14abb0efc3b6dc45fbbbff1cf879
- fix: centrifuge_db needs to be in if/else scope
- fix: collectFile in CAT_SUMMARY and QUAST_BINS_SUMMARY to avoid input file name collision
- refactor: renaming reads into bins in ch_input_for_quast_bins map, quast deals with bins, not reads

In `subworkflows/gtdbk.nf` 2805d9965718c1ee21c6f4d4ddd39fb3f48a52e5
- fix: busco_db needs to be cast to file to call getBaseName() function, 
- failOnMistmatch needs to be False to handle unrefined genomes coming through the ch_bin_metrics(depth) channel

In `subworkflows/gtdbk.nf` afa3ad3e3e7b8d2097ce12c17a75b1f66cc5e9a8
- fix: input file name collision for MAG_DEPTHS_SUMMARY solved by concatenating files with same name in one with .collectFile()

In `modules/nf-core/gtdbtk/classifywf` 54e9fc46bb158c6ea698aa14f894192b9c9a5df1
- fix: update GTDB-Tk module and fix moving/compressing files

In `modules/local/cat.nf` and `modules/local/cat_summary.nf` 779fa0db083aa05f34063017391567de90445926
- fix: bin2classification.names.txt needs to be decompressed for .collectFile() in order to solve the input file name collision 

In `bin/combine_tables.py` f9c4f84073a9e5eec35454fd568ccd1eaa202ca8
- fix: handle case where genomes in depth files were not processed by GTDB-Tk


## PR checklist

- [x] This comment contains a description of changes (with reason).
