### PR TITLE
Re-add contigs vs scaffolds metaSPAdes selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#974](https://github.com/nf-core/mag/pull974) - Re-add accidently removed functionality for using metaSPAdes contigs downstream rather than scaffolds (reported by @Pranjal-Bioinfo, fix by @jfy133)
+
 ### `Dependencies`
 
 | Tool | Previous version | New version |

--- a/subworkflows/local/assembly_shortread/main.nf
+++ b/subworkflows/local/assembly_shortread/main.nf
@@ -5,7 +5,7 @@ include { SPADES as METASPADES } from '../../../modules/nf-core/spades/main'
 workflow SHORTREAD_ASSEMBLY {
     take:
     ch_short_reads_grouped // [val(meta), path(fastq1), path(fastq2)] (mandatory)
-    ch_short_reads_spades  // [val(meta), path(fastq1)]               (mandatory)
+    ch_short_reads_spades // [val(meta), path(fastq1)]               (mandatory)
 
     main:
     ch_versions = channel.empty()
@@ -13,7 +13,7 @@ workflow SHORTREAD_ASSEMBLY {
 
     if (!params.single_end && !params.skip_spades) {
         METASPADES(ch_short_reads_spades.map { meta, reads -> [meta, reads, [], []] }, [], [])
-        ch_spades_assemblies = METASPADES.out.scaffolds.map { meta, assembly ->
+        ch_spades_assemblies = (params.spades_downstreaminput == 'contigs' ? METASPADES.out.contigs : METASPADES.out.scaffolds).map { meta, assembly ->
             def meta_new = meta + [assembler: 'SPAdes']
             [meta_new, assembly]
         }


### PR DESCRIPTION
Re-adds functionality added in #745 

Was accidently lost during the re-factoring of the assembly steps to workflows due to concurent development.

Reported https://nfcore.slack.com/archives/CE9MS66BS/p1770452516999219

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
