### PR TITLE
Revert CheckM2 database download workaround and update modules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -88,12 +88,12 @@
                     },
                     "checkm2/databasedownload": {
                         "branch": "master",
-                        "git_sha": "bcba09053293bbc4fcfecbe094af6d0127f2e0ec",
+                        "git_sha": "81470b59ebadb3d01dcfcd37d44f88eb890f4851",
                         "installed_by": ["modules"]
                     },
                     "checkm2/predict": {
                         "branch": "master",
-                        "git_sha": "92c71995da96e0e01946156302997cc86f9324c6",
+                        "git_sha": "81470b59ebadb3d01dcfcd37d44f88eb890f4851",
                         "installed_by": ["modules"]
                     },
                     "chopper": {

--- a/modules/nf-core/checkm2/databasedownload/main.nf
+++ b/modules/nf-core/checkm2/databasedownload/main.nf
@@ -24,13 +24,17 @@ process CHECKM2_DATABASEDOWNLOAD {
 
     output:
     tuple val(meta), path("checkm2_db_v${db_version}.dmnd"), emit: database
-    path("versions.yml")                                   , emit: versions
+    tuple val("${task.process}"), val('aria2'), eval("aria2c --version 2>&1 | sed '1s/[^ ]* [^ ]* //; q'"), topic: versions, emit: versions_checkm2_databasedownload
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args ?: ''
+    def args = task.ext.args ?: ''
+    // Append user-agent if not already present
+    if( !args.contains('--user-agent') ) {
+        args = args ? "${args} --user-agent=\"Wget/1.21.4\"" : '--user-agent="Wget/1.21.4"'
+    }
     zenodo_id  = db_zenodo_id ?: 14897628  // Default to version 3 if no ID provided
     api_data   = downloadZenodoApiEntry(zenodo_id)
     db_version = api_data.metadata.version
@@ -48,10 +52,8 @@ process CHECKM2_DATABASEDOWNLOAD {
     db_path=\$(find -name *.dmnd)
     mv \$db_path checkm2_db_v${db_version}.dmnd
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        aria2: \$(echo \$(aria2c --version 2>&1) | grep 'aria2 version' | cut -f3 -d ' ')
-    END_VERSIONS
+    # cleanup
+    rm -f checkm2_database.tar.gz
     """
 
     stub:
@@ -59,10 +61,5 @@ process CHECKM2_DATABASEDOWNLOAD {
     meta       = [id: 'checkm2_db', version: db_version]
     """
     touch checkm2_db_v${db_version}.dmnd
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        aria2: \$(echo \$(aria2c --version 2>&1) | grep 'aria2 version' | cut -f3 -d ' ')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/checkm2/databasedownload/meta.yml
+++ b/modules/nf-core/checkm2/databasedownload/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "checkm2_databasedownload"
 description: CheckM2 database download
 keywords:
@@ -16,12 +15,10 @@ tools:
       doi: "10.1038/s41592-023-01940-w"
       licence: ["GPL v3"]
       identifier: ""
-
 input:
   - db_zenodo_id:
       type: integer
       description: Zenodo ID of the CheckM2 database to download
-
 output:
   database:
     - - meta:
@@ -34,12 +31,29 @@ output:
           description: CheckM2 database file
           pattern: "checkm2_db_v*.dmnd"
           ontologies: []
+  versions_checkm2_databasedownload:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - aria2:
+          type: string
+          description: The tool name
+      - "aria2c --version 2>&1 | sed '1s/[^ ]* [^ ]* //; q'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - aria2:
+          type: string
+          description: The tool name
+      - "aria2c --version 2>&1 | sed '1s/[^ ]* [^ ]* //; q'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@dialvarezs"
+  - "@eit-maxlcummins"

--- a/modules/nf-core/checkm2/databasedownload/tests/main.nf.test
+++ b/modules/nf-core/checkm2/databasedownload/tests/main.nf.test
@@ -21,7 +21,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.versions).match() },
+                { assert path(process.out.database.get(0).get(1)).exists() },
+                { assert snapshot(
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() },
             )
         }
 
@@ -42,7 +44,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.versions).match() },
+                { assert path(process.out.database.get(0).get(1)).exists() },
+                { assert snapshot(
+                    process.out.findAll { key, val -> key.startsWith('versions') }).match() },
             )
         }
 

