### PR TITLE
Fix when there are no too short contigs for MetaBinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#927](https://github.com/nf-core/mag/pull/927) - MetaBinner now succeeds when no contigs are too short or all are binned (by @d4straub)
+
 ### `Dependencies`
 
 | Tool | Previous version | New version |

--- a/modules/local/metabinner_bins/main.nf
+++ b/modules/local/metabinner_bins/main.nf
@@ -13,10 +13,10 @@ process METABINNER_BINS {
     val val_min_contig_size
 
     output:
-    tuple val(meta), path("*.tooShort.fa.gz")         , emit: tooshort
-    tuple val(meta), path("*.unbinned.fa.gz")         , emit: unbinned
-    tuple val(meta), path("bins/*.fa.gz")             , emit: bins
-    path "versions.yml"                               , emit: versions
+    tuple val(meta), path("*.tooShort.fa.gz"), optional: true, emit: tooshort
+    tuple val(meta), path("*.unbinned.fa.gz"), optional: true, emit: unbinned
+    tuple val(meta), path("bins/*.fa.gz")                    , emit: bins
+    path "versions.yml"                                      , emit: versions
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"


### PR DESCRIPTION
Closes https://github.com/nf-core/mag/issues/926

Added optional output to METABINNER_BINS to succeed when no contigs are too short or unbinned.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
