### PR TITLE
Fix gunc overwriting of raw and checkm files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#648](https://github.com/nf-core/mag/pull/648) - Fix sample ID/assembly ID check failure when no IDs match (reported by @zackhenny, fix by @prototaxites)
 - [#646](https://github.com/nf-core/mag/pull/646) - GTDB-Tk directory input now creates a value channel so it runs for all entries to the process and not just the first (reported by @amizeranschi, fix by @prototaxites).
 - [#639](https://github.com/nf-core/mag/pull/639) - Fix pipeline failure when a sample produces only a single bin (fix by @d-callan)
-- [#652](https://github.com/nf-core/mag/pull/651) - Replace base container for bash only modules to reduce number of containers in pipeline (reported and fixed by @harper357)
+- [#651](https://github.com/nf-core/mag/pull/651) - Replace base container for bash only modules to reduce number of containers in pipeline (reported and fixed by @harper357)
+- [#652](https://github.com/nf-core/mag/pull/652) - Fix documentation typo in using user-defined assembly parameters (reported and fixed by @amizeranschi)
+- [#653](https://github.com/nf-core/mag/pull/653) - Fix overwriting of per-bin 'raw' GUNC RUN output files (multi-bin summary tables not affected) (reported by @zackhenny and fixed by @jfy133)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -447,7 +447,7 @@ process {
     // Make sure to keep directory in sync with gunc_qc.nf
     withName: 'GUNC_RUN' {
         publishDir = [
-            path: { "${params.outdir}/GenomeBinning/QC/GUNC/raw/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" },
+            path: { "${params.outdir}/GenomeBinning/QC/GUNC/raw/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}/${fasta.baseName}/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -456,7 +456,7 @@ process {
     // Make sure to keep directory in sync with gunc_qc.nf
     withName: 'GUNC_MERGECHECKM' {
         publishDir = [
-            path: { "${params.outdir}/GenomeBinning/QC/GUNC/checkmmerged/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" },
+            path: { "${params.outdir}/GenomeBinning/QC/GUNC/checkmmerged/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}/${checkm_file.baseName}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/docs/output.md
+++ b/docs/output.md
@@ -565,9 +565,9 @@ If the parameter `--save_checkm_reference` is set, additionally the used the Che
 - `[gunc-database].dmnd`
 - `GUNC/`
   - `raw/`
-    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/GUNC_checkM.merged.tsv`: Per sample GUNC [output](https://grp-bork.embl-community.io/gunc/output.html) containing with taxonomic and completeness QC statistics.
+    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/[fasta input file name]/GUNC_checkM.merged.tsv`: Per sample GUNC [output](https://grp-bork.embl-community.io/gunc/output.html) containing with taxonomic and completeness QC statistics.
   - `checkmmerged/`
-    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/GUNC.progenomes_2.1.maxCSS_level.tsv`: Per sample GUNC output merged with output from [CheckM](#checkm)
+    - `[assembler]-[binner]-[domain]-[refinement]-[sample/group]/[checkm input file name]/GUNC.progenomes_2.1.maxCSS_level.tsv`: Per sample GUNC output merged with output from [CheckM](#checkm)
 
 </details>
 


### PR DESCRIPTION
This issue comes about from the unfortunate naming scheme of GUNC.

One other option would be to update the module to use `--input_dir` and give multiple files to get a single 'raw' file, however then this would make it harder for us to then join the same info with the output from CheckM (coming as per-bin files), thus I've gone the slightly ugly route of just making an additional level directory that is named after the input FASTA file, to ensure they are distinct.

Now looks like:

```
.
├── MEGAHIT-DASTool-unclassified-dastool_refined-test_minigut
│   ├── MEGAHIT-MetaBAT2Refined-test_minigut.1
│   │   └── GUNC.progenomes_2.1.maxCSS_level.tsv
│   └── MEGAHIT-MetaBAT2Refined-test_minigut.2
│       └── GUNC.progenomes_2.1.maxCSS_level.tsv
├── MEGAHIT-DASTool-unclassified-dastool_refined_unbinned-test_minigut
│   └── MEGAHIT-DASToolUnbinned-test_minigut
│       └── GUNC.progenomes_2.1.maxCSS_level.tsv
├── SPAdes-DASTool-unclassified-dastool_refined-test_minigut
│   ├── SPAdes-MaxBin2Refined-test_minigut.001_sub
│   │   └── GUNC.progenomes_2.1.maxCSS_level.tsv
│   └── SPAdes-MetaBAT2Refined-test_minigut.2
│       └── GUNC.progenomes_2.1.maxCSS_level.tsv
└── SPAdes-DASTool-unclassified-dastool_refined_unbinned-test_minigut
    └── SPAdes-DASToolUnbinned-test_minigut
        └── GUNC.progenomes_2.1.maxCSS_level.tsv
        ```
        
Wheras before it was 

```bash
.
├── MEGAHIT-DASTool-unclassified-dastool_refined-test_minigut
│   │   └── GUNC.progenomes_2.1.maxCSS_level.tsv
├── MEGAHIT-DASTool-unclassified-dastool_refined_unbinned-test_minigut
│       └── GUNC.progenomes_2.1.maxCSS_level.tsv
├── SPAdes-DASTool-unclassified-dastool_refined-test_minigut
│   │   └── GUNC.progenomes_2.1.maxCSS_level.tsv
└── SPAdes-DASTool-unclassified-dastool_refined_unbinned-test_minigut
        └── GUNC.progenomes_2.1.maxCSS_level.tsv
```

Where yo ucan see we are missing 2 of the files...

Note that the summary `gunc_summary.tsv` file was _not_ affected by this issue, and displayed all 6 bins in the test data correctly :) it was purely the publishing that was the issue here.

Thanks to @zackhenny for reporting!
        

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