--- a/modules/nf-core/checkm2/databasedownload/tests/main.nf.test.snap
+++ b/modules/nf-core/checkm2/databasedownload/tests/main.nf.test.snap
@@ -1,26 +1,38 @@
 {
     "test_checkm2_databasedownload": {
         "content": [
-            [
-                "versions.yml:md5,74b6560ab3e6bae88ae53cb8ae3c283e"
-            ]
+            {
+                "versions_checkm2_databasedownload": [
+                    [
+                        "CHECKM2_DATABASEDOWNLOAD",
+                        "aria2",
+                        "1.37.0"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-03-13T21:41:14.428719466"
+        "timestamp": "2026-01-23T09:04:29.73758792"
     },
     "test_checkm2_databasedownload - stub": {
         "content": [
-            [
-                "versions.yml:md5,74b6560ab3e6bae88ae53cb8ae3c283e"
-            ]
+            {
+                "versions_checkm2_databasedownload": [
+                    [
+                        "CHECKM2_DATABASEDOWNLOAD",
+                        "aria2",
+                        "1.37.0"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-03-13T21:41:24.118075242"
+        "timestamp": "2026-01-29T15:49:13.916311854"
     }
 }

--- a/modules/nf-core/checkm2/predict/environment.yml
+++ b/modules/nf-core/checkm2/predict/environment.yml
@@ -5,3 +5,10 @@ channels:
   - bioconda
 dependencies:
   - bioconda::checkm2=1.1.0
+  - conda-forge::keras=3.9.0
+  - conda-forge::numpy=1.26.4
+  - conda-forge::pandas=2.2.3
+  - conda-forge::python=3.12.9
+  - conda-forge::scikit-learn=1.6.1
+  - conda-forge::scipy=1.15.2
+  - conda-forge::tensorflow=2.17.0

--- a/modules/nf-core/checkm2/predict/main.nf
+++ b/modules/nf-core/checkm2/predict/main.nf
@@ -3,18 +3,18 @@ process CHECKM2_PREDICT {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0a/0af812c983aeffc99c0fca9ed2c910816b2ddb9a9d0dcad7b87dab0c9c08a16f/data'
-        : 'community.wave.seqera.io/library/checkm2:1.1.0--60f287bc25d7a10d'}"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0a/0af812c983aeffc99c0fca9ed2c910816b2ddb9a9d0dcad7b87dab0c9c08a16f/data':
+        'community.wave.seqera.io/library/checkm2:1.1.0--60f287bc25d7a10d' }"
 
     input:
     tuple val(meta), path(fasta, stageAs: "input_bins/*")
     tuple val(dbmeta), path(db)
 
     output:
-    tuple val(meta), path("${prefix}"), emit: checkm2_output
+    tuple val(meta), path("${prefix}")                   , emit: checkm2_output
     tuple val(meta), path("${prefix}_checkm2_report.tsv"), emit: checkm2_tsv
-    path ("versions.yml"), emit: versions
+    tuple val("${task.process}"), val('checkm2'), eval('checkm2 --version'), topic: versions, emit: versions_checkm2_predict
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,22 +23,15 @@ process CHECKM2_PREDICT {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    export DB=\$(find -L . -name "*.dmnd" -type f)
-
     checkm2 \\
         predict \\
         --input ${fasta} \\
         --output-directory ${prefix} \\
         --threads ${task.cpus} \\
-        --database_path \$DB \\
+        --database_path ${db} \\
         ${args}
 
     cp ${prefix}/quality_report.tsv ${prefix}_checkm2_report.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        checkm2: \$(checkm2 --version)
-    END_VERSIONS
     """
 
     stub:
@@ -46,10 +39,5 @@ process CHECKM2_PREDICT {
     """
     mkdir ${prefix}/
     touch ${prefix}_checkm2_report.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        checkm2: \$(checkm2 --version)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/checkm2/predict/meta.yml
+++ b/modules/nf-core/checkm2/predict/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "checkm2_predict"
 description: CheckM2 bin quality prediction
 keywords:
@@ -16,7 +15,6 @@ tools:
       doi: "10.1038/s41592-023-01940-w"
       licence: ["GPL v3"]
       identifier: ""
-
 input:
   - - meta:
         type: map
@@ -60,12 +58,27 @@ output:
           pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_checkm2_predict:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - checkm2:
+          type: string
+          description: The name of the tool
+      - "checkm2 --version":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - checkm2:
+          type: string
+          description: The name of the tool
+      - "checkm2 --version":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@dialvarezs"
+  - "@eit-maxlcummins"

--- a/modules/nf-core/checkm2/predict/tests/main.nf.test
+++ b/modules/nf-core/checkm2/predict/tests/main.nf.test
@@ -5,18 +5,16 @@ nextflow_process {
     tag "modules"
     tag "checkm2"
     tag "checkm2/predict"
-    tag "untar"
+    tag "checkm2/databasedownload"
     script "modules/nf-core/checkm2/predict/main.nf"
     process "CHECKM2_PREDICT"
 
     setup {
-            run("UNTAR") {
-                script "../../../untar/main.nf"
+            run("CHECKM2_DATABASEDOWNLOAD") {
+                script "../../databasedownload/main.nf"
                 process {
                     """
-                    input[0] = channel
-                        .fromPath("https://zenodo.org/records/14897628/files/checkm2_database.tar.gz", checkIfExists: true)
-                        .map { dbfile -> [ [id: 'checkm2db'], dbfile ] }
+                    input[0] = []
                     """
                 }
             }
@@ -31,7 +29,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [id: 'test'], [file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true)] ]
-                input[1] = UNTAR.out.untar
+                input[1] = CHECKM2_DATABASEDOWNLOAD.out.database
                 """
             }
         }
@@ -39,7 +37,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.checkm2_tsv, process.out.versions).match() }
+                { assert snapshot(process.out.checkm2_tsv, process.out.findAll { key, val -> key.startsWith('versions') }).match() }
             )
         }
     }
@@ -55,7 +53,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [id: 'test'], [file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true)] ]
-                input[1] = UNTAR.out.untar
+                input[1] = CHECKM2_DATABASEDOWNLOAD.out.database
                 """
             }
         }
@@ -63,7 +61,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.checkm2_tsv, process.out.versions).match() }
+                { assert snapshot(process.out.checkm2_tsv, process.out.findAll { key, val -> key.startsWith('versions') }).match() }
             )
         }
     }

--- a/modules/nf-core/checkm2/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/checkm2/predict/tests/main.nf.test.snap
@@ -9,15 +9,21 @@
                     "test_checkm2_report.tsv:md5,1b6021262d336b21f526d8369f6ddd3f"
                 ]
             ],
