### PR TITLE
fix: use gunc test db from nf-core/test-datastes

### DIFF
--- a/conf/test_assembly_input.config
+++ b/conf/test_assembly_input.config
@@ -56,7 +56,7 @@ params {
     exclude_unbins_from_postbinning = true
 
     run_gunc                        = true
-    gunc_database_type              = 'test_data'
+    gunc_db                         = params.pipelines_testdata_base_path + 'mag/databases/gunc/ci_test.dmnd'
 
     skip_metaeuk                    = false
     metaeuk_mmseqs_db               = 'Kalamari'

--- a/tests/test_assembly_input.nf.test.snap
+++ b/tests/test_assembly_input.nf.test.snap
@@ -65,7 +65,7 @@
     },
     "-profile assembly_input": {
         "content": [
-            286,
+            285,
             {
                 "ADJUST_MAXBIN2_EXT": {
                     "coreutils": 9.5
@@ -121,9 +121,6 @@
                 "FASTQC_RAW": {
                     "fastqc": "0.12.1"
                 },
-                "GUNC_DOWNLOADDB": {
-                    "gunc": "1.1.0"
-                },
                 "GUNC_RUN": {
                     "gunc": "1.1.0"
                 },
@@ -175,7 +172,7 @@
                 }
             }
         ],
-        "timestamp": "2026-04-09T09:21:33.205568806",
+        "timestamp": "2026-04-21T06:05:20.469766681",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"


### PR DESCRIPTION
GUNC database server has been down for a few days now.
So I uploaded their test db to nf-core/test-datasets/

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
