### PR TITLE
Prevent execution of `gtdbtk/summary` when no bins pass QC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1012](https://github.com/nf-core/mag/pull/1012) - Prevent adapter trimming with Porechop on PacBio reads (by @dialvarezs)
 - [#1011](https://github.com/nf-core/mag/pull/1011) - Fix issue making CheckM2 running only for one sample per run (by @dialvarezs)
 - [#1017](https://github.com/nf-core/mag/pull/1017) - Prevent ALE running on long read assemblies when a sample has both LR and SR data (reported by @jfy133, fix by @dialvarezs)
+- [#1021](https://github.com/nf-core/mag/pull/1021) - Prevent execution of `gtdbtk/summary` when no bins pass QC (reported by @jfy133, fix by @dialvarezs)
 
 ### `Dependencies`
 

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -86,7 +86,7 @@ workflow GTDBTK {
         .count()
         .filter { count -> count == 0 }
         .subscribe { _count ->
-            log.warn("No bin QC results were available. Skipping GTDB-Tk classification.")
+            log.warn("[nf-core/mag] No bin QC results were available. Skipping GTDB-Tk classification.")
         }
 
     GTDBTK_CLASSIFYWF(
@@ -102,7 +102,7 @@ workflow GTDBTK {
         .combine(ch_filtered_bins.discarded.count())
         .subscribe { passed, failed ->
             if ((passed + failed) > 0 && passed == 0) {
-                log.warn("No contigs passed GTDB-TK min. completeness filters.")
+                log.warn("[nf-core/mag] No contigs passed GTDB-TK min. completeness filters. GTDB-Tk will not be executed.")
             }
         }
 

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -81,6 +81,14 @@ workflow GTDBTK {
         error("Unsupported object given to --gtdb, database must be supplied as either a directory or a .tar.gz file!")
     }
 
+    // Warn if no QC data was available (all QC tools likely failed)
+    ch_bin_qc_summary
+        .count()
+        .filter { count -> count == 0 }
+        .subscribe { _count ->
+            log.warn("No bin QC results were available. Skipping GTDB-Tk classification.")
+        }
+
     GTDBTK_CLASSIFYWF(
         ch_filtered_bins.passed.groupTuple(),
         ch_db_for_gtdbtk,
@@ -94,20 +102,22 @@ workflow GTDBTK {
         .combine(ch_filtered_bins.discarded.count())
         .subscribe { passed, failed ->
             if ((passed + failed) > 0 && passed == 0) {
-                log.warn("No contigs passed GTDB-TK min. completeness filters. GTDB-TK summary will execute but results will be empty!")
+                log.warn("No contigs passed GTDB-TK min. completeness filters.")
             }
         }
 
     GTDBTK_SUMMARY(
         ch_filtered_bins.discarded.map { _meta, bin -> bin }.collect().ifEmpty([]),
-        GTDBTK_CLASSIFYWF.out.summary.map { _meta, summary -> summary }.collect().ifEmpty { ([]) },
+        GTDBTK_CLASSIFYWF.out.summary.map { _meta, summary -> summary }.collect(),
         [],
         [],
     )
+
+    ch_summary = channel.empty().mix(GTDBTK_SUMMARY.out.summary)
     ch_versions = ch_versions.mix(GTDBTK_SUMMARY.out.versions)
 
     emit:
-    summary       = GTDBTK_SUMMARY.out.summary
-    multiqc_files = GTDBTK_SUMMARY.out.summary
+    summary       = ch_summary
+    multiqc_files = ch_summary
     versions      = ch_versions
 }


### PR DESCRIPTION
This removes the `.ifEmpty()` of `GTDBTK_CLASSIFYWF.out.summary`  to prevent running `GTDBTK_SUMMARY` when no summaries are available.
It also adds a warning when no bins passed QC thresholds.

Closes #981.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