-            [
-                "versions.yml:md5,f13e02312d6a08ca746e6de2659d8195"
-            ]
+            {
+                "versions_checkm2_predict": [
+                    [
+                        "CHECKM2_PREDICT",
+                        "checkm2",
+                        "1.1.0"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-03-13T15:23:26.857419645"
+        "timestamp": "2026-01-30T09:44:45.556228913"
     },
     "test_checkm2_predict - stub": {
         "content": [
@@ -29,14 +35,20 @@
                     "test_checkm2_report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
-            [
-                "versions.yml:md5,f13e02312d6a08ca746e6de2659d8195"
-            ]
+            {
+                "versions_checkm2_predict": [
+                    [
+                        "CHECKM2_PREDICT",
+                        "checkm2",
+                        "1.1.0"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-03-13T15:23:40.153127645"
+        "timestamp": "2026-01-23T09:28:10.0910672"
     }
 }

--- a/subworkflows/local/bin_qc/main.nf
+++ b/subworkflows/local/bin_qc/main.nf
@@ -3,8 +3,7 @@
  */
 
 include { BUSCO_BUSCO                       } from '../../../modules/nf-core/busco/busco/main'
-// 2016-01-19: Temporarily diabling Checkm2 database downloading due to Zenodo blocking Aria2 downloads
-//include { CHECKM2_DATABASEDOWNLOAD      } from '../../../modules/nf-core/checkm2/databasedownload/main'
+include { CHECKM2_DATABASEDOWNLOAD          } from '../../../modules/nf-core/checkm2/databasedownload/main'
 include { CHECKM_QA                         } from '../../../modules/nf-core/checkm/qa/main'
 include { CHECKM_LINEAGEWF                  } from '../../../modules/nf-core/checkm/lineagewf/main'
 include { CHECKM2_PREDICT                   } from '../../../modules/nf-core/checkm2/predict/main'
@@ -18,7 +17,6 @@ include { GUNC_RUN                          } from '../../../modules/nf-core/gun
 include { GUNC_MERGECHECKM                  } from '../../../modules/nf-core/gunc/mergecheckm/main'
 include { UNTAR as BUSCO_UNTAR              } from '../../../modules/nf-core/untar/main'
 include { UNTAR as CHECKM_UNTAR             } from '../../../modules/nf-core/untar/main'
-include { UNTAR as CHECKM2_UNTAR            } from '../../../modules/nf-core/untar/main'
 
 
 workflow BIN_QC {
@@ -67,14 +65,8 @@ workflow BIN_QC {
         ch_checkm2_db = [[:], file(params.checkm2_db, checkIfExists: true)]
     }
     else if (params.run_checkm2) {
-        // 2016-01-19: Temporarily diabling Checkm2 database downloading due to Zenodo blocking Aria2 downloads
-        //CHECKM2_DATABASEDOWNLOAD(params.checkm2_db_version)
-        //ch_versions = ch_versions.mix(CHECKM2_DATABASEDOWNLOAD.out.versions)
-        ch_checkm2_tar = channel.fromPath("https://zenodo.org/records/${params.checkm2_db_version}/files/checkm2_database.tar.gz", checkIfExists: true)
-            .map { db_tar -> [[id: 'checkm2_db', version: params.checkm2_db_version], db_tar] }
-        CHECKM2_UNTAR(ch_checkm2_tar)
-        ch_checkm2_db = CHECKM2_UNTAR.out.untar
-        ch_versions = ch_versions.mix(CHECKM2_UNTAR.out.versions)
+        CHECKM2_DATABASEDOWNLOAD(params.checkm2_db_version)
+        ch_checkm2_db = CHECKM2_DATABASEDOWNLOAD.out.database
     }
     else {
         ch_checkm2_db = []
@@ -172,7 +164,6 @@ workflow BIN_QC {
          * CheckM2
          */
         CHECKM2_PREDICT(ch_input_bins_for_qc.groupTuple(), ch_checkm2_db)
-        ch_versions = ch_versions.mix(CHECKM2_PREDICT.out.versions)
 
         ch_checkm2_summaries = CHECKM2_PREDICT.out.checkm2_tsv
             .map { _meta, summary -> [[id: 'checkm2'], summary] }

--- a/tests/test_alternatives.nf.test.snap
+++ b/tests/test_alternatives.nf.test.snap
@@ -36,11 +36,11 @@
                 "BUSCO_BUSCO": {
                     "busco": "6.0.0"
                 },
+                "CHECKM2_DATABASEDOWNLOAD": {
+                    "aria2": "1.37.0"
+                },
                 "CHECKM2_PREDICT": {
                     "checkm2": "1.1.0"
-                },
-                "CHECKM2_UNTAR": {
-                    "untar": 1.34
                 },
                 "CONCAT_BUSCO_TSV": {
                     "qsv": "5.1.0"
@@ -114,7 +114,7 @@
                 }
             }
         ],
-        "timestamp": "2026-04-01T14:55:43.449448611",
+        "timestamp": "2026-04-02T10:04:53.615386693",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"


### PR DESCRIPTION
This PR updates CheckM2 modules to newer versions using topics.
And also reverts the workaround introduced in #966 since it's no longer necessary, because the module was patched to set the UA in https://github.com/nf-core/modules/pull/9744

But, more importantly, the workaround introduced a bug that we didn't notice: the CheckM2 database channel was being consumed after one process, so CheckM2 (and so GTDB-TK that depends on the Bin QC channel) was effectively executing only for one bin/unbin set.

I detected this recently looking at full tests runs on Seqera Cloud:
<img width="1521" height="1100" alt="image" src="https://github.com/user-attachments/assets/facc291c-24e9-4707-a73a-9039e006a1b7" />
You see only 1 CheckM2 and 0 GTDB-Tk jobs because CheckM2 processed an "unbin" set, so it didn't make the cut for the qc threshold.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
