### PR TITLE
Fix QUAST MultiQC config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-### `Dependencies`
+- [#752](https://github.com/nf-core/mag/pull/752) - Fix QUAST results not being displayed when skipping certain steps (reported by @amizeranschi, fix by @jfy133)
 
 ### `Dependencies`
+
+### `Deprecated`
 
 ## 3.3.0 [2024-12-19]
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -18,7 +18,7 @@ data_format: "yaml"
 run_modules:
   - fastqc
   - fastp
-  - adapterRemoval
+  - adapterremoval
   - custom_content
   - bowtie2
   - busco
@@ -35,7 +35,7 @@ top_modules:
       path_filters_exclude:
         - "*trimmed*"
   - "fastp"
-  - "adapterRemoval"
+  - "adapterremoval"
   - "porechop"
   - "filtlong"
   - "fastqc":
@@ -118,12 +118,12 @@ custom_data:
 sp:
   host_removal:
     fn: "host_removal_metrics.tsv"
-  adapterRemoval:
+  adapterremoval:
     fn: "*_ar2.settings"
   kraken:
     fn_re: ".*[kraken2|centrifuge].*report.txt"
   quast:
-    fn_re: "report.*.tsv"
+    fn: "report*.tsv"
   filtlong:
     num_lines: 20
     fn_re: ".*_filtlong.log"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,20 +28,20 @@ process {
             "--cut_front",
             "--cut_tail",
             "--cut_mean_quality ${params.fastp_cut_mean_quality}",
-            "--length_required ${params.reads_minlength}"
+            "--length_required ${params.reads_minlength}",
         ].join(' ').trim()
         publishDir = [
             [
                 path: { "${params.outdir}/QC_shortreads/fastp/${meta.id}" },
                 mode: params.publish_dir_mode,
-                pattern: "*.{html,json}"
+                pattern: "*.{html,json}",
             ],
             [
                 path: { "${params.outdir}/QC_shortreads/fastp/${meta.id}" },
                 mode: params.publish_dir_mode,
                 pattern: "*.fastq.gz",
-                enabled: params.save_clipped_reads
-            ]
+                enabled: params.save_clipped_reads,
+            ],
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_fastp" }
         tag        = { "${meta.id}_run${meta.run}" }
@@ -52,20 +52,20 @@ process {
             "--minlength ${params.reads_minlength}",
             "--adapter1 ${params.adapterremoval_adapter1} --adapter2 ${params.adapterremoval_adapter2}",
             "--minquality ${params.adapterremoval_minquality} --trimns",
-            params.adapterremoval_trim_quality_stretch ? "--trim_qualities" : "--trimwindows 4"
+            params.adapterremoval_trim_quality_stretch ? "--trim_qualities" : "--trimwindows 4",
         ].join(' ').trim()
         publishDir = [
             [
                 path: { "${params.outdir}/QC_shortreads/adapterremoval/${meta.id}" },
                 mode: params.publish_dir_mode,
-                pattern: "*.{settings}"
+                pattern: "*.{settings}",
             ],
             [
                 path: { "${params.outdir}/QC_shortreads/adapterremoval/${meta.id}" },
                 mode: params.publish_dir_mode,
                 pattern: "*.{truncated,discarded}.gz",
-                enabled: params.save_clipped_reads
-            ]
+                enabled: params.save_clipped_reads,
+            ],
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_ar2" }
         tag        = { "${meta.id}_run${meta.run}" }
@@ -76,12 +76,12 @@ process {
             "--minlength ${params.reads_minlength}",
             "--adapter1 ${params.adapterremoval_adapter1}",
             "--minquality ${params.adapterremoval_minquality} --trimns",
-            params.adapterremoval_trim_quality_stretch ? "--trim_qualities" : "--trimwindows 4"
+            params.adapterremoval_trim_quality_stretch ? "--trim_qualities" : "--trimwindows 4",
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/QC_shortreads/adapterremoval/${meta.id}" },
             mode: params.publish_dir_mode,
-            pattern: "*.{settings}"
+            pattern: "*.{settings}",
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_ar2" }
         tag        = { "${meta.id}_run${meta.run}" }
@@ -93,14 +93,14 @@ process {
             [
                 path: { "${params.outdir}/QC_shortreads/remove_phix" },
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: "*.log",
             ],
             [
                 path: { "${params.outdir}/QC_shortreads/remove_phix" },
                 mode: params.publish_dir_mode,
                 pattern: "*.unmapped*.fastq.gz",
-                enabled: params.save_phixremoved_reads
-            ]
+                enabled: params.save_phixremoved_reads,
+            ],
         ]
         tag        = { "${meta.id}_run${meta.run}" }
     }
