### PR TITLE
Fix hybrid co-assembly with SPAdes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Ignore `catpack/summarise` errors, since it's a limitation from the tool (reported by @jfy133, fix by @dialvarezs)
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Feed `catpack/contig` with merged unbinned output to prevent execution errors (reported by @Juassis, fix by @dialvarezs)
 - [#1021](https://github.com/nf-core/mag/pull/1021) - Prevent execution of `gtdbtk/summary` when no bins pass QC (reported by @jfy133, fix by @dialvarezs)
+- [#1031](https://github.com/nf-core/mag/pull/1031) - Fix hybrid co-assembly with SPAdes (short & long reads with `--coassemble_group`) (fix by @d4straub)
 
 ### `Dependencies`
 

--- a/subworkflows/local/assembly/main.nf
+++ b/subworkflows/local/assembly/main.nf
@@ -63,6 +63,7 @@ workflow ASSEMBLY {
                 meta.id = "group-${group}"
                 meta.group = group
                 meta.lr_platform = metas.lr_platform[0]
+                meta.single_end = true
                 [meta, reads]
             }
     }


### PR DESCRIPTION
Fix https://github.com/nf-core/mag/issues/1031

Essentially, `meta.single_end` was missing for long reads that were about to be pooled with `POOL_LONG_READS` (that is the nf-core module `CAT_FASTQ`). This is added here at the appropriate point.

Afaik there is no test config that makes sure that problem is tested.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
