### PR TITLE
feat: update GTDB-Tk to v2.7.2 / GTDB r232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1028](https://github.com/nf-core/mag/pull/1028) - Add nf-test snapshot for `test_longread_alternatives` profile (by @dialvarezs)
 - [#1039](https://github.com/nf-core/mag/pull/1039) - Add nf-test snapshot for `test_longread` profile (started by @brovolia, finished by @dialvarezs)
 - [#1041](https://github.com/nf-core/mag/pull/1041) - Refined and corrected unclear section of metromap (by @jfy133)
+- [#1044](https://github.com/nf-core/mag/pull/1044) - Add new `--gtdbtk_place_species` parameter (by @dialvarezs)
 
 ### `Changed`
 
@@ -40,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#908](https://github.com/nf-core/mag/pull/908) - Removed local `quast_bins_summary` in favor of `csvtk/concat` (by @dialvarezs)
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Remove `mag_depths_plot` local module (by @dialvarezs)
-- [#1018](https://github.com/nf-core/mag/pull/1018) - Rename `--gtdbtk_skip_aniscreen` to `--gtdbtk_place_species` (by @dialvarezs)
+- [#1018](https://github.com/nf-core/mag/pull/1018) - Deprecated `--gtdbtk_skip_aniscreen` in favor of `--gtdbtk_place_species` (by @dialvarezs)
 
 ## 5.4.2 Yellow Frog patch [2026-03-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1011](https://github.com/nf-core/mag/pull/1011) - Reverted CheckM2 database download workaround from #966 (by @dialvarezs)
 - [#1020](https://github.com/nf-core/mag/pull/1020) - Update CONCOCT subworkflow and modules (by @dialvarezs)
 - [#1030](https://github.com/nf-core/mag/pull/1030) - Updated to nf-core 4.0.2 template (by @dialvarezs)
+- [#1044](https://github.com/nf-core/mag/pull/1044) - Updated GTDB-Tk to v2.7.2 / GTDB r232 (by @dialvarezs)
 
 ### `Fixed`
 
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#908](https://github.com/nf-core/mag/pull/908) - Removed local `quast_bins_summary` in favor of `csvtk/concat` (by @dialvarezs)
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Remove `mag_depths_plot` local module (by @dialvarezs)
+- [#1018](https://github.com/nf-core/mag/pull/1018) - Rename `--gtdbtk_skip_aniscreen` to `--gtdbtk_place_species` (by @dialvarezs)
 
 ## 5.4.2 Yellow Frog patch [2026-03-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+| Tool    | Previous version | New version |
+| ------- | ---------------- | ----------- |
+| GTDB-Tk | 2.5.2            | 2.7.2       |
+
 ### `Deprecated`
 
 - [#908](https://github.com/nf-core/mag/pull/908) - Removed local `quast_bins_summary` in favor of `csvtk/concat` (by @dialvarezs)

--- a/conf/base.config
+++ b/conf/base.config
@@ -101,7 +101,7 @@ process {
     }
     withName: GTDBTK_CLASSIFYWF {
         cpus   = { 10 * task.attempt }
-        memory = { 128.GB * task.attempt }
+        memory = { 140.GB * task.attempt }
         time   = { 12.h * task.attempt }
     }
     //MEGAHIT returns exit code 250 when running out of memory

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -685,7 +685,7 @@ process {
             "--min_af ${params.gtdbtk_min_af}",
             "--pplacer_cpus ${params.gtdbtk_pplacer_cpus}",
             params.gtdbtk_use_full_tree ? "-f" : "",
-            params.gtdbtk_place_species ? "--place_species" : "",
+            params.gtdbtk_place_species || params.gtdbtk_skip_aniscreen ? "--place_species" : "",
         ].join(' ')
         ext.prefix = { "${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -685,7 +685,7 @@ process {
             "--min_af ${params.gtdbtk_min_af}",
             "--pplacer_cpus ${params.gtdbtk_pplacer_cpus}",
             params.gtdbtk_use_full_tree ? "-f" : "",
-            params.gtdbtk_skip_aniscreen ? "--skip_ani_screen" : "",
+            params.gtdbtk_place_species ? "--place_species" : "",
         ].join(' ')
         ext.prefix = { "${meta.assembler}-${meta.binner}-${meta.domain}-${meta.refinement}-${meta.id}" }
         publishDir = [

--- a/conf/test.config
+++ b/conf/test.config
@@ -38,7 +38,7 @@ params {
     // Prokka is the slowest step of the tests, so we speed up by turning off CDS/product searching
     prokka_fast_mode            = true
     // Source: https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/auxillary_files/gtdbtk_package/mockup_db/
-    gtdb_db                     = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz'
+    gtdb_db                     = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_r232_20260507.tar.gz'
     cat_db                      = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'
     cat_no_suggestive_asterisks = true
     gtdbtk_min_completeness     = 0.01

--- a/conf/test.config
+++ b/conf/test.config
@@ -43,7 +43,7 @@ params {
     cat_no_suggestive_asterisks = true
     gtdbtk_min_completeness     = 0.01
     // Required for the small GTDBTk dummy database aa
-    gtdbtk_skip_aniscreen       = true
+    gtdbtk_place_species        = true
     gtdbtk_use_full_tree        = true
     megahit_fix_cpu_1           = true
     spades_fix_cpus             = 1

--- a/conf/test_alternatives.config
+++ b/conf/test_alternatives.config
@@ -44,7 +44,7 @@ params {
     skip_prodigal              = true
     skip_prokka                = true
     skip_gtdbtk                = true
-    gtdbtk_skip_aniscreen      = true
+    gtdbtk_place_species       = true
     skip_maxbin2               = true
     skip_concoct               = true
     skip_comebin               = true

--- a/conf/test_assembly_input.config
+++ b/conf/test_assembly_input.config
@@ -43,7 +43,7 @@ params {
     skip_prodigal                   = true
     skip_prokka                     = true
     skip_gtdbtk                     = true
-    gtdbtk_skip_aniscreen           = true
+    gtdbtk_place_species            = true
     skip_concoct                    = false
     skip_comebin                    = true
     skip_metabinner                 = true

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -20,7 +20,7 @@ params {
     input                      = "https://github.com/nf-core/test-datasets/raw/refs/heads/mag/samplesheets/samplesheet.full.v4.csv"
 
     //cat_db                     = "s3://ngi-igenomes/test-data/mag/CAT_prepare_20210107.tar.gz" // Current full test fails because of multiple classifications that CAT_pack summarise does not support
-    gtdb_db                    = "s3://nf-core-awsmegatests/mag/full_test_data/gtdb/release226/"
+    gtdb_db                    = "s3://nf-core-awsmegatests/mag/full_test_data/gtdb/release232/"
     skip_gtdbtk                = false
 
     skip_spades                = false

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -37,7 +37,7 @@ params {
     skip_flye                     = true
     skip_metamdbg                 = true
     skip_gtdbtk                   = true
-    gtdbtk_skip_aniscreen         = true
+    gtdbtk_place_species          = true
     skip_concoct                  = true
     skip_comebin                  = true
     skip_metabinner               = true

--- a/conf/test_longreadonly.config
+++ b/conf/test_longreadonly.config
@@ -36,7 +36,7 @@ params {
     busco_db_lineage           = 'bacteria_odb10'
 
     skip_gtdbtk                = true
-    gtdbtk_skip_aniscreen      = true
+    gtdbtk_place_species       = true
     skip_concoct               = true
     skip_comebin               = true
     skip_metabinner            = true

--- a/conf/test_longreadonly_alternatives.config
+++ b/conf/test_longreadonly_alternatives.config
@@ -43,7 +43,7 @@ params {
     skip_prodigal                 = true
     skip_prokka                   = true
     skip_gtdbtk                   = true
-    gtdbtk_skip_aniscreen         = true
+    gtdbtk_place_species          = true
     skip_concoct                  = true
     skip_comebin                  = true
     skip_metabinner               = true

--- a/conf/test_minimal.config
+++ b/conf/test_minimal.config
@@ -51,7 +51,7 @@ params {
     run_checkm2                   = false
     skip_gtdbtk                   = true
     gtdbtk_min_completeness       = 0.01
-    gtdbtk_skip_aniscreen         = true
+    gtdbtk_place_species          = true
     skip_metaeuk                  = true
     skip_ancient_damagecorrection = true
 }

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -52,7 +52,7 @@ params {
     genomad_db                           = null
     gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz'
     gtdbtk_min_completeness              = 3
-    gtdbtk_skip_aniscreen                = true
+    gtdbtk_place_species                 = true
     cat_db                               = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'
     cat_no_suggestive_asterisks          = true
 }

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -53,6 +53,7 @@ params {
     gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_r232_20260507.tar.gz'
     gtdbtk_min_completeness              = 3
     gtdbtk_place_species                 = true
+    gtdbtk_use_full_tree                 = true
     cat_db                               = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'
     cat_no_suggestive_asterisks          = true
 }

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -50,7 +50,7 @@ params {
     run_virus_identification             = true
     genomad_splits                       = 7
     genomad_db                           = null
-    gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz'
+    gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_r232_20260507.tar.gz'
     gtdbtk_min_completeness              = 3
     gtdbtk_place_species                 = true
     cat_db                               = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,7 +189,8 @@ If you enable the `--save_cat_db` option, the database will be saved in the `Tax
 > This database is very large at ~110 GB!
 > This can take a long time, so we strongly recommend downloading and unzipping prior the pipeline run.
 
-This database can be downloaded from the GTDB developers' website. The current pipeline default points to [the GTDB-Tk r232 full package](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz), which is hosted in Australia (and could be slow for other regions of the world).
+This database can be downloaded from the GTDB developers' website. The current pipeline default points to [the GTDB-Tk r232 full package](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz), which is hosted in Europe (and could be slow for other regions of the world).
+See the [GTDB downloads page](https://gtdb.ecogenomic.org/downloads) for other mirrors.
 The developers also offer a split archive of 10 GB files that can be downloaded more stably from [the split package directory](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/split_package/) and subsequently (manually) combined after.
 More documentation can be seen [here](https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,8 +189,8 @@ If you enable the `--save_cat_db` option, the database will be saved in the `Tax
 > This database is very large at ~110 GB!
 > This can take a long time, so we strongly recommend downloading and unzipping prior the pipeline run.
 
-This database can be downloaded from the GTDB developers' website. The current pipeline default points to [the GTDB-Tk r226 full package](https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r226_data.tar.gz), which is hosted in Australia (and could be slow for other regions of the world).
-The developers also offer a split archive of 10 GB files that can be downloaded more stably from [the split package directory](https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/split_package/) and subsequently (manually) combined after.
+This database can be downloaded from the GTDB developers' website. The current pipeline default points to [the GTDB-Tk r232 full package](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz), which is hosted in Australia (and could be slow for other regions of the world).
+The developers also offer a split archive of 10 GB files that can be downloaded more stably from [the split package directory](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/split_package/) and subsequently (manually) combined after.
 More documentation can be seen [here](https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data).
 
 ## Running the pipeline
@@ -484,25 +484,25 @@ This feature is only available with container engines `apptainer` and `singulari
 To generate your SquashFS image:
 
 1. Install [squashfs-tools](https://github.com/plougher/squashfs-tools), if it is not already on your system
-2. Download the GTDB archive either via the full [`.tar.gz` archive](https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/) or the [split database](https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/split_package) version.
+2. Download the GTDB archive either via the full [`.tar.gz` archive](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/) or the [split database](https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/split_package/) version.
 3. Convert to a SquashFS image
 
 - Full package (compressed):
 
   ```bash
-  gzip -cd gtdbtk_r226_data.tar.gz | mksquashfs - gtdbtk_r226.squashfs -tar
+  gzip -cd gtdbtk_r232_data.tar.gz | mksquashfs - gtdbtk_r232.squashfs -tar
   ```
 
 - Full package (uncompressed)
 
   ```bash
-  mksquashfs /path/to/database gtdbtk_r226.squashfs
+  mksquashfs /path/to/database gtdbtk_r232.squashfs
   ```
 
 - Split package (compressed)
 
   ```bash
-  cat gtdbtk_r226_data.tar.gz.part_* | gzip -cd - | mksquashfs - gtdbtk_r226.squashfs -tar
+  cat gtdbtk_r232_data.tar.gz.part_* | gzip -cd - | mksquashfs - gtdbtk_r232.squashfs -tar
   ```
 
 To use the image in the pipeline:
@@ -513,7 +513,7 @@ To use the image in the pipeline:
    ```nextflow
    process {
        withName: GTDBTK_CLASSIFYWF {
-               containerOptions = "-B /<path>/<to>/gtdbtk_r226.squashfs:${params.gtdb_db}:image-src=/"
+               containerOptions = "-B /<path>/<to>/gtdbtk_r232.squashfs:${params.gtdb_db}:image-src=/"
        }
    }
    ```
@@ -525,7 +525,7 @@ To use the image in the pipeline:
    ```
 
 :::warning
-Make sure to update the paths where indicated, and the GTDB release version if using a different one than r226.
+Make sure to update the paths where indicated, and the GTDB release version if using a different one than r232.
 :::
 
 :::note
@@ -534,7 +534,7 @@ If you have issues with this, you may need to specify a different `image-src=` s
 You can determine this with:
 
 ```bash
-unsquashfs -l -max-depth 1 -d'' gtdbtk_r226.squashfs
+unsquashfs -l -max-depth 1 -d'' gtdbtk_r232.squashfs
 ```
 
 And use the resulting output in `image-src=`
@@ -542,7 +542,7 @@ And use the resulting output in `image-src=`
 ```nextflow
 process {
     withName: GTDBTK_CLASSIFYWF {
-            containerOptions = "-B /<path>/<to>/gtdbtk_r226.squashfs:${params.gtdb_db}:image-src=/<output_from_unsquashfs_ls>"
+            containerOptions = "-B /<path>/<to>/gtdbtk_r232.squashfs:${params.gtdb_db}:image-src=/<output_from_unsquashfs_ls>"
     }
 }
 ```

--- a/modules.json
+++ b/modules.json
@@ -183,7 +183,7 @@
                     },
                     "gtdbtk/classifywf": {
                         "branch": "master",
-                        "git_sha": "5e433c4659a72e3e4aaf9d7275147d1a944165ee",
+                        "git_sha": "b581ebb37c529fa07e22c38d128a7c5c273ed286",
                         "installed_by": ["modules"]
                     },
                     "gunc/downloaddb": {

--- a/modules/nf-core/gtdbtk/classifywf/environment.yml
+++ b/modules/nf-core/gtdbtk/classifywf/environment.yml
@@ -4,5 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gtdbtk=2.5.2
-  - conda-forge::python=3.13.7
+  - bioconda::gtdbtk=2.7.2

--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -3,9 +3,9 @@ process GTDBTK_CLASSIFYWF {
     label 'process_high_memory'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gtdbtk:2.5.2--pyh1f0d9b5_0':
-        'biocontainers/gtdbtk:2.5.2--pyh1f0d9b5_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa734cc7e63b0f7d0c04788ec61de5e6a101a07e966d3dde24384d54a9d75e85/data'
+        : 'community.wave.seqera.io/library/gtdbtk:2.7.2--64b0fd171db01270'}"
 
     input:
     tuple val(meta)   , path("bins/*")
@@ -23,7 +23,8 @@ process GTDBTK_CLASSIFYWF {
     tuple val(meta), path("${prefix}/identify/*.failed_genomes.tsv") , emit: failed     , optional: true
     tuple val(meta), path("${prefix}/${prefix}.log")                 , emit: log
     tuple val(meta), path("${prefix}/${prefix}.warnings.log")        , emit: warnings
-    path ("versions.yml")                                            , emit: versions
+    tuple val("${task.process}"), val('gtdbtk'), eval("gtdbtk --version 2>&1 | grep -Eo '[0-9]+(\\.[0-9]+)+' | head -1") , topic: versions, emit: versions_gtdbtk
+    tuple val("${task.process}"), val('gtdb_db'), eval('grep VERSION_DATA \$GTDBTK_DATA_PATH/metadata/metadata.txt | sed "s/VERSION_DATA=//"'), topic: versions, emit: versions_gtdbtk_db
 
     when:
     task.ext.when == null || task.ext.when
@@ -49,17 +50,13 @@ process GTDBTK_CLASSIFYWF {
 
     mv ${prefix}/gtdbtk.log "${prefix}/${prefix}.log"
     mv ${prefix}/gtdbtk.warnings.log "${prefix}/${prefix}.warnings.log"
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gtdbtk: \$(echo \$(gtdbtk --version 2>/dev/null) | sed "s/gtdbtk: version //; s/ Copyright.*//")
-        gtdb_db: \$(grep VERSION_DATA \$GTDBTK_DATA_PATH/metadata/metadata.txt | sed "s/VERSION_DATA=//")
-    END_VERSIONS
     """
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
+    export GTDBTK_DATA_PATH="\$(find -L ${db} -name 'metadata' -type d -exec dirname {} \\;)"
+
     mkdir ${prefix}
     mkdir ${prefix}/identify
     mkdir ${prefix}/classify
@@ -81,10 +78,5 @@ process GTDBTK_CLASSIFYWF {
     touch ${prefix}/${prefix}.log
     touch ${prefix}/${prefix}.warnings.log
     touch ${prefix}/${prefix}.failed_genomes.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gtdbtk: \$(echo \$(gtdbtk --version 2>/dev/null) | sed "s/gtdbtk: version //; s/ Copyright.*//")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/gtdbtk/classifywf/meta.yml
+++ b/modules/nf-core/gtdbtk/classifywf/meta.yml
@@ -177,13 +177,46 @@ output:
           pattern: "*.{warnings.log}"
           ontologies:
             - edam: http://edamontology.org/data_3671 # Text
+  versions_gtdbtk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gtdbtk:
+          type: string
+          description: The name of the tool
+      - "gtdbtk --version 2>&1 | grep -Eo '[0-9]+(\\.[0-9]+)+' | head -1":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_gtdbtk_db:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gtdb_db:
+          type: string
+          description: The name of the database
+      - 'grep VERSION_DATA \$GTDBTK_DATA_PATH/metadata/metadata.txt | sed "s/VERSION_DATA=//"':
+          type: eval
+          description: The expression to obtain the version of the database
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gtdbtk:
+          type: string
+          description: The name of the tool
+      - "gtdbtk --version 2>&1 | grep -Eo '[0-9]+(\\.[0-9]+)+' | head -1":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gtdb_db:
+          type: string
+          description: The name of the database
+      - 'grep VERSION_DATA \$GTDBTK_DATA_PATH/metadata/metadata.txt | sed "s/VERSION_DATA=//"':
+          type: eval
+          description: The expression to obtain the version of the database
 authors:
   - "@skrakau"
   - "@prototaxites"

--- a/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test
+++ b/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test
@@ -17,8 +17,8 @@ nextflow_process {
             process {
             """
             input[0] = [
-                        [ id:'mockup' ], // meta map
-                        file('https://github.com/nf-core/test-datasets/raw/refs/heads/mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz', checkIfExists: true)
+                [ id:'mockup' ], // meta map
+                file('https://github.com/nf-core/test-datasets/raw/refs/heads/mag/databases/gtdbtk/gtdbtk_mockup_r232_20260507.tar.gz', checkIfExists: true)
             ]
             """
             }
@@ -32,18 +32,16 @@ nextflow_process {
 
             params {
                 // Recommended by the GTDB developers: https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_package/mockup_db/HOWTO.txt
-                // The `--skip_ani_screen` requires comparison against a full database and goes through the full classfywf pipeline
-                module_args = '--extension fa --skip_ani_screen'
+                // The `--place_species` requires comparison against a full database and goes through the full classfywf pipeline
+                module_args = '--extension fa --place_species'
             }
 
             process {
                 """
                 input[0] = [
-                        [ id:'test', single_end:false, assembler:'SPADES' ],
-                        [
-                            file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true),
-                        ]
-                    ]
+                    [ id:'test', single_end:false, assembler:'SPADES' ],
+                    [file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true)]
+                ]
                 input[1] = UNTAR.out.untar
                 input[2] = false
                 """
@@ -53,16 +51,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                        process.out.summary,
-                        process.out.tree,
-                        process.out.markers,
-                        process.out.msa,
-                        process.out.user_msa,
-                        process.out.filtered,
-                        file(process.out.log[0][1]).readLines().contains('INFO: Done.'),
-                        process.out.versions,
-                    ).match() }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["gtdb_outdir", "warnings", "failed", "log"])).match() }
             )
         }
     }
@@ -75,19 +64,17 @@ nextflow_process {
 
             params {
                 // Recommended by the GTDB developers: https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_package/mockup_db/HOWTO.txt
-                // The `--skip_ani_screen` requires comparison against a full database and goes through the full classfywf pipeline
-                module_args = '--extension fa --skip_ani_screen'
+                // The `--place_species` requires comparison against a full database and goes through the full classfywf pipeline
+                module_args = '--extension fa --place_species'
             }
 
             process {
                 """
                 input[0] = [
-                        [ id:'test', single_end:false, assembler:'SPADES' ],
-                        [
-                            file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true),
-                        ]
-                    ]
-                input[1] = [[:],[]]
+                    [ id:'test', single_end:false, assembler:'SPADES' ],
+                    [file(params.modules_testdata_base_path + 'genomics/prokaryotes/escherichia_coli/genome/genome.fa', checkIfExists: true)]
+                ]
+                input[1] = UNTAR.out.untar
                 input[2] = false
                 """
             }
@@ -96,7 +83,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test.snap
+++ b/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test.snap
@@ -1,183 +1,107 @@
 {
     "E. coli - genome fasta": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false,
-                        "assembler": "SPADES"
-                    },
-                    "test.bac120.summary.tsv:md5,6d78949595cbfb145108cc5374dbac23"
-                ]
-            ],
-            [
-                
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false,
-                        "assembler": "SPADES"
-                    },
+            {
+                "failed": [
                     [
-                        "test.ar53.markers_summary.tsv:md5,3ba12aa91791ee263df1bee8558413eb",
-                        "test.bac120.markers_summary.tsv:md5,49c710e91fe35aff2ee5bf6b1b949ed4"
+                        {
+                            "assembler": "SPADES",
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.failed_genomes.tsv"
+                    ]
+                ],
+                "filtered": [
+                    
+                ],
+                "gtdb_outdir": [
+                    [
+                        {
+                            "assembler": "SPADES",
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "assembler": "SPADES",
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log"
+                    ]
+                ],
+                "markers": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false,
+                            "assembler": "SPADES"
+                        },
+                        [
+                            "test.ar53.markers_summary.tsv:md5,3ba12aa91791ee263df1bee8558413eb",
+                            "test.bac120.markers_summary.tsv:md5,49c710e91fe35aff2ee5bf6b1b949ed4"
+                        ]
+                    ]
+                ],
+                "msa": [
+                    
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false,
+                            "assembler": "SPADES"
+                        },
+                        "test.bac120.summary.tsv:md5,6d78949595cbfb145108cc5374dbac23"
+                    ]
+                ],
+                "tree": [
+                    
+                ],
+                "user_msa": [
+                    
+                ],
+                "versions_gtdbtk": [
+                    [
+                        "GTDBTK_CLASSIFYWF",
+                        "gtdbtk",
+                        "2.7.2"
+                    ]
+                ],
+                "versions_gtdbtk_db": [
+                    [
+                        "GTDBTK_CLASSIFYWF",
+                        "gtdb_db",
+                        "r232"
+                    ]
+                ],
+                "warnings": [
+                    [
+                        {
+                            "assembler": "SPADES",
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.warnings.log"
                     ]
                 ]
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                
-            ],
-            false,
-            [
-                "versions.yml:md5,f5ba303be4c50477b9511d73e3f73ba2"
-            ]
+            }
         ],
+        "timestamp": "2026-05-08T14:20:35.638891787",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-09-18T13:09:35.646716179"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - genome fasta - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        [
-                            [
-                                "test.ar53.filtered.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.ar53.msa.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                                "test.bac120.filtered.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.bac120.user_msa.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                            ],
-                            [
-                                "test.ar53.classify.tree:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.ar53.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.bac120.classify.tree:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.bac120.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            [
-                                "test.ar53.markers_summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "test.bac120.markers_summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "test.failed_genomes.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.log:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.warnings.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        [
-                            "test.ar53.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.bac120.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "10": [
-                    "versions.yml:md5,c1ff04482b013ad1c6aa1c743c32f8ed"
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        [
-                            "test.ar53.classify.tree:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.bac120.classify.tree:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        [
-                            "test.ar53.markers_summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.bac120.markers_summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        "test.ar53.msa.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        "test.bac120.user_msa.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        [
-                            "test.ar53.filtered.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.bac120.filtered.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "9": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false,
-                            "assembler": "SPADES"
-                        },
-                        "test.warnings.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
                 "failed": [
                     
                 ],
@@ -293,8 +217,19 @@
                         "test.bac120.user_msa.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,c1ff04482b013ad1c6aa1c743c32f8ed"
+                "versions_gtdbtk": [
+                    [
+                        "GTDBTK_CLASSIFYWF",
+                        "gtdbtk",
+                        "2.7.2"
+                    ]
+                ],
+                "versions_gtdbtk_db": [
+                    [
+                        "GTDBTK_CLASSIFYWF",
+                        "gtdb_db",
+                        ""
+                    ]
                 ],
                 "warnings": [
                     [
@@ -308,10 +243,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-05-08T14:21:03.525578896",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-09-18T13:10:11.349991414"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -100,7 +100,7 @@ params {
     cat_no_suggestive_asterisks          = false
     save_cat_db                          = false
     skip_gtdbtk                          = false
-    gtdb_db                              = "https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r226_data.tar.gz"
+    gtdb_db                              = "https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz"
     gtdbtk_min_completeness              = 50.0
     gtdbtk_max_contamination             = 10.0
     gtdbtk_min_perc_aa                   = 10

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,6 +109,7 @@ params {
     gtdbtk_pplacer_useram                = false
     gtdbtk_use_full_tree                 = false
     gtdbtk_place_species                 = false
+    gtdbtk_skip_aniscreen                = false // DEPRECATED: use gtdbtk_place_species instead
 
     // long read preprocessing options
     skip_adapter_trimming                = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -108,7 +108,7 @@ params {
     gtdbtk_pplacer_cpus                  = 1
     gtdbtk_pplacer_useram                = false
     gtdbtk_use_full_tree                 = false
-    gtdbtk_skip_aniscreen                = false
+    gtdbtk_place_species                 = false
 
     // long read preprocessing options
     skip_adapter_trimming                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -529,7 +529,7 @@
                 "gtdb_db": {
                     "type": "string",
                     "description": "Specify the location of a GTDBTK database. Can be either an uncompressed directory or a `.tar.gz` archive. If not specified will be downloaded for you when GTDBTK or binning QC is not skipped.",
-                    "default": "https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r226_data.tar.gz",
+                    "default": "https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz",
                     "format": "path"
                 },
                 "gtdbtk_min_completeness": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -577,7 +577,7 @@
                     "type": "boolean",
                     "description": "Specify to have GTDBTk to use the full bacterial tree rather than the split tree (requires more memory!)"
                 },
-                "gtdbtk_skip_aniscreen": {
+                "gtdbtk_place_species": {
                     "type": "boolean",
                     "description": "Specify to disable fast classification of genomes by ANI using skani in GTDB-Tk."
                 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -580,6 +580,11 @@
                 "gtdbtk_place_species": {
                     "type": "boolean",
                     "description": "Specify to disable fast classification of genomes by ANI using skani in GTDB-Tk."
+                },
+                "gtdbtk_skip_aniscreen": {
+                    "type": "boolean",
+                    "description": "[DEPRECATED] Use `--gtdbtk_place_species` instead. Specify to disable fast classification of genomes by ANI using skani in GTDB-Tk.",
+                    "hidden": true
                 }
             }
         },

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -94,7 +94,6 @@ workflow GTDBTK {
         ch_db_for_gtdbtk,
         params.gtdbtk_pplacer_useram ? false : true,
     )
-    ch_versions = ch_versions.mix(GTDBTK_CLASSIFYWF.out.versions)
 
     // Print warning why GTDB-TK summary empty if passed channel gets no files
     ch_filtered_bins.passed

--- a/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
@@ -376,6 +376,10 @@ def validateInputParameters(hybrid) {
         }
     }
 
+    if (params.gtdbtk_skip_aniscreen) {
+        log.warn("[nf-core/mag]: The parameter '--gtdbtk_skip_aniscreen' is deprecated and will be removed in a future release. Please use '--gtdbtk_place_species' instead.")
+    }
+
     if (!params.skip_gtdbtk) {
         if (params.skip_binqc) {
             log.warn('[nf-core/mag]: --skip_binqc is specified, but --skip_gtdbtk is explicitly set to run! GTDB-tk will be omitted because GTDB-tk bin classification requires bin filtering based on BUSCO or CheckM QC results to avoid GTDB-tk errors.')

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -63,8 +63,8 @@
                     "fastqc": "0.12.1"
                 },
                 "GTDBTK_CLASSIFYWF": {
-                    "gtdb_db": "r226",
-                    "gtdbtk": "2.5.2"
+                    "gtdb_db": "r232",
+                    "gtdbtk": "2.7.2"
                 },
                 "GTDBTK_DB_PREPARATION": {
                     "tar": 1.34
@@ -136,10 +136,10 @@
                 }
             }
         ],
-        "timestamp": "2026-05-04T09:02:47.805341806",
+        "timestamp": "2026-05-27T09:38:57.61754217",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "multiqc": {
@@ -368,7 +368,7 @@
                 "fastqc_sequence_counts_plot.yaml:md5,914b960f91309a956e21c178901982bc",
                 "fastqc_sequence_duplication_levels_plot.yaml:md5,93d0cd165640262a7d44005856c624ab",
                 "fastqc_sequence_length_distribution_plot.yaml:md5,8bc1572ea1e12100dd1b41f54f060879",
-                "gtdbtk-first-table.yaml:md5,08b7e4d446732aa6282caff9f8cfc314",
+                "gtdbtk-first-table.yaml:md5,35227792ecdac2f09857800052cd2546",
                 "multiqc_bowtie2.yaml:md5,dbe34bb5e06f65c3cf7af116f1d54a10",
                 "multiqc_bowtie2_bowtie2-2.yaml:md5,b60f4adf7e78bec1bf16046ce5ea3b7d",
                 "multiqc_busco.yaml:md5,8dfe2fb699e8c4aad16a65a30ce42aad",
@@ -376,8 +376,8 @@
                 "multiqc_fastp.yaml:md5,51ec2abfc64be1bc93c4c3f7298da1e1",
                 "multiqc_fastqc.yaml:md5,c856302b60a6c3c3fd5f273ed1a7c967",
                 "multiqc_fastqc_fastqc-1.yaml:md5,b090818c369a65b9218bae720078035c",
-                "multiqc_general_stats.yaml:md5,eb0e0141f528d72ac61cfc98dd86f538",
-                "multiqc_gtdbtk.yaml:md5,3bbdb38502ded227673a4e25c6d7219a",
+                "multiqc_general_stats.yaml:md5,d812f12329d4132ac1405614124254dc",
+                "multiqc_gtdbtk.yaml:md5,19e1814e0e8c7170b2aa6417b0afb32a",
                 "multiqc_prokka.yaml:md5,7a103b0d4385c2de011fc286cb4c5cc3",
                 "multiqc_quast.yaml:md5,1be7cc2def0a960cbc3c19bdc4504c78",
                 "multiqc_quast_quast-1.yaml:md5,2ef7e71adce9f4e864e27565057a6632",
@@ -386,10 +386,10 @@
                 "quast_table.yaml:md5,2d53029b92bc2e3940ee2ae932fa2c9d"
             ]
         ],
-        "timestamp": "2026-05-04T10:28:41.89347695",
+        "timestamp": "2026-05-27T09:38:57.667416849",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     }
 }

--- a/tests/test_single_end.nf.test.snap
+++ b/tests/test_single_end.nf.test.snap
@@ -1966,13 +1966,13 @@
                 "MEGAHIT-MetaBAT2-test_minigut-bins_bin2classification.names.txt:md5,ce1b6bae00995e88d70722462d9fcedb",
                 "MEGAHIT-MetaBAT2-test_minigut-bins_summary.txt:md5,c2986e27b93008b06709a59bb298e3ea",
                 "bat_summary.tsv:md5,ab01c0858ee334804fb97180d1ba321e",
-                "gtdbtk_summary.tsv:md5,e4d3f904cdfb4737d52a587e13547720"
+                "gtdbtk_summary.tsv:md5,75c4048c09d6126dc7f1019d138d33fe"
             ]
         ],
-        "timestamp": "2026-05-27T09:54:51.894785301",
+        "timestamp": "2026-06-02T06:28:57.339358478",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.3"
         }
     },
     "-profile test_single_end": {
@@ -2346,7 +2346,7 @@
                 "multiqc_fastqc.yaml:md5,2bbd80f21c5c264249bc935eada2ff41",
                 "multiqc_fastqc_fastqc-1.yaml:md5,b21efcd71ad261049a5aeaa238492f92",
                 "multiqc_general_stats.yaml:md5,8e3cd8d0950bf1e8869d5833e3fb4228",
-                "multiqc_gtdbtk.yaml:md5,7e80512a87910eb1cd97214d5ab7220b",
+                "multiqc_gtdbtk.yaml:md5,280f2d76c51024eb41df184c3b0dae70",
                 "multiqc_prokka.yaml:md5,e55c687925d611b869e4c4b27c71470c",
                 "multiqc_quast.yaml:md5,b7dae5bb61679ff9d5a3ede9898e5cfa",
                 "multiqc_quast_quast-1.yaml:md5,0b8fe8ee8f69277c0471dfe621c27b03",
@@ -2355,10 +2355,10 @@
                 "quast_table.yaml:md5,55ee8b4825b107d592cfeb16928f3487"
             ]
         ],
-        "timestamp": "2026-05-27T09:54:51.802758126",
+        "timestamp": "2026-06-02T06:28:57.250315083",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.3"
         }
     },
     "ancient": {

--- a/tests/test_single_end.nf.test.snap
+++ b/tests/test_single_end.nf.test.snap
@@ -1801,16 +1801,16 @@
                 "MEGAHIT-MaxBin2-test_minigut.001_pydamage_bin_results.tsv:md5,99bb3502616c763cd62ee79fa2e3b1d2",
                 "MEGAHIT-MaxBin2-test_minigut.002_pydamage_bin_results.tsv:md5,9974a24fa3787a38b3939cbfbd9226df",
                 "MEGAHIT-MetaBAT2-test_minigut.1_pydamage_bin_results.tsv:md5,3d2237a104a6ed0bf1f7efb52195ea82",
-                "bin_summary.tsv:md5,63b2c0d2164c16a997f12b94bd7037fc",
+                "bin_summary.tsv:md5,4c73af8b474fed74ca5ef59111606afe",
                 "contig_to_bin_map.tsv:md5,9a146f6bd0eaf2fd9605cf1885dd37bc",
                 "bin_depths_summary.tsv:md5,bd54b32dc4c741cd4edd2bbba51f6552",
                 "versions.yml:md5,553ee8a62e65d93ce1163bb16314da29"
             ]
         ],
-        "timestamp": "2026-05-04T09:02:43.048161171",
+        "timestamp": "2026-05-27T09:54:51.697235507",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "viral": {
@@ -1966,13 +1966,13 @@
                 "MEGAHIT-MetaBAT2-test_minigut-bins_bin2classification.names.txt:md5,ce1b6bae00995e88d70722462d9fcedb",
                 "MEGAHIT-MetaBAT2-test_minigut-bins_summary.txt:md5,c2986e27b93008b06709a59bb298e3ea",
                 "bat_summary.tsv:md5,ab01c0858ee334804fb97180d1ba321e",
-                "gtdbtk_summary.tsv:md5,af05337c99159421caf2348dcae802e7"
+                "gtdbtk_summary.tsv:md5,e4d3f904cdfb4737d52a587e13547720"
             ]
         ],
-        "timestamp": "2026-05-04T09:02:44.075431879",
+        "timestamp": "2026-05-27T09:54:51.894785301",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "-profile test_single_end": {
@@ -2082,8 +2082,8 @@
                     "genomad": "1.11.2"
                 },
                 "GTDBTK_CLASSIFYWF": {
-                    "gtdb_db": "r226",
-                    "gtdbtk": "2.5.2"
+                    "gtdb_db": "r232",
+                    "gtdbtk": "2.7.2"
                 },
                 "GTDBTK_DB_PREPARATION": {
                     "tar": 1.34
@@ -2156,10 +2156,10 @@
                 }
             }
         ],
-        "timestamp": "2026-05-04T09:02:42.319883678",
+        "timestamp": "2026-05-27T09:54:51.480520914",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "multiqc": {
@@ -2336,7 +2336,7 @@
                 "fastqc_sequence_counts_plot.yaml:md5,f742336e560c390f4179dc1c6d766585",
                 "fastqc_sequence_duplication_levels_plot.yaml:md5,c515ca326698a98b7a561df2bb44603b",
                 "fastqc_sequence_length_distribution_plot.yaml:md5,65d8d87d8ca970f93b1168c0d0c416e1",
-                "gtdbtk-first-table.yaml:md5,f579edc5838374386ed0e3fd8cf85e18",
+                "gtdbtk-first-table.yaml:md5,ca74632a902424875d32ad022b38b070",
                 "multiqc_adapter_removal.yaml:md5,a1af2581288dffacad44a69744f6d93b",
                 "multiqc_bowtie2.yaml:md5,b4e58a2943b5009634fa5da76214073d",
                 "multiqc_bowtie2_bowtie2-1.yaml:md5,b4e58a2943b5009634fa5da76214073d",
@@ -2345,8 +2345,8 @@
                 "multiqc_citations.yaml:md5,332da3731e12b7a0d205f47685ddd53e",
                 "multiqc_fastqc.yaml:md5,2bbd80f21c5c264249bc935eada2ff41",
                 "multiqc_fastqc_fastqc-1.yaml:md5,b21efcd71ad261049a5aeaa238492f92",
-                "multiqc_general_stats.yaml:md5,1942d207cff0cb6a2f88ccf4e72c1661",
-                "multiqc_gtdbtk.yaml:md5,9629f17dc32ae85aaccede6db3f7f823",
+                "multiqc_general_stats.yaml:md5,8e3cd8d0950bf1e8869d5833e3fb4228",
+                "multiqc_gtdbtk.yaml:md5,7e80512a87910eb1cd97214d5ab7220b",
                 "multiqc_prokka.yaml:md5,e55c687925d611b869e4c4b27c71470c",
                 "multiqc_quast.yaml:md5,b7dae5bb61679ff9d5a3ede9898e5cfa",
                 "multiqc_quast_quast-1.yaml:md5,0b8fe8ee8f69277c0471dfe621c27b03",
@@ -2355,10 +2355,10 @@
                 "quast_table.yaml:md5,55ee8b4825b107d592cfeb16928f3487"
             ]
         ],
-        "timestamp": "2026-05-04T10:28:44.987525115",
+        "timestamp": "2026-05-27T09:54:51.802758126",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "ancient": {
@@ -2396,10 +2396,10 @@
             "BAT summary: 27",
             "GTDB-Tk summary: 26"
         ],
-        "timestamp": "2026-04-16T17:37:10.984121707",
+        "timestamp": "2026-05-27T09:04:17.164489007",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.2"
         }
     }
 }


### PR DESCRIPTION
- **Module bump**: `gtdbtk/classifywf` updated to latest nf-core (2.5.2 to 2.7.2).
- **Database r232**: default `gtdb_db` URL, mock db, and full test data paths updated from r226 to r232. Docs refreshed accordingly.
- **Add `--gtdbtk_place_species` and deprecate `--gtdbtk_skip_aniscreen`**: GTDB-Tk 2.7 renamed the flag; pipeline parameter renamed to match.
- **Memory bump**: GTDBTK_CLASSIFYWF base memory 128 to 140 GB, as recommended by the developers.
- **Snapshots**: regenerated for GTDB-Tk 2.7.2 / r232 output.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).