@@ -113,14 +113,14 @@ process {
             [
                 path: { "${params.outdir}/QC_shortreads/remove_host" },
                 mode: params.publish_dir_mode,
-                pattern: "*{.log,read_ids.txt}"
+                pattern: "*{.log,read_ids.txt}",
             ],
             [
                 path: { "${params.outdir}/QC_shortreads/remove_host" },
                 mode: params.publish_dir_mode,
                 pattern: "*.unmapped*.fastq.gz",
-                enabled: params.save_hostremoved_reads
-            ]
+                enabled: params.save_hostremoved_reads,
+            ],
         ]
         tag        = { "${meta.id}_run${meta.run}" }
     }
@@ -131,7 +131,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/QC_shortreads/fastqc" },
             mode: params.publish_dir_mode,
-            pattern: "*.html"
+            pattern: "*.html",
         ]
         tag        = { "${meta.id}_run${meta.run}" }
     }
@@ -139,22 +139,22 @@ process {
     withName: BBMAP_BBNORM {
         ext.args   = [
             params.bbnorm_target ? "target=${params.bbnorm_target}" : '',
-            params.bbnorm_min ? "min=${params.bbnorm_min}" : ''
+            params.bbnorm_min ? "min=${params.bbnorm_min}" : '',
         ].join(' ').trim()
         publishDir = [
             [
                 path: { "${params.outdir}/bbmap/bbnorm/logs" },
                 enabled: params.save_bbnorm_reads,
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: "*.log",
             ],
             [
                 path: { "${params.outdir}/bbmap/bbnorm/" },
                 mode: 'copy',
                 enabled: params.save_bbnorm_reads,
                 mode: params.publish_dir_mode,
-                pattern: "*.fastq.gz"
-            ]
+                pattern: "*.fastq.gz",
+            ],
         ]
     }
 
@@ -163,7 +163,7 @@ process {
             path: { "${params.outdir}/QC_longreads/porechop" },
             mode: params.publish_dir_mode,
             pattern: "*_porechop_trimmed.fastq.gz",
-            enabled: params.save_porechop_reads
+            enabled: params.save_porechop_reads,
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_porechop_trimmed" }
     }
@@ -173,7 +173,7 @@ process {
             path: { "${params.outdir}/QC_longreads/porechop" },
             mode: params.publish_dir_mode,
             pattern: "*_porechop-abi_trimmed.fastq.gz",
-            enabled: params.save_porechop_reads
+            enabled: params.save_porechop_reads,
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_porechop-abi_trimmed" }
     }
@@ -184,13 +184,13 @@ process {
             "--keep_percent ${params.longreads_keep_percent}",
             "--trim",
             "--length_weight ${params.longreads_length_weight}",
-            params.longreads_min_quality ? "--min_mean_q ${params.longreads_min_quality}" : ''
+            params.longreads_min_quality ? "--min_mean_q ${params.longreads_min_quality}" : '',
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/QC_longreads/Filtlong" },
             mode: params.publish_dir_mode,
             pattern: "*_filtlong.fastq.gz",
-            enabled: params.save_filtered_longreads
+            enabled: params.save_filtered_longreads,
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_filtlong" }
     }
