### PR TITLE
Fix gtdb dirrectory input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#582](https://github.com/nf-core/mag/pull/575) - Fix GTDB database input when directory supplied (fix by @jfy133)
+- [#583](https://github.com/nf-core/mag/pull/583) - Fix GTDB database input when directory supplied (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#582](https://github.com/nf-core/mag/pull/575) - Fix GTDB database input when directory supplied (fix by @jfy133)
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/test.config
+++ b/conf/test.config
@@ -29,5 +29,7 @@ params {
     busco_db                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     busco_clean                   = true
     skip_gtdbtk                   = true
+    gtdbtk_min_completeness       = 0
     skip_concoct                  = true
+
 }

--- a/conf/test_adapterremoval.config
+++ b/conf/test_adapterremoval.config
@@ -29,6 +29,7 @@ params {
     max_unbinned_contigs        = 2
     busco_db                    = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness     = 0
     clip_tool                   = 'adapterremoval'
     skip_concoct                = true
     bin_domain_classification   = true

--- a/conf/test_ancient_dna.config
+++ b/conf/test_ancient_dna.config
@@ -28,6 +28,7 @@ params {
     max_unbinned_contigs                 = 2
     busco_db                             = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     skip_gtdbtk                          = true
+    gtdbtk_min_completeness              = 0
     ancient_dna                          = true
     binning_map_mode                     = 'own'
     skip_spades                          = false

--- a/conf/test_bbnorm.config
+++ b/conf/test_bbnorm.config
@@ -35,6 +35,7 @@ params {
     busco_db                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     busco_clean                   = true
     skip_gtdbtk                   = true
+    gtdbtk_min_completeness       = 0
     bbnorm                        = true
     coassemble_group              = true
 }

--- a/conf/test_binrefinement.config
+++ b/conf/test_binrefinement.config
@@ -29,6 +29,7 @@ params {
     max_unbinned_contigs          = 2
     busco_db                      = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     skip_gtdbtk                   = true
+    gtdbtk_min_completeness       = 0
     refine_bins_dastool           = true
     refine_bins_dastool_threshold = 0
     // TODO not using 'both' until #489 merged

--- a/conf/test_busco_auto.config
+++ b/conf/test_busco_auto.config
@@ -25,6 +25,7 @@ params {
     min_length_unbinned_contigs = 1
     max_unbinned_contigs        = 2
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness     = 0
     skip_prokka                 = true
     skip_prodigal               = true
     skip_quast                  = true

--- a/conf/test_host_rm.config
+++ b/conf/test_host_rm.config
@@ -26,5 +26,6 @@ params {
     max_unbinned_contigs        = 2
     busco_db                    = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness     = 0
     skip_concoct                = true
 }

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -25,5 +25,6 @@ params {
     max_unbinned_contigs        = 2
     busco_db                    = "https://busco-data.ezlab.org/v5/data/lineages/bacteria_odb10.2024-01-08.tar.gz"
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness     = 0
     skip_concoct                = true
 }

--- a/conf/test_hybrid_host_rm.config
+++ b/conf/test_hybrid_host_rm.config
@@ -27,4 +27,5 @@ params {
     skip_binqc                  = true
     skip_concoct                = true
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness     = 0
 }

--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -39,5 +39,6 @@ params {
     skip_prokka                   = true
     skip_binqc                    = true
     skip_gtdbtk                   = true
+    gtdbtk_min_completeness       = 0
     skip_concoct                  = true
 }

--- a/conf/test_virus_identification.config
+++ b/conf/test_virus_identification.config
@@ -28,6 +28,7 @@ params {
     reads_minlength             = 150
     coassemble_group            = true
     skip_gtdbtk                 = true
+    gtdbtk_min_completeness       = 0
     skip_binning                = true
     skip_prokka                 = true
     skip_spades                 = true

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -66,13 +66,16 @@ workflow GTDBTK {
         // Expects to be tar.gz!
         ch_db_for_gtdbtk = GTDBTK_DB_PREPARATION ( gtdb ).db
     } else if ( gtdb.isDirectory() ) {
-        // Make up meta id to match expected channel cardinality for GTDBTK
+        // The classifywf module expects a list of the _contents_ of the GTDB
+        // database, not just the directory itself (I'm not sure why). But
+        // for now we generate this list before putting into a channel,
+        // then grouping again to pass to the module.
+        // Then make up meta id to match expected channel cardinality for GTDBTK
+        gtdb_dir = gtdb.listFiles()
         ch_db_for_gtdbtk = Channel
-                            .of(gtdb)
-                            .map{
-                                [ it.toString().split('/').last(), it ]
-                            }
-                            .collect()
+                            .of(gtdb_dir)
+                            .map{['gtdb', it]}
+                            .groupTuple()
     } else {
         error("Unsupported object given to --gtdb, database must be supplied as either a directory or a .tar.gz file!")
     }
@@ -86,7 +89,7 @@ workflow GTDBTK {
 
     GTDBTK_CLASSIFYWF (
         ch_filtered_bins.passed.groupTuple(),
-        ch_db_for_gtdbtk,
+        ch_db_for_gtdbtk.dump(tag: 'gtdb_db'),
         gtdb_mash
     )
 

--- a/subworkflows/local/gtdbtk.nf
+++ b/subworkflows/local/gtdbtk.nf
@@ -89,7 +89,7 @@ workflow GTDBTK {
 
     GTDBTK_CLASSIFYWF (
         ch_filtered_bins.passed.groupTuple(),
-        ch_db_for_gtdbtk.dump(tag: 'gtdb_db'),
+        ch_db_for_gtdbtk,
         gtdb_mash
     )
 


### PR DESCRIPTION
I discovered when testing that supplying an already unpacked GTDB directory, this would fail at the CLASSIFYWF module, as this module doesn't expect the directory, but rather a list of the contents itself. I'm not sure why this is.... 

I will in the future update the module (And thoroughly test it), but for now this workaround makes the module work for directory input.

The PR also includes setting a GTDBTK contamination filter to 0, so when it is tested manually (as it the database doesn't fit on GHA), we can be sure the module executes.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
