### PR TITLE
BIgMAG compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#861](https://github.com/nf-core/mag/pull/861) - Added `--bigmag` to execute the bigmag workflow that generates the file to be used as input for [BIgMAG](https://github.com/jeffe107/BIgMAG)
 - [#718](https://github.com/nf-core/mag/pull/718) - Add support for independent long-read metagenomic assembly (requested by @ljmesi and many others, added by @muabnezor)
 - [#718](https://github.com/nf-core/mag/pull/718) - Added metaMDBG and (meta)Flye as long read assemblers (added by @muabnezor)
 - [#718](https://github.com/nf-core/mag/pull/718) - Added host removal for long reads using minimap2 as aligner (added by @muabnezor)

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -82,6 +82,10 @@
 
   > Orakov, A., Fullam, A., Coelho, A. P., Khedkar, S., Szklarczyk, D., Mende, D. R., Schmidt, T. S. B., and Bork, P.. 2021. “GUNC: Detection of Chimerism and Contamination in Prokaryotic Genomes.” Genome Biology 22 (1): 178. doi: 10.1186/s13059-021-02393-0.
 
+- [MAGFlow/BIgMAG](https://doi.org/10.12688/f1000research.152290.2)
+
+  > Yepes-García, J., Falquet, L. (2024). Metagenome quality metrics and taxonomical annotation visualization through the integration of MAGFlow and BIgMAG. F1000Research 13:640. doi.org/10.12688/f1000research.152290.2  
+
 - [MaxBin2](https://doi.org/10.1093/bioinformatics/btv638)
 
   > Yu-Wei, W., Simmons, B. A. & Singer, S. W. (2015) MaxBin 2.0: An Automated Binning Algorithm to Recover Genomes from Multiple Metagenomic Datasets. Bioinformatics 32 (4): 605–7. doi: 10.1093/bioinformatics/btv638.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Other code contributors include:
 - [Nikolaos Vergoulidis](https://github.com/IceGreb)
 - [Greg Fedewa](https://github.com/harper357)
 - [Vini Salazar](https://github.com/vinisalazar)
+- [Jeferyd Yepes](https://github.com/jeffe107)
 
 Long read processing was inspired by [caspargross/HybridAssembly](https://github.com/caspargross/HybridAssembly) written by Caspar Gross [@caspargross](https://github.com/caspargross)
 

--- a/bin/bigmag_summary.py
+++ b/bin/bigmag_summary.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import pandas as pd
+import re
+import argparse
+import sys
+import warnings
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--summary", metavar="FILE", help="Pipeline summary file.")
+    parser.add_argument("-g", "--gunc_summary", metavar="FILE", help="GUNC summary file.")
+    parser.add_argument("-a", "--alt_summary", metavar="FILE", help="BUSCO or CheckM2 summary file.")
+    parser.add_argument(
+        "-t", "--binqc_tool", help="Bin QC tool used", choices=["busco", "checkm", "checkm2"]
+    )
+
+    parser.add_argument(
+        "-o",
+        "--out",
+        required=True,
+        metavar="FILE",
+        type=argparse.FileType("w"),
+        help="Output file containing final bigmag summary.",
+    )
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    if (
+        not args.summary
+        and not args.gunc_summary
+        and not args.alt_summary
+    ):
+        sys.exit(
+            "No summary specified! "
+            "Please specify the pipeline summary, the GUNC summary and BUSCO or CheckM2 summary."
+        )
+
+    df_summary = pd.read_csv(args.summary, sep='\t', index_col=0)
+    for i in range(len(df_summary["bin"])):
+        name = df_summary["bin"][i]
+        name = re.sub(r'\.(fa|fasta)(\..*)?$', '', name)
+        df_summary.at[i,"bin"] = name
+        df_summary = df_summary.sort_values(by='bin')
+        df_summary["bin"] = df_summary["bin"].astype(str)
+    
+    df_gunc = pd.read_csv(args.gunc_summary, sep='\t')
+    df_gunc["genome"] = df_gunc["genome"].astype(str)
+    df_gunc = df_gunc.sort_values(by='genome')
+
+    df_alt = pd.read_csv(args.alt_summary, sep='\t')
+
+    column_names = ['genome']
+
+    if args.binqc_tool == "busco":
+        df_alt["Name"] = df_alt["Name"].astype(str)
+        df_alt = df_alt.sort_values(by='Name')
+        column_names.append("Name")
+
+    elif args.binqc_tool == "checkm" or args.binqc_tool == "checkm2":
+        for i in range(len(df_alt["Input_file"])):
+            name = df_alt["Input_file"][i]
+            name = re.sub(r'\.(fa|fasta)(\..*)?$', '', name)
+            df_alt.at[i,"Input_file"] = name
+            df_alt = df_alt.sort_values(by='Input_file')
+            df_alt["Input_file"] = df_alt["Input_file"].astype(str)
+        column_names.append("Input_file")
+
+    df_list = [df_gunc, df_alt]
+    for i in range(len(df_list)):
+        df_summary = pd.merge(df_summary, df_list[i], left_on='bin', right_on=column_names[i], how='left')
+    
+    df_summary.rename(columns={'bin': 'Bin'}, inplace=True)
+    
+    columns_to_remove = ['Name', "genome", 'Input_file', 'Assembly', 'Bin Id']
+    for column in df_summary.columns:
+        if column in columns_to_remove:
+            df_summary = df_summary.drop(columns=column)
+
+    df_summary['sample'] = None
+    for f in range(len(df_summary["Bin"])):
+        match = re.search(r'^.*?-.*?-(.*)$', df_summary["Bin"][f])
+        if match:
+            name = match.group(1)
+            name = re.sub(r'\.(unbinned|noclass)(\..*)?$', '', name)
+            name = re.sub(r'\.\d+(\.[^.]+)?$', '', name)
+            df_summary.at[f,"sample"] = name
+
+    df_summary.to_csv(args.out, sep="\t", index=True)
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -895,4 +895,20 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
+    withName: BIGMAG_SUMMARY {
+        publishDir = [
+            [
+                path: { "${params.outdir}/GenomeBinning/BIgMAG/" },
+                mode: params.publish_dir_mode,
+                pattern: '*.tsv',
+            ]
+        ]
+    }
+        withName: CONCAT_BIGMAG {
+        publishDir = [
+            path: { "${params.outdir}/GenomeBinning/QC" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -760,6 +760,15 @@ In cases where eukaryotic genomes are recovered in binning, [MetaEuk](https://gi
 
 </details>
 
+## Summary file to be used as input for BIgMAG
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `GenomeBinning/BIgMAG/bigmag_summary.tsv`: Summary of bin sequencing depths together with GUNC, QUAST, GTDB-Tk, BUSCO and CheckM or CheckM2 results. This file is suitable to be used as input for the dashboard BIgMAG. It is generated through a subworkflow that takes the file `bin_summary.tsv` as input, and it executes CheckM2 if BUSCO is the selected quality control tool or BUSCO if CheckM or CheckM2 was specified by the user as the main tool. By default the subworkflow will execute GUNC.
+
+</details>
+
 ## Ancient DNA
 
 Optional, only running when parameter `-profile ancient_dna` is specified.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -531,3 +531,7 @@ Up until version 4.0.0, this pipeline offered raw read taxonomic profiling using
 This feature was removed in version 5.0.0 to strengthen the pipeline's focus on metagenome assembly and binning.
 
 If you require taxonomic profiling of raw reads, we recommend using [nf-core/taxprofiler](https://nf-co.re/taxprofiler/), which is specifically designed for taxonomic profiling of raw reads and supports a wide range of tools for this purpose.
+
+## BIgMAG compatibility
+
+With the parameter `--bigmag` a subworkflow will be triggered to generate one and unique file that contains the ouput from all of the bin-quality tools and that can be used as input for the application [BIgMAG](https://github.com/jeffe107/BIgMAG).

--- a/modules/local/bigmag_summary/main.nf
+++ b/modules/local/bigmag_summary/main.nf
@@ -1,0 +1,36 @@
+process BIGMAG_SUMMARY {
+
+    conda "conda-forge::pandas=1.4.3"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/pandas:1.4.3'
+        : 'biocontainers/pandas:1.4.3'}"
+
+    input:
+    path summary
+    path gunc_sum
+    path alt_sum
+    val  binqc_tool
+
+    output:
+    path "bigmag_summary.tsv", emit: bigmag_summary
+    path "versions.yml"   , emit: versions
+
+    script:
+    def summary  = summary.sort().size() > 0 ? "--summary ${summary}" : ""
+    def gunc_summary  = gunc_sum.sort().size() > 0 ? "--gunc_summary ${gunc_sum}" : ""
+    def alt_summary = alt_sum.sort().size() > 0 ? "--alt_summary ${alt_sum}" : ""
+    """
+    bigmag_summary.py \
+        ${summary} \
+        ${gunc_summary} \
+        ${alt_summary} \
+        --binqc_tool ${binqc_tool} \
+        --out bigmag_summary.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        pandas: \$(python -c "import pkg_resources; print(pkg_resources.get_distribution('pandas').version)")
+    END_VERSIONS
+    """
+}

--- a/modules/local/concat_bigmag/main.nf
+++ b/modules/local/concat_bigmag/main.nf
@@ -1,0 +1,55 @@
+process CONCAT_BIGMAG {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/csvtk:0.31.0--h9ee0642_0' :
+        'biocontainers/csvtk:0.31.0--h9ee0642_0' }"
+
+    input:
+    tuple val(meta), path(csv, name: 'inputs/csv*/*')
+    val in_format
+    val out_format
+
+    output:
+    tuple val(meta), path("${prefix}.${out_extension}"), emit: csv
+    path "versions.yml"                                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix = params.binqc_tool == 'busco' ? 'checkm2_summary' : 'busco_summary'
+    def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
+    def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
+    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    """
+    csvtk \\
+        concat \\
+        $args \\
+        --num-cpus $task.cpus \\
+        --delimiter "${delimiter}" \\
+        --out-delimiter "${out_delimiter}" \\
+        --out-file ${prefix}.${out_extension} \\
+        $csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        csvtk: \$(echo \$( csvtk version | sed -e "s/csvtk v//g" ))
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = params.binqc_tool == 'busco' ? 'checkm2_summary' : 'busco_summary'
+    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    """
+    touch ${prefix}.${out_extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        csvtk: \$(echo \$( csvtk version | sed -e "s/csvtk v//g" ))
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -159,6 +159,7 @@ params {
     gunc_database_type                   = 'progenomes'
     gunc_db                              = null
     gunc_save_db                         = false
+    bigmag                               = false
 
     // Reproducibility options
     megahit_fix_cpu_1                    = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -966,6 +966,11 @@
                     "type": "boolean",
                     "description": "Save the used GUNC reference files downloaded when not using --gunc_db parameter.",
                     "help_text": "If specified, the corresponding DIAMOND file downloaded from the GUNC server will be stored in your output directory alongside your GUNC results."
+                },
+                "bigmag": {
+                    "type": "boolean",
+                    "description": "Make the file bin_summary.tsv suitable for the application BIgMAG.",
+                    "help_text": "If specified, BUSCO, ChecKM2 and GUNC will be executed simultaneously."
                 }
             }
         },

--- a/subworkflows/local/bigmag/main.nf
+++ b/subworkflows/local/bigmag/main.nf
@@ -1,0 +1,146 @@
+/*
+ * BUSCO/CheckM2: Alternative workflow to run the missing QC tool to create the file for BIgMAG
+ */
+
+include { BUSCO_BUSCO                      } from '../../../modules/nf-core/busco/busco/main'
+include { CHECKM2_DATABASEDOWNLOAD         } from '../../../modules/nf-core/checkm2/databasedownload/main'
+include { CHECKM2_PREDICT                  } from '../../../modules/nf-core/checkm2/predict/main'
+include { UNTAR as BUSCO_UNTAR             } from '../../../modules/nf-core/untar/main'
+include { BIGMAG_SUMMARY                   } from '../../../modules/local/bigmag_summary/main'
+include { GUNC_DOWNLOADDB                  } from '../../../modules/nf-core/gunc/downloaddb/main'
+include { GUNC_RUN                         } from '../../../modules/nf-core/gunc/run/main'
+include { CONCAT_BIGMAG                    } from '../../../modules/local/concat_bigmag/main'
+
+workflow BIGMAG {
+    take:
+    ch_bins // [ [ meta] , fasta ], input bins (mandatory)
+    summary // Output from BIN_SUMMARY
+
+    main:
+    ch_input_bins_for_qc = ch_bins.transpose()
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
+    /*
+    ================================
+     * Setup databases
+    ================================
+     */
+
+    if (params.busco_db) {
+        ch_busco_db = file(params.busco_db, checkIfExists: true)
+    }
+    else {
+        ch_busco_db = []
+    }
+
+    if (params.checkm2_db) {
+        ch_checkm2_db = [[:], file(params.checkm2_db, checkIfExists: true)]
+    }
+    else if (params.binqc_tool == 'busco') {
+        CHECKM2_DATABASEDOWNLOAD(params.checkm2_db_version)
+        ch_checkm2_db = CHECKM2_DATABASEDOWNLOAD.out.database
+    }
+    else {
+        ch_checkm2_db = []
+    }
+
+    if (params.gunc_db) {
+        ch_gunc_db = file(params.gunc_db, checkIfExists: true)
+    }
+    else {
+        ch_gunc_db = Channel.empty()
+    }
+
+    /*
+    ================================
+     * Run QC tools
+    ================================
+     */
+
+    if (params.binqc_tool == "checkm" || params.binqc_tool == "checkm2") {
+        /*
+         * BUSCO
+         */
+
+        // Prepare database object depending on type
+        // If directory, assumes sub structure of `params.busco_db/lineages/<taxa>_odb(10|12)`
+        if (ch_busco_db && ch_busco_db.extension in ['gz', 'tgz']) {
+            BUSCO_UNTAR([[id: ch_busco_db.getSimpleName()], ch_busco_db])
+            ch_busco_db = BUSCO_UNTAR.out.untar.map { it[1] }
+        }
+        else if (ch_busco_db && ch_busco_db.isDirectory()) {
+            ch_busco_db = ch_busco_db
+        }
+        else {
+            ch_busco_db = []
+        }
+
+        BUSCO_BUSCO(ch_bins, 'genome', params.busco_db_lineage, ch_busco_db, [], params.busco_clean)
+
+        ch_alt_summary = BUSCO_BUSCO.out.batch_summary
+            .map { _meta, summary -> [[id: 'busco'], summary] }
+            .groupTuple()
+        ch_versions = ch_versions.mix(BUSCO_BUSCO.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(
+            BUSCO_BUSCO.out.short_summaries_txt.map { it[1] }.flatten()
+        )
+    }
+    else if (params.binqc_tool == "busco") {
+        /*
+         * CheckM2
+         */
+        CHECKM2_PREDICT(ch_input_bins_for_qc.groupTuple(), ch_checkm2_db)
+
+        ch_alt_summary = CHECKM2_PREDICT.out.checkm2_tsv
+            .map { _meta, summary -> [[id: 'checkm2'], summary] }
+            .groupTuple()
+        ch_versions = ch_versions.mix(CHECKM2_PREDICT.out.versions.first())
+    }
+
+ if (params.run_gunc) {
+    ch_gunc_summary = Channel.fromPath( "${params.outdir}/GenomeBinning/QC/gunc_summary.tsv" )
+    }
+
+ else if (!params.run_gunc) {
+        /*
+         * GUNC
+         */
+        ch_input_bins_for_gunc = ch_bins.filter { meta, _bins ->
+            meta.domain != "eukarya"
+        }
+
+        if (params.gunc_db) {
+            ch_db_for_gunc = ch_gunc_db
+        }
+        else {
+            ch_db_for_gunc = GUNC_DOWNLOADDB(params.gunc_database_type).db
+            ch_versions.mix(GUNC_DOWNLOADDB.out.versions)
+        }
+
+        GUNC_RUN(ch_input_bins_for_gunc, ch_db_for_gunc)
+        ch_versions.mix(GUNC_RUN.out.versions)
+
+        // Make sure to keep directory in sync with modules.conf
+        ch_gunc_summary = GUNC_RUN.out.maxcss_level_tsv
+            .map { _meta, gunc_summary -> gunc_summary }
+            .collectFile(
+                name: "gunc_summary.tsv",
+                keepHeader: true,
+                storeDir: "${params.outdir}/GenomeBinning/QC/",
+            )
+    }
+
+    // Combine summaries
+    CONCAT_BIGMAG (ch_alt_summary, 'tsv', 'tsv')
+    ch_missing_summary = CONCAT_BIGMAG.out.csv.map { _meta, summary -> summary }
+    ch_versions = ch_versions.mix(CONCAT_BIGMAG.out.versions)
+    
+    BIGMAG_SUMMARY(summary, ch_gunc_summary, ch_missing_summary, params.binqc_tool)
+    ch_versions = ch_versions.mix(BIGMAG_SUMMARY.out.versions)
+
+    emit:
+    bigmag_summary  = BIGMAG_SUMMARY.out.bigmag_summary
+    multiqc_files   = ch_multiqc_files
+    versions        = ch_versions
+}

--- a/subworkflows/local/bigmag/meta.yml
+++ b/subworkflows/local/bigmag/meta.yml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "bigmag"
+description: Executing alternative tools to complete the required input file for BIgMAG dashboard
+keywords:
+  - quality control
+  - bins
+  - metagenomics
+  - busco
+  - checkm2
+  - gunc
+components:
+  - busco/busco
+  - checkm2/databasedownload
+  - checkm2/predict
+  - concat_bigmag
+  - bigmag_summary
+  - gunc/downloaddb
+  - gunc/run
+  - untar
+input:
+  - ch_bins:
+      description: Metagenomic bins in FASTA format
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - fasta:
+            type: file
+            description: Metagenomic bins in FASTA format
+            pattern: "*.{fasta,fa}"
+  - summary:
+      description: Bin summary
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - fasta:
+            type: file
+            description: Bin summary as TSV file
+            pattern: "*.tsv"
+output:
+  - bigmag_summary:
+      description: Combined quality assessment summary
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - tsv:
+            type: file
+            description: Summary in TSV format ready to be used for BIgMAG
+            pattern: "*.tsv"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - multiqc_files:
+      description: MultiQC files for quality control statistics
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - "*":
+            type: file
+            description: MultiQC report files
+            pattern: "*"
+authors:
+  - "@jeffe107"
+maintainers:
+  - "@jfy133"
+  - "@prototaxites"
+  - "@dialvarezs"
+  - "@d4straub"
+  - "@muabnezor"

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -25,7 +25,7 @@ include { LONGREAD_PREPROCESSING          } from '../subworkflows/local/preproce
 include { SHORTREAD_PREPROCESSING         } from '../subworkflows/local/preprocessing_shortread/main'
 include { ASSEMBLY                        } from '../subworkflows/local/assembly/main'
 include { CATPACK                         } from '../subworkflows/local/catpack/main'
-
+include { BIGMAG                          } from '../subworkflows/local/bigmag/main'
 //
 // MODULE: Installed directly from nf-core/modules
 //
@@ -460,6 +460,13 @@ workflow MAG {
                 params.binqc_tool,
             )
             ch_versions = ch_versions.mix(BIN_SUMMARY.out.versions)
+        }
+        if (params.bigmag && !params.skip_binqc) {
+            BIGMAG(ch_input_for_postbinning,
+                   BIN_SUMMARY.out.summary,
+                   )
+            ch_bigmag_summary = BIGMAG.out.bigmag_summary
+            ch_versions = ch_versions.mix(BIGMAG.out.versions)
         }
 
         /*


### PR DESCRIPTION
Hello,

I apologize for creating a new PR, I couldn't force the previous one to take the changes from dev branch. I include again my message, and in the next comment I will post your comments from the previous PR.

According to issue [#859 ] to produce the file that is used as input for [BIgMAG](https://github.com/jeffe107/BIgMAG) I have included the following:

I didn't want to mess with the current state of the pipeline, so I included a subworkflow that handles the execution in this manner:

- If BUSCO (default tool) is selected as QC tool, it will trigger CheckM2. If the user selects CheckM or CheckM2, BUSCO will be executed then.
- It runs GUNC by default. It is aware that GUNC can be run within the subworkflow BIN_QC, so it adjusted to that situation.
- It takes as input the global bin_summary file.
- Two modules were added: concat_bigmag.nf and bigmag_summary.nf. The first performs the merge of the TSV files just like CSVTK_CONCAT. I had to create it because if I call the same module, it would overwrite the summary file in the GenomeBinning folder, but in essence they are the same module. The second one joins all of the files (bin_summary, alternative_tool and gunc_summary). bigmag_summary.nf executes the script bigmag_summary.py found in the folder _bin_.

## PR checklist

- [ ✓] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ✓] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ✓] Usage Documentation in `docs/usage.md` is updated.
- [ ✓] Output Documentation in `docs/output.md` is updated.
- [ ✓] `CHANGELOG.md` is updated.
- [ ✓] `README.md` is updated (including new tool citations and authors/contributors).