@@ -199,20 +199,20 @@ process {
         ext.args   = [
             "--min-len ${params.longreads_min_length}",
             params.longreads_min_quality ? "--min-qual ${params.longreads_min_quality}" : '',
-            "-vv"
+            "-vv",
         ].join(' ').trim()
         publishDir = [
             [
                 path: { "${params.outdir}/QC_longreads/Nanoq" },
                 mode: params.publish_dir_mode,
                 pattern: "*_nanoq_filtered.fastq.gz",
-                enabled: params.save_filtered_longreads
+                enabled: params.save_filtered_longreads,
             ],
             [
                 path: { "${params.outdir}/QC_longreads/Nanoq" },
                 mode: params.publish_dir_mode,
-                pattern: "*_nanoq_filtered.stats"
-            ]
+                pattern: "*_nanoq_filtered.stats",
+            ],
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_nanoq_filtered" }
     }
@@ -222,14 +222,14 @@ process {
             [
                 path: { "${params.outdir}/QC_longreads/NanoLyse" },
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: "*.log",
             ],
             [
                 path: { "${params.outdir}/QC_longreads/NanoLyse" },
                 mode: params.publish_dir_mode,
                 pattern: "*_nanolyse.fastq.gz",
-                enabled: params.save_lambdaremoved_reads
-            ]
+                enabled: params.save_lambdaremoved_reads,
+            ],
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_lambdafiltered" }
     }
@@ -237,20 +237,20 @@ process {
     withName: CHOPPER {
         ext.args2  = [
             params.longreads_min_quality ? "--quality ${params.longreads_min_quality}" : '',
-            params.longreads_min_length ? "--minlength ${params.longreads_min_length}" : ''
+            params.longreads_min_length ? "--minlength ${params.longreads_min_length}" : '',
         ].join(' ').trim()
         publishDir = [
             [
                 path: { "${params.outdir}/QC_longreads/Chopper" },
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: "*.log",
             ],
             [
                 path: { "${params.outdir}/QC_longreads/Chopper" },
                 mode: params.publish_dir_mode,
                 pattern: "*_chopper.fastq.gz",
-                enabled: params.save_lambdaremoved_reads || params.save_filtered_longreads
-            ]
+                enabled: params.save_lambdaremoved_reads || params.save_filtered_longreads,
+            ],
         ]
         ext.prefix = { "${meta.id}_run${meta.run}_chopper" }
     }
@@ -261,13 +261,13 @@ process {
             [
                 "-p raw_",
                 "--title ${meta.id}_raw",
-                "-c darkblue"
+                "-c darkblue",
             ].join(' ').trim()
         }
         publishDir = [
             path: { "${params.outdir}/QC_longreads/NanoPlot/${meta.id}" },
             mode: params.publish_dir_mode,
-            pattern: "*.{png,html,txt}"
+            pattern: "*.{png,html,txt}",
         ]
     }
 
@@ -276,13 +276,13 @@ process {
             [
                 "-p filtered_",
                 "--title ${meta.id}_filtered",
-                "-c darkblue"
+                "-c darkblue",
             ].join(' ').trim()
         }
         publishDir = [
             path: { "${params.outdir}/QC_longreads/NanoPlot/${meta.id}" },
             mode: params.publish_dir_mode,
-            pattern: "*.{png,html,txt}"
+            pattern: "*.{png,html,txt}",
         ]
     }
 
@@ -300,7 +300,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/Taxonomy/kraken2/${meta.id}" },
             mode: params.publish_dir_mode,
-            pattern: "*.txt"
+            pattern: "*.txt",
         ]
     }
 
@@ -338,12 +338,12 @@ process {
         ext.args   = [
             "--cleanup",
             "--min-score ${params.genomad_min_score}",
-            "--splits ${params.genomad_splits}"
+            "--splits ${params.genomad_splits}",
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/VirusIdentification/geNomad/${meta.id}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -354,14 +354,14 @@ process {
             [
                 path: { "${params.outdir}/Assembly/${assembly_meta.assembler}/QC/${assembly_meta.id}" },
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: "*.log",
             ],
             [
                 path: { "${params.outdir}/Assembly/${assembly_meta.assembler}/QC/${assembly_meta.id}" },
                 mode: params.publish_dir_mode,
                 pattern: "*.{bam,bai}",
-                enabled: params.save_assembly_mapped_reads
-            ]
+                enabled: params.save_assembly_mapped_reads,
+            ],
         ]
     }
 
