### PR TITLE
Add parameter to exclude unbinned data from post-binning steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## dev [unreleased]
 
 ### `Added`
+
 - [#708](https://github.com/nf-core/mag/pull/708) - Added `dev-exclude-unbinned` parameter to exclude unbinned contigs from post-binning processes (added by @dialvarezs)
 
 ### `Changed`
 
 ### `Fixed`
+
 - [#708](https://github.com/nf-core/mag/pull/708) - Fixed channel passed as GUNC input (added by @dialvarezs)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## dev [unreleased]
 
 ### `Added`
+- [#708](https://github.com/nf-core/mag/pull/708) - Added `dev-exclude-unbinned` parameter to exclude unbinned contigs from post-binning processes (added by @dialvarezs)
 
 ### `Changed`
 
 ### `Fixed`
+- [#708](https://github.com/nf-core/mag/pull/708) - Fixed channel passed as GUNC input (added by @dialvarezs)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#708](https://github.com/nf-core/mag/pull/708) - Added `dev-exclude-unbinned` parameter to exclude unbinned contigs from post-binning processes (added by @dialvarezs)
+- [#708](https://github.com/nf-core/mag/pull/708) - Added `--exclude_unbins_from_postbinning` parameter to exclude unbinned contigs from post-binning processes, speeding up Prokka in some cases (added by @dialvarezs)
 
 ### `Changed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -121,6 +121,7 @@ params {
     refine_bins_dastool             = false
     refine_bins_dastool_threshold   = 0.5
     postbinning_input               = 'raw_bins_only'
+    include_unbins_in_postbinning   = true
 
     // Bin QC
     skip_binqc                           = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -121,7 +121,7 @@ params {
     refine_bins_dastool             = false
     refine_bins_dastool_threshold   = 0.5
     postbinning_input               = 'raw_bins_only'
-    include_unbins_in_postbinning   = true
+    exclude_unbins_in_postbinning   = false
 
     // Bin QC
     skip_binqc                           = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -121,7 +121,7 @@ params {
     refine_bins_dastool             = false
     refine_bins_dastool_threshold   = 0.5
     postbinning_input               = 'raw_bins_only'
-    exclude_unbins_in_postbinning   = false
+    exclude_unbins_from_postbinning   = false
 
     // Bin QC
     skip_binqc                           = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -704,6 +704,11 @@
                     "type": "integer",
                     "default": 3000,
                     "description": "Minimum contig length for Tiara to use for domain classification. For accurate classification, should be longer than 3000 bp."
+                },
+                "include_unbins_in_postbinning": {
+                    "type": "boolean",
+                    "description": "Include unbinned contigs in the post-binning output (.",
+                    "default": true
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -708,7 +708,7 @@
                 "exclude_unbins_from_postbinning": {
                     "type": "boolean",
                     "description": "Exclude unbinned contigs in the post-binning steps (bin QC, taxonomic classification, and annotation steps).",
-                    "help": "If you're not interested in assemblies results that are not considered 'genome level', excluding unbinned contigs  can greatly speed up downstream steps such as Prokka, that can be quite slow and spin up many tasks.",
+                    "help": "If you're not interested in assemby results that are not considered 'genome level', excluding unbinned contigs can greatly speed up downstream steps such as Prokka, that can be quite slow and spin up many tasks.",
                     "default": false
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -705,9 +705,10 @@
                     "default": 3000,
                     "description": "Minimum contig length for Tiara to use for domain classification. For accurate classification, should be longer than 3000 bp."
                 },
-                "exclude_unbins_in_postbinning": {
+                "exclude_unbins_from_postbinning": {
                     "type": "boolean",
-                    "description": "Exclude unbinned contigs in the post-binning steps (bin qc, taxonomic classification and annotation).",
+                    "description": "Exclude unbinned contigs in the post-binning steps (bin QC, taxonomic classification, and annotation steps).",
+                    "help": "If you're not interested in assemblies results that are not considered 'genome level', excluding unbinned contigs  can greatly speed up downstream steps such as Prokka, that can be quite slow and spin up many tasks.",
                     "default": false
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -707,7 +707,7 @@
                 },
                 "include_unbins_in_postbinning": {
                     "type": "boolean",
-                    "description": "Include unbinned contigs in the post-binning output (.",
+                    "description": "Include unbinned contigs in the post-binning steps (bin qc, taxonomic classification and annotation).",
                     "default": true
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -705,10 +705,10 @@
                     "default": 3000,
                     "description": "Minimum contig length for Tiara to use for domain classification. For accurate classification, should be longer than 3000 bp."
                 },
-                "include_unbins_in_postbinning": {
+                "exclude_unbins_in_postbinning": {
                     "type": "boolean",
-                    "description": "Include unbinned contigs in the post-binning steps (bin qc, taxonomic classification and annotation).",
-                    "default": true
+                    "description": "Exclude unbinned contigs in the post-binning steps (bin qc, taxonomic classification and annotation).",
+                    "default": false
                 }
             }
         },

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -769,7 +769,11 @@ workflow MAG {
             ch_input_for_postbinning_bins_unbins = ch_binning_results_bins.mix(ch_binning_results_unbins)
         }
 
-        DEPTHS(ch_input_for_postbinning_bins_unbins, BINNING.out.metabat2depths, ch_short_reads)
+        def ch_input_for_postbinning = params.include_unbins_in_postbinning
+            ? ch_input_for_postbinning_bins_unbins
+            : ch_input_for_postbinning_bins
+
+        DEPTHS(ch_input_for_postbinning, BINNING.out.metabat2depths, ch_short_reads)
         ch_input_for_binsummary = DEPTHS.out.depths_summary
         ch_versions = ch_versions.mix(DEPTHS.out.versions)
 
@@ -777,7 +781,7 @@ workflow MAG {
         * Bin QC subworkflows: for checking bin completeness with either BUSCO, CHECKM, and/or GUNC
         */
 
-        ch_input_bins_for_qc = ch_input_for_postbinning_bins_unbins.transpose()
+        ch_input_bins_for_qc = ch_input_for_postbinning.transpose()
 
         if (!params.skip_binqc && params.binqc_tool == 'busco') {
             /*
@@ -821,7 +825,7 @@ workflow MAG {
             ch_versions = ch_versions.mix(GUNC_QC.out.versions)
         }
         else if (params.run_gunc) {
-            ch_input_bins_for_gunc = ch_input_for_postbinning_bins_unbins.filter { meta, bins ->
+            ch_input_bins_for_gunc = ch_input_for_postbinning.filter { meta, bins ->
                 meta.domain != "eukarya"
             }
             GUNC_QC(ch_input_bins_for_qc, ch_gunc_db, [])
@@ -830,7 +834,7 @@ workflow MAG {
 
         ch_quast_bins_summary = Channel.empty()
         if (!params.skip_quast) {
-            ch_input_for_quast_bins = ch_input_for_postbinning_bins_unbins
+            ch_input_for_quast_bins = ch_input_for_postbinning
                 .groupTuple()
                 .map { meta, bins ->
                     def new_bins = bins.flatten()
@@ -859,7 +863,7 @@ workflow MAG {
             ch_cat_db = CAT_DB_GENERATE.out.db
         }
         CAT(
-            ch_input_for_postbinning_bins_unbins,
+            ch_input_for_postbinning,
             ch_cat_db
         )
         // Group all classification results for each sample in a single file
@@ -890,7 +894,7 @@ workflow MAG {
             ch_gtdbtk_summary = Channel.empty()
             if (gtdb) {
 
-                ch_gtdb_bins = ch_input_for_postbinning_bins_unbins.filter { meta, bins ->
+                ch_gtdb_bins = ch_input_for_postbinning.filter { meta, bins ->
                     meta.domain != "eukarya"
                 }
 
@@ -925,7 +929,7 @@ workflow MAG {
          */
 
         if (!params.skip_prokka) {
-            ch_bins_for_prokka = ch_input_for_postbinning_bins_unbins
+            ch_bins_for_prokka = ch_input_for_postbinning
                 .transpose()
                 .map { meta, bin ->
                     def meta_new = meta + [id: bin.getBaseName()]
@@ -944,7 +948,7 @@ workflow MAG {
         }
 
         if (!params.skip_metaeuk && (params.metaeuk_db || params.metaeuk_mmseqs_db)) {
-            ch_bins_for_metaeuk = ch_input_for_postbinning_bins_unbins
+            ch_bins_for_metaeuk = ch_input_for_postbinning
                 .transpose()
                 .filter { meta, bin ->
                     meta.domain in ["eukarya", "unclassified"]

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -769,9 +769,9 @@ workflow MAG {
             ch_input_for_postbinning_bins_unbins = ch_binning_results_bins.mix(ch_binning_results_unbins)
         }
 
-        ch_input_for_postbinning = params.include_unbins_in_postbinning
-            ? ch_input_for_postbinning_bins_unbins
-            : ch_input_for_postbinning_bins
+        ch_input_for_postbinning = params.exclude_unbins_in_postbinning
+            ? ch_input_for_postbinning_bins
+            : ch_input_for_postbinning_bins_unbins
 
         DEPTHS(ch_input_for_postbinning, BINNING.out.metabat2depths, ch_short_reads)
         ch_input_for_binsummary = DEPTHS.out.depths_summary

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -769,7 +769,7 @@ workflow MAG {
             ch_input_for_postbinning_bins_unbins = ch_binning_results_bins.mix(ch_binning_results_unbins)
         }
 
-        def ch_input_for_postbinning = params.include_unbins_in_postbinning
+        ch_input_for_postbinning = params.include_unbins_in_postbinning
             ? ch_input_for_postbinning_bins_unbins
             : ch_input_for_postbinning_bins
 

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -769,7 +769,7 @@ workflow MAG {
             ch_input_for_postbinning_bins_unbins = ch_binning_results_bins.mix(ch_binning_results_unbins)
         }
 
-        ch_input_for_postbinning = params.exclude_unbins_in_postbinning
+        ch_input_for_postbinning = params.exclude_unbins_from_postbinning
             ? ch_input_for_postbinning_bins
             : ch_input_for_postbinning_bins_unbins
 

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -828,7 +828,7 @@ workflow MAG {
             ch_input_bins_for_gunc = ch_input_for_postbinning.filter { meta, bins ->
                 meta.domain != "eukarya"
             }
-            GUNC_QC(ch_input_bins_for_qc, ch_gunc_db, [])
+            GUNC_QC(ch_input_bins_for_gunc, ch_gunc_db, [])
             ch_versions = ch_versions.mix(GUNC_QC.out.versions)
         }
 


### PR DESCRIPTION
This pr adds a  new parameter `exclude_unbins_from_postbinning`, with default value `false`.
The reasoning behind this is that as stated in #649, Prokka can take a really long time with unbinned data, and also qc metrics and taxonomic classification normally are not meaningful for non-bins.
With the default set to `false`, this parameter doesn't introduce any breaking change to the current workflow, but adds flexibility to focus on binned data on post-binning steps.

This PR also fixes one minor issue I found in line 827 of `mag.nf`, where the channel passed to `GUNC` was `ch_input_bins_for_qc` instead of `ch_input_bins_for_gunc` (the same, but without eukarya domain).

Closes #649 .

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
