### PR TITLE
Prevent running ALE on long read data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1012](https://github.com/nf-core/mag/pull/1012) - Prevent adapter trimming with Porechop on PacBio reads (by @dialvarezs)
 - [#1011](https://github.com/nf-core/mag/pull/1011) - Fix issue making CheckM2 running only for one sample per run (by @dialvarezs)
+- [#1017](https://github.com/nf-core/mag/pull/1017) - Prevent ALE running on long read assemblies when a sample has both LR and SR data (reported by @jfy133, fix by @dialvarezs)
 
 ### `Dependencies`
 

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -275,12 +275,8 @@ workflow MAG {
     */
 
     if (!params.skip_ale) {
-        ch_shortread_assemblies_for_ale = ch_assemblies.filter { meta, _assembly ->
-            meta.sr_platform != null && meta.sr_platform != []
-        }
-
         ch_ale_input = BINNING_PREPARATION.out.grouped_mappings
-            .join(ch_shortread_assemblies_for_ale, by: 0)
+            .join(ch_shortread_assemblies, by: 0)
             .map { meta, _contigs, bams, _bais, assembly ->
                 // Try to find the BAM where reads came from the same sample as the assembly (co-binning may include multiple BAMs)
                 // If none matches (coassembly), take the first one after sorting for determinism


### PR DESCRIPTION
Right now we were depending on a filter on `sr_platform` to determine if ALE should be run for an assembly.
The problem with this is that if a sample has both longread and shortread data, it will run for the LR assembly too, failing as we have seen in the full tests.
The solution is to just use `ch_shortread_assemblies` instead.

Fixes #974.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