@@ -373,7 +373,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning" },
             mode: params.publish_dir_mode,
-            pattern: "*.{png,tsv}"
+            pattern: "*.{png,tsv}",
         ]
     }
 
@@ -388,7 +388,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/BUSCO" },
             mode: params.publish_dir_mode,
-            pattern: "*.{log,err,faa.gz,fna.gz,gff,txt}"
+            pattern: "*.{log,err,faa.gz,fna.gz,gff,txt}",
         ]
     }
 
@@ -410,7 +410,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/CheckM" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -420,7 +420,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/CheckM" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -429,7 +429,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -439,7 +439,7 @@ process {
             mode: params.publish_dir_mode,
             overwrite: false,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            enabled: params.save_checkm2_data
+            enabled: params.save_checkm2_data,
         ]
     }
 
@@ -448,7 +448,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/CheckM2" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -457,7 +457,7 @@ process {
             path: { "${params.outdir}/GenomeBinning/QC/GUNC" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            enabled: params.gunc_save_db
+            enabled: params.gunc_save_db,
         ]
     }
 
@@ -466,7 +466,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/GUNC/raw/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}/${fasta.baseName}/" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -475,7 +475,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/QC/GUNC/checkmmerged/${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}/${checkm_file.baseName}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 
@@ -496,13 +496,13 @@ process {
             "--extension fa",
             "--min_perc_aa ${params.gtdbtk_min_perc_aa}",
             "--min_af ${params.gtdbtk_min_af}",
-            "--pplacer_cpus ${params.gtdbtk_pplacer_cpus}"
+            "--pplacer_cpus ${params.gtdbtk_pplacer_cpus}",
         ].join(' ')
         ext.prefix = { "${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/Taxonomy/GTDB-Tk/${meta.assembler}/${meta.binner}/${meta.id}" },
             mode: params.publish_dir_mode,
-            pattern: "*.{log,tsv,tree.gz,fasta,fasta.gz}"
+            pattern: "*.{log,tsv,tree.gz,fasta,fasta.gz}",
         ]
     }
 
@@ -539,7 +539,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/variant_calling/consensus" },
             mode: params.publish_dir_mode,
-            pattern: "*.fa"
+            pattern: "*.fa",
         ]
     }
 
@@ -549,7 +549,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/variant_calling/index" },
             mode: params.publish_dir_mode,
-            enabled: false
+            enabled: false,
         ]
     }
 
@@ -557,7 +557,7 @@ process {
         ext.prefix = { "${meta.assembler}-${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/pydamage/analyze/${meta.assembler}-${meta.id}/" },
-            mode: params.publish_dir_mode
+            mode: params.publish_dir_mode,
         ]
     }
 
@@ -566,7 +566,7 @@ process {
         ext.args   = "-t ${params.pydamage_accuracy}"
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/pydamage/filter/${meta.assembler}-${meta.id}/" },
-            mode: params.publish_dir_mode
+            mode: params.publish_dir_mode,
         ]
     }
 
@@ -575,7 +575,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/Ancient_DNA/samtools/faidx" },
             mode: params.publish_dir_mode,
-            enabled: false
+            enabled: false,
         ]
     }
 
@@ -590,7 +590,7 @@ process {
         ext.args   = [
             params.min_contig_size < 1500 ? "-m 1500" : "-m ${params.min_contig_size}",
             "--unbinned",
-            "--seed ${params.metabat_rng_seed}"
+            "--seed ${params.metabat_rng_seed}",
         ].join(' ').trim()
     }
 
