### PR TITLE
Fix #638 [MAG_DEPTHS_PLOT fails if only a single bin is produced]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 ### `Fixed`
+
 - [#639](https://github.com/nf-core/mag/pull/639) - Fix pipeline failure when a sample produces only a single bin (fix by @d-callan)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 ### `Fixed`
+- [#639](https://github.com/nf-core/mag/pull/639) - Fix pipeline failure when a sample produces only a single bin (fix by @d-callan)
 
 ### `Dependencies`
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Hadrien Gourlé, Daniel Straub, Sabrina Krakau
+Copyright (c) Hadrien Gourlé, Daniel Straub, Sabrina Krakau, James A. Fellows Yates, Maxime Borry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -77,14 +77,25 @@ When group-wise co-assembly is enabled, `SPAdes` is run on accordingly pooled re
 
 ## Credits
 
-nf-core/mag was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se), [Daniel Straub](https://github.com/d4straub) and [Sabrina Krakau](https://github.com/skrakau) at the [Quantitative Biology Center (QBiC)](http://qbic.life). [James A. Fellows Yates](https://github.com/jfy133) and [Maxime Borry](https://github.com/maxibor) at the [Max Planck Institute for Evolutionary Anthropology](https://www.eva.mpg.de) joined in version 2.2.0. More recent contributors include [Jim Downie](https://github.com/prototaxites) and [Carson Miller](https://github.com/CarsonJM).
+nf-core/mag was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se), [Daniel Straub](https://github.com/d4straub) and [Sabrina Krakau](https://github.com/skrakau) at the [Quantitative Biology Center (QBiC)](http://qbic.life). [James A. Fellows Yates](https://github.com/jfy133) and [Maxime Borry](https://github.com/maxibor) at the [Max Planck Institute for Evolutionary Anthropology](https://www.eva.mpg.de) joined in version 2.2.0. 
+
+Other code contributors include:
+
+- [Antonia Schuster](https://github.com/AntoniaSchuster)
+- [Alexander Ramos](https://github.com/alxndrdiaz) 
+- [Carson Miller](https://github.com/CarsonJM)
+- [Daniel Lundin](https://github.com/erikrikarddaniel)
+- [Danielle Callan](https://github.com/d-callan)
+- [Gregory Sprenger](https://github.com/gregorysprenger)
+- [Jim Downie](https://github.com/prototaxites)
+- [Phil Palmer](https://github.com/PhilPalmer)
+- [@willros](https://github.com/willros)
 
 Long read processing was inspired by [caspargross/HybridAssembly](https://github.com/caspargross/HybridAssembly) written by Caspar Gross [@caspargross](https://github.com/caspargross)
 
 We thank the following people for their extensive assistance in the development of this pipeline:
 
 - [Alexander Peltzer](https://github.com/apeltzer)
-- [Antonia Schuster](https://github.com/antoniaschuster)
 - [Phil Ewels](https://github.com/ewels)
 - [Gisela Gabernet](https://github.com/ggabernet)
 - [Harshil Patel](https://github.com/drpatelh)

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ When group-wise co-assembly is enabled, `SPAdes` is run on accordingly pooled re
 
 ## Credits
 
-nf-core/mag was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se), [Daniel Straub](https://github.com/d4straub) and [Sabrina Krakau](https://github.com/skrakau) at the [Quantitative Biology Center (QBiC)](http://qbic.life). [James A. Fellows Yates](https://github.com/jfy133) and [Maxime Borry](https://github.com/maxibor) at the [Max Planck Institute for Evolutionary Anthropology](https://www.eva.mpg.de) joined in version 2.2.0. 
+nf-core/mag was written by [Hadrien Gourlé](https://hadriengourle.com) at [SLU](https://slu.se), [Daniel Straub](https://github.com/d4straub) and [Sabrina Krakau](https://github.com/skrakau) at the [Quantitative Biology Center (QBiC)](http://qbic.life). [James A. Fellows Yates](https://github.com/jfy133) and [Maxime Borry](https://github.com/maxibor) at the [Max Planck Institute for Evolutionary Anthropology](https://www.eva.mpg.de) joined in version 2.2.0.
 
 Other code contributors include:
 
 - [Antonia Schuster](https://github.com/AntoniaSchuster)
-- [Alexander Ramos](https://github.com/alxndrdiaz) 
+- [Alexander Ramos](https://github.com/alxndrdiaz)
 - [Carson Miller](https://github.com/CarsonJM)
 - [Daniel Lundin](https://github.com/erikrikarddaniel)
 - [Danielle Callan](https://github.com/d-callan)

--- a/docs/output.md
+++ b/docs/output.md
@@ -454,7 +454,7 @@ For each bin or refined bin the median sequencing depth is computed based on the
 - `GenomeBinning/depths/bins/`
   - `bin_depths_summary.tsv`: Summary of bin sequencing depths for all samples. Depths are available for samples mapped against the corresponding assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
   - `bin_refined_depths_summary.tsv`: Summary of sequencing depths for refined bins for all samples, if refinement was performed. Depths are available for samples mapped against the corresponding assembly, i.e. according to the mapping strategy specified with `--binning_map_mode`. Only for short reads.
-  - `[assembler]-[binner]-[sample/group]-binDepths.heatmap.png`: Clustered heatmap showing bin abundances of the assembly across samples. Bin depths are transformed to centered log-ratios and bins as well as samples are clustered by Euclidean distance. Again, sample depths are available according to the mapping strategy specified with `--binning_map_mode`.
+  - `[assembler]-[binner]-[sample/group]-binDepths.heatmap.png`: Clustered heatmap showing bin abundances of the assembly across samples. Bin depths are transformed to centered log-ratios and bins as well as samples are clustered by Euclidean distance. Again, sample depths are available according to the mapping strategy specified with `--binning_map_mode`. If a sample produces only a single bin, a heatmap will not be provided.
 
 </details>
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -385,7 +385,7 @@ dag {
 
 manifest {
     name            = 'nf-core/mag'
-    author          = """Hadrien Gourlé, Daniel Straub, Sabrina Krakau"""
+    author          = """Hadrien Gourlé, Daniel Straub, Sabrina Krakau, James A. Fellows Yates, Maxime Borry"""
     homePage        = 'https://github.com/nf-core/mag'
     description     = """Assembly, binning and annotation of metagenomes"""
     mainScript      = 'main.nf'

--- a/subworkflows/local/depths.nf
+++ b/subworkflows/local/depths.nf
@@ -10,7 +10,7 @@ def getColNo(filename) {
     return lines[0].split('\t').size()
 }
 
-/* 
+/*
  * Get number of rows in a file
  */
 def getRowNo(filename) {

--- a/subworkflows/local/depths.nf
+++ b/subworkflows/local/depths.nf
@@ -10,6 +10,14 @@ def getColNo(filename) {
     return lines[0].split('\t').size()
 }
 
+/* 
+ * Get number of rows in a file
+ */
+def getRowNo(filename) {
+    lines = file(filename).readLines()
+    return lines.size()
+}
+
 workflow DEPTHS {
     take:
     bins_unbins     //channel: val(meta), [ path(bins) ]
@@ -53,9 +61,10 @@ workflow DEPTHS {
         .collectFile(name:'sample_groups.tsv'){ meta, reads -> meta.id + '\t' + meta.group + '\n' }
 
     // Filter MAG depth files: use only those for plotting that contain depths for > 2 samples
+    // as well as > 2 bins
     ch_mag_depths_plot = MAG_DEPTHS.out.depths
         .map { meta, bin_depths_file ->
-            if (getColNo(bin_depths_file) > 2) [ meta, bin_depths_file ]
+            if (getColNo(bin_depths_file) > 2 && getRowNo(bin_depths_file) > 2) [ meta, bin_depths_file ]
         }
 
     MAG_DEPTHS_PLOT ( ch_mag_depths_plot, ch_sample_groups.collect() )


### PR DESCRIPTION
This PR fixes #638 by introducing a check against the number of rows in the bin depths files, and only attempting to produce heatmaps if there are > 2. 

I'll work through the checklist shortly, though may need some guidance re testing (@jfy133 )

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
