### PR TITLE
Add support for pre-supplying host reference bowtie2 index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#665](https://github.com/nf-core/mag/pull/648) - Add support for supplying pre-made bowtie host reference index (requested by @simone-pignotti, added by @jfy133)
+
 ### `Changed`
 
 ### `Fixed`

--- a/modules/local/bowtie2_removal_align.nf
+++ b/modules/local/bowtie2_removal_align.nf
@@ -26,8 +26,12 @@ process BOWTIE2_REMOVAL_ALIGN {
     def save_ids = (args2.contains('--host_removal_save_ids')) ? "Y" : "N"
     if (!meta.single_end){
         """
+        INDEX=`find -L ./ -name "*.rev.1.bt2" | sed "s/\\.rev.1.bt2\$//"`
+        [ -z "\$INDEX" ] && INDEX=`find -L ./ -name "*.rev.1.bt2l" | sed "s/\\.rev.1.bt2l\$//"`
+        [ -z "\$INDEX" ] && echo "Bowtie2 index files not found" 1>&2 && exit 1
+
         bowtie2 -p ${task.cpus} \
-                -x ${index[0].getSimpleName()} \
+                -x \$INDEX \
                 -1 "${reads[0]}" -2 "${reads[1]}" \
                 $args \
                 --un-conc-gz ${prefix}.unmapped_%.fastq.gz \

--- a/modules/local/bowtie2_removal_build.nf
+++ b/modules/local/bowtie2_removal_build.nf
@@ -10,14 +10,14 @@ process BOWTIE2_REMOVAL_BUILD {
     path fasta
 
     output:
-    path 'bt2_index_base*', emit: index
-    path "versions.yml"   , emit: versions
+    path "*.bt2"        , emit: index
+    path "versions.yml" , emit: versions
 
     script:
     def args = task.ext.args ?: ''
     """
     mkdir bowtie
-    bowtie2-build --threads $task.cpus $fasta "bt2_index_base"
+    bowtie2-build --threads $task.cpus $fasta ${fasta.simpleName}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,7 @@ params {
     phix_reference                       = "${baseDir}/assets/data/GCA_002596845.1_ASM259684v1_genomic.fna.gz"
     save_phixremoved_reads               = false
     host_fasta                           = null
+    host_fasta_bowtie2index              = null
     host_genome                          = null
     host_removal_verysensitive           = false
     host_removal_save_ids                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -383,6 +383,11 @@
                     "description": "Fasta reference file for host contamination removal.",
                     "help_text": "This parameter is mutually exclusive with `--host_genome`. The reference can be masked. Host read removal is done with Bowtie2."
                 },
+                "host_fasta_bowtie2index": {
+                    "type": "string",
+                    "description": "Bowtie2 index directory corresponding to --host_fasta reference file for host contamination removal.",
+                    "help_text": "This parameter must be used in combination with --host_fasta, and should be a directory containing files from the output of `bowtie2-build`, i.e. files ending in `.bt2`"
+                },
                 "host_removal_verysensitive": {
                     "type": "boolean",
                     "description": "Use the `--very-sensitive` instead of the`--sensitive`setting for Bowtie 2 to map reads against the host genome."

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -250,11 +250,17 @@ workflow MAG {
         }
 
         if (params.host_fasta){
-            BOWTIE2_HOST_REMOVAL_BUILD (
-                ch_host_fasta
-            )
-            ch_host_bowtie2index = BOWTIE2_HOST_REMOVAL_BUILD.out.index
+            if ( params.host_fasta_bowtie2index ) {
+                ch_host_bowtie2index = file(params.host_fasta_bowtie2index, checkIfExists: true)
+            } else {
+                BOWTIE2_HOST_REMOVAL_BUILD (
+                    ch_host_fasta
+                )
+                ch_host_bowtie2index = BOWTIE2_HOST_REMOVAL_BUILD.out.index
+            }
+
         }
+
         ch_bowtie2_removal_host_multiqc = Channel.empty()
         if (params.host_fasta || params.host_genome){
             BOWTIE2_HOST_REMOVAL_ALIGN (


### PR DESCRIPTION
To close https://github.com/nf-core/mag/issues/452

(I would rather replace this with the official nf-=core bowtie2 module, but it's not an easy swap out, so will do that later)

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