@@ -599,13 +599,13 @@ process {
             [
                 path: { "${params.outdir}/GenomeBinning/MaxBin2/discarded" },
                 mode: params.publish_dir_mode,
-                pattern: '*.tooshort.gz'
+                pattern: '*.tooshort.gz',
             ],
             [
                 path: { "${params.outdir}/GenomeBinning/MaxBin2/" },
                 mode: params.publish_dir_mode,
-                pattern: '*.{summary,abundance}'
-            ]
+                pattern: '*.{summary,abundance}',
+            ],
         ]
         ext.prefix = { "${meta.assembler}-MaxBin2-${meta.id}" }
     }
@@ -615,7 +615,7 @@ process {
             [
                 path: { "${params.outdir}/GenomeBinning/MaxBin2/bins/" },
                 mode: params.publish_dir_mode,
-                pattern: '*.fa.gz'
+                pattern: '*.fa.gz',
             ]
         ]
     }
@@ -625,14 +625,14 @@ process {
             [
                 path: { "${params.outdir}/GenomeBinning/CONCOCT/stats/" },
                 mode: params.publish_dir_mode,
-                pattern: "*.{txt,csv,tsv}"
+                pattern: "*.{txt,csv,tsv}",
             ],
             [
                 path: { "${params.outdir}/GenomeBinning/CONCOCT/bins" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> new File(filename).getName() },
-                pattern: "*/*.fa.gz"
-            ]
+                pattern: "*/*.fa.gz",
+            ],
         ]
         ext.prefix = { "${meta.assembler}-CONCOCT-${meta.id}" }
     }
@@ -662,7 +662,7 @@ process {
             [
                 path: { "${params.outdir}/GenomeBinning/DASTool" },
                 mode: params.publish_dir_mode,
-                pattern: '*.{tsv,log,eval,seqlength}'
+                pattern: '*.{tsv,log,eval,seqlength}',
             ]
         ]
         ext.prefix = { "${meta.assembler}-DASTool-${meta.id}" }
@@ -674,13 +674,13 @@ process {
             [
                 path: { "${params.outdir}/GenomeBinning/DASTool/unbinned" },
                 mode: params.publish_dir_mode,
-                pattern: '*-DASToolUnbinned-*.fa'
+                pattern: '*-DASToolUnbinned-*.fa',
             ],
             [
                 path: { "${params.outdir}/GenomeBinning/DASTool/bins" },
                 mode: params.publish_dir_mode,
-                pattern: '*-{MetaBAT2,MaxBin2,CONCOCT}Refined-*.fa'
-            ]
+                pattern: '*-{MetaBAT2,MaxBin2,CONCOCT}Refined-*.fa',
+            ],
         ]
     }
 
@@ -688,7 +688,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/Taxonomy/Tiara/" },
             mode: params.publish_dir_mode,
-            pattern: "*.txt"
+            pattern: "*.txt",
         ]
         ext.args   = { "--min_len ${params.tiara_min_length} --probabilities" }
         ext.prefix = { "${meta.assembler}-${meta.id}.tiara" }
@@ -715,11 +715,11 @@ process {
         publishDir = [path: { "${params.outdir}/Annotation/MetaEuk/${meta.assembler}/${meta.id}" }, mode: params.publish_dir_mode, saveAs: { filename -> filename.equals('versions.yml') ? null : filename }]
     }
     withName: MULTIQC {
-        ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
+        ext.args   = { params.multiqc_title ? "--title \"${params.multiqc_title}\"" : '' }
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 }

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -806,10 +806,10 @@ workflow MAG {
     ch_multiqc_files = ch_multiqc_files.mix(KRAKEN2.out.report.collect { it[1] }.ifEmpty([]))
 
     if (!params.skip_quast) {
-        ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.report.dump(tag: 'pre-collect').collect().dump(tag: 'post-collect').ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.report.collect().ifEmpty([]))
 
         if (!params.skip_binning) {
-            ch_multiqc_files = ch_multiqc_files.mix(QUAST_BINS.out.dir.dump(tag: 'pre-collect-bin').collect().dump(tag: 'post-collect-bin').ifEmpty([]))
+            ch_multiqc_files = ch_multiqc_files.mix(QUAST_BINS.out.dir.collect().ifEmpty([]))
         }
     }
 
