### PR TITLE
feat: allow adna co-binning

### DIFF
--- a/lib/WorkflowMag.groovy
+++ b/lib/WorkflowMag.groovy
@@ -19,9 +19,6 @@ class WorkflowMag {
         if (params.coassemble_group && params.binning_map_mode == 'own') {
             Nextflow.error("Invalid combination of parameter '--binning_map_mode own' and parameter '--coassemble_group'. Select either 'all' or 'group' mapping mode when performing group-wise co-assembly.")
         }
-        if (params.ancient_dna && params.binning_map_mode != 'own') {
-            Nextflow.error("Invalid combination of parameter '--binning_map_mode' and parameter '--ancient_dna'. Ancient DNA mode can only be executed with --binning_map_mode own. You supplied: --binning_map_mode ${params.binning_map_mode}")
-        }
 
         // Check if specified cpus for SPAdes are available
         if ( params.spades_fix_cpus > params.max_cpus ) {

--- a/subworkflows/local/ancient_dna.nf
+++ b/subworkflows/local/ancient_dna.nf
@@ -12,7 +12,14 @@ workflow ANCIENT_DNA_ASSEMBLY_VALIDATION {
     main:
         ch_versions = Channel.empty()
 
-        PYDAMAGE_ANALYZE(input.map {item -> [item[0], item[2], item[3]]})
+        PYDAMAGE_ANALYZE(
+            input.map {
+                meta, contigs, bam, bai -> [
+                    meta, bam[0], bai[0]
+                ]
+            }
+        )
+
         PYDAMAGE_FILTER(PYDAMAGE_ANALYZE.out.csv)
         ch_versions = ch_versions.mix(PYDAMAGE_ANALYZE.out.versions.first())
 


### PR DESCRIPTION
This PR enables the possibility to perform co-binning when using the ancient DNA mode.

Once merged, it can close #572 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
