### PR TITLE
Change unnecessary MultiQC containers to nf-core/ubuntu:20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#648](https://github.com/nf-core/mag/pull/648) - Fix sample ID/assembly ID check failure when no IDs match (reported by @zackhenny, fix by @prototaxites)
 - [#646](https://github.com/nf-core/mag/pull/646) - GTDB-Tk directory input now creates a value channel so it runs for all entries to the process and not just the first (reported by @amizeranschi, fix by @prototaxites).
 - [#639](https://github.com/nf-core/mag/pull/639) - Fix pipeline failure when a sample produces only a single bin (fix by @d-callan)
+- [#652](https://github.com/nf-core/mag/pull/651) - Replace base container for bash only modules to reduce number of containers in pipeline (reported and fixed by @harper357)
 
 ### `Dependencies`
 

--- a/modules/local/adjust_maxbin2_ext.nf
+++ b/modules/local/adjust_maxbin2_ext.nf
@@ -2,11 +2,10 @@ process ADJUST_MAXBIN2_EXT {
     tag "${meta.assembler}-${meta.id}"
     label 'process_low'
 
-    // Using container from multiqc since it'll be included anyway
-    conda "bioconda::multiqc=1.12"
+    conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(bins)

--- a/modules/local/rename_postdastool.nf
+++ b/modules/local/rename_postdastool.nf
@@ -2,11 +2,10 @@ process RENAME_POSTDASTOOL {
     tag "${meta.assembler}-${meta.id}"
     label 'process_low'
 
-    // Using container from multiqc since it'll be included anyway
-    conda "bioconda::multiqc=1.12"
+    conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(bins)

--- a/modules/local/rename_predastool.nf
+++ b/modules/local/rename_predastool.nf
@@ -2,11 +2,10 @@ process RENAME_PREDASTOOL {
     tag "${meta.assembler}-${meta.binner}-${meta.id}"
     label 'process_low'
 
-    // Using container from multiqc since it'll be included anyway
-    conda "bioconda::multiqc=1.12"
+    conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(bins)


### PR DESCRIPTION
Re: [slack question about old MultiQC containers](https://nfcore.slack.com/archives/CE9MS66BS/p1723680992023749)

A small PR to replace unnecessary MultiQC containers with nf-core/ubuntu:20.04.

<!--
# nf-core/mag pull request

Many thanks for contributing to nf-core/mag!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