@@ -827,7 +827,7 @@ workflow MAG {
 
 
     MULTIQC(
-        ch_multiqc_files.collect().dump(tag: 'final_mqc'),
+        ch_multiqc_files.collect(),
         ch_multiqc_config.toList(),
         ch_multiqc_custom_config.toList(),
         ch_multiqc_logo.toList(),

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -63,7 +63,7 @@ include { COMBINE_TSV as COMBINE_SUMMARY_TSV                    } from '../modul
 
 workflow MAG {
     take:
-    ch_raw_short_reads // channel: samplesheet read in from --input
+    ch_raw_short_reads  // channel: samplesheet read in from --input
     ch_raw_long_reads
     ch_input_assemblies
 
@@ -115,8 +115,9 @@ workflow MAG {
     }
 
     if (!params.keep_lambda) {
-        ch_lambda_db = Channel.value(file( "${params.lambda_reference}" ))
-    } else {
+        ch_lambda_db = Channel.value(file("${params.lambda_reference}"))
+    }
+    else {
         ch_lambda_db = Channel.empty()
     }
 
@@ -162,14 +163,13 @@ workflow MAG {
             ch_raw_short_reads,
             ch_host_fasta,
             ch_phix_db_file,
-            ch_metaeuk_db
+            ch_metaeuk_db,
         )
 
         ch_versions = ch_versions.mix(SHORTREAD_PREPROCESSING.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(SHORTREAD_PREPROCESSING.out.multiqc_files.collect { it[1] }.ifEmpty([]))
         ch_short_reads = SHORTREAD_PREPROCESSING.out.short_reads
         ch_short_reads_assembly = SHORTREAD_PREPROCESSING.out.short_reads_assembly
-
     }
     else {
         ch_short_reads = ch_raw_short_reads.map { meta, reads ->
@@ -187,7 +187,7 @@ workflow MAG {
     LONGREAD_PREPROCESSING(
         ch_raw_long_reads,
         ch_short_reads,
-        ch_lambda_db
+        ch_lambda_db,
     )
 
     ch_versions = ch_versions.mix(LONGREAD_PREPROCESSING.out.versions)
@@ -218,7 +218,7 @@ workflow MAG {
         ch_short_reads,
         ch_db_for_centrifuge,
         false,
-        false
+        false,
     )
     ch_versions = ch_versions.mix(CENTRIFUGE_CENTRIFUGE.out.versions.first())
 
@@ -255,7 +255,7 @@ workflow MAG {
 
     KRAKEN2(
         ch_short_reads,
-        ch_db_for_kraken2
+        ch_db_for_kraken2,
     )
     ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
 
@@ -287,7 +287,7 @@ workflow MAG {
 
         KRONA_KTIMPORTTAXONOMY(
             ch_tax_classifications,
-            ch_krona_db
+            ch_krona_db,
         )
         ch_versions = ch_versions.mix(KRONA_KTIMPORTTAXONOMY.out.versions.first())
     }
@@ -450,7 +450,7 @@ workflow MAG {
     if (!params.skip_prodigal) {
         PRODIGAL(
             ch_assemblies,
-            'gff'
+            'gff',
         )
         ch_versions = ch_versions.mix(PRODIGAL.out.versions.first())
     }
@@ -477,7 +477,7 @@ workflow MAG {
     if (!params.skip_binning || params.ancient_dna) {
         BINNING_PREPARATION(
             ch_assemblies,
-            ch_short_reads
+            ch_short_reads,
         )
         ch_versions = ch_versions.mix(BINNING_PREPARATION.out.bowtie2_version.first())
     }
@@ -505,13 +505,13 @@ workflow MAG {
         if (params.ancient_dna && !params.skip_ancient_damagecorrection) {
             BINNING(
                 BINNING_PREPARATION.out.grouped_mappings.join(ANCIENT_DNA_ASSEMBLY_VALIDATION.out.contigs_recalled).map { it -> [it[0], it[4], it[2], it[3]] },
-                ch_short_reads
+                ch_short_reads,
             )
         }
         else {
             BINNING(
                 BINNING_PREPARATION.out.grouped_mappings,
-                ch_short_reads
+                ch_short_reads,
             )
         }
         ch_versions = ch_versions.mix(BINNING.out.versions)
@@ -654,7 +654,7 @@ workflow MAG {
         }
         CAT(
             ch_input_for_postbinning,
-            ch_cat_db
+            ch_cat_db,
         )
         // Group all classification results for each sample in a single file
         ch_cat_summary = CAT.out.tax_classification_names.collectFile(keepHeader: true) { meta, classification ->
@@ -692,7 +692,7 @@ workflow MAG {
                     ch_gtdb_bins,
                     ch_bin_qc_summary,
                     gtdb,
-                    gtdb_mash
+                    gtdb_mash,
                 )
                 ch_versions = ch_versions.mix(GTDBTK.out.versions.first())
                 ch_gtdbtk_summary = GTDBTK.out.summary
@@ -709,7 +709,7 @@ workflow MAG {
                 ch_quast_bins_summary.ifEmpty([]),
                 ch_gtdbtk_summary.ifEmpty([]),
                 ch_cat_global_summary.ifEmpty([]),
-                params.binqc_tool
+                params.binqc_tool,
             )
         }
 
@@ -731,7 +731,7 @@ workflow MAG {
             PROKKA(
                 ch_bins_for_prokka,
                 [],
-                []
+                [],
             )
             ch_versions = ch_versions.mix(PROKKA.out.versions.first())
         }
@@ -758,9 +758,9 @@ workflow MAG {
     softwareVersionsToYAML(ch_versions)
         .collectFile(
             storeDir: "${params.outdir}/pipeline_info",
-            name: 'nf_core_'  +  'mag_software_'  + 'mqc_'  + 'versions.yml',
+            name: 'nf_core_' + 'mag_software_' + 'mqc_' + 'versions.yml',
             sort: true,
-            newLine: true
+            newLine: true,
         )
         .set { ch_collated_versions }
 
@@ -798,7 +798,7 @@ workflow MAG {
     ch_multiqc_files = ch_multiqc_files.mix(
         ch_methods_description.collectFile(
             name: 'methods_description_mqc.yaml',
-            sort: true
+            sort: true,
         )
     )
 
@@ -806,10 +806,10 @@ workflow MAG {
     ch_multiqc_files = ch_multiqc_files.mix(KRAKEN2.out.report.collect { it[1] }.ifEmpty([]))
 
     if (!params.skip_quast) {
-        ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.report.collect().ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.report.dump(tag: 'pre-collect').collect().dump(tag: 'post-collect').ifEmpty([]))
 
         if (!params.skip_binning) {
-            ch_multiqc_files = ch_multiqc_files.mix(QUAST_BINS.out.dir.collect().ifEmpty([]))
+            ch_multiqc_files = ch_multiqc_files.mix(QUAST_BINS.out.dir.dump(tag: 'pre-collect-bin').collect().dump(tag: 'post-collect-bin').ifEmpty([]))
         }
     }
 
@@ -827,12 +827,12 @@ workflow MAG {
 
 
     MULTIQC(
-        ch_multiqc_files.collect(),
+        ch_multiqc_files.collect().dump(tag: 'final_mqc'),
         ch_multiqc_config.toList(),
         ch_multiqc_custom_config.toList(),
         ch_multiqc_logo.toList(),
         [],
-        []
+        [],
     )
 
     emit:


### PR DESCRIPTION
Close #741 

Basically the `fun_re` was not picking up the files - I do not understand why though. Maybe it was because it was an invalid regex.

- Includes another small fix to the MultiQC config because of a warning I noticed (adapterremoval mispelt)
- And a language-server formatting of `modules.config`  and `mag.nf` but there is no content changing there


Final thing:
- [x] ✅ I will do two tests of a 'normal' run and a skipping run to double check

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
