### PR TITLE
feat: allow GTDTB-Tk running on a single job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1028](https://github.com/nf-core/mag/pull/1028) - Add nf-test snapshot for `test_longread_alternatives` profile (by @dialvarezs)
 - [#1039](https://github.com/nf-core/mag/pull/1039) - Add nf-test snapshot for `test_longread` profile (started by @brovolia, finished by @dialvarezs)
 - [#1041](https://github.com/nf-core/mag/pull/1041) - Refined and corrected unclear section of metromap (by @jfy133)
+- [#1047](https://github.com/nf-core/mag/issues/1007) - Add `--gtdbtk_single_job` to run GTDB-Tk classification for all bins in a single job (requested by @sarah-shah-bioinf, by @dialvarezs)
 
 ### `Changed`
 

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -53,6 +53,7 @@ params {
     gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz'
     gtdbtk_min_completeness              = 3
     gtdbtk_skip_aniscreen                = true
+    gtdbtk_single_job                    = false
     cat_db                               = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'
     cat_no_suggestive_asterisks          = true
 }

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -53,7 +53,7 @@ params {
     gtdb_db                              = params.pipelines_testdata_base_path + 'mag/databases/gtdbtk/gtdbtk_mockup_20250422.tar.gz'
     gtdbtk_min_completeness              = 3
     gtdbtk_skip_aniscreen                = true
-    gtdbtk_single_job                    = false
+    gtdbtk_single_job                    = true
     cat_db                               = params.pipelines_testdata_base_path + 'mag/databases/cat/minigut_cat.tar.gz'
     cat_no_suggestive_asterisks          = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,6 +109,7 @@ params {
     gtdbtk_pplacer_useram                = false
     gtdbtk_use_full_tree                 = false
     gtdbtk_skip_aniscreen                = false
+    gtdbtk_single_job                    = false
 
     // long read preprocessing options
     skip_adapter_trimming                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -580,6 +580,11 @@
                 "gtdbtk_skip_aniscreen": {
                     "type": "boolean",
                     "description": "Specify to disable fast classification of genomes by ANI using skani in GTDB-Tk."
+                },
+                "gtdbtk_single_job": {
+                    "type": "boolean",
+                    "description": "Run GTDB-Tk classification for all bins in a single job, rather than one job per sample/assembler/binner group.",
+                    "help_text": "By default nf-core/mag submits a separate GTDBTK_CLASSIFYWF job per group of bins. When classifying very large numbers of bins, it can be more efficient to run all bins together in one job, as steps such as skani and pplacer are then performed once over the whole dataset instead of being repeated per job."
                 }
             }
         },

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -89,8 +89,14 @@ workflow GTDBTK {
             log.warn("[nf-core/mag] No bin QC results were available. Skipping GTDB-Tk classification.")
         }
 
+    // Optionally combine all bins into a single GTDB-Tk job, instead of one job
+    // per bin group, which can be more efficient for very large bin counts
+    ch_bins_for_classifywf = params.gtdbtk_single_job
+        ? ch_filtered_bins.passed.map { _meta, bin -> [[id: 'all_bins', assembler: 'all', binner: 'all', domain: 'all', refinement: 'all'], bin] }.groupTuple()
+        : ch_filtered_bins.passed.groupTuple()
+
     GTDBTK_CLASSIFYWF(
-        ch_filtered_bins.passed.groupTuple(),
+        ch_bins_for_classifywf,
         ch_db_for_gtdbtk,
         params.gtdbtk_pplacer_useram ? false : true,
     )

--- a/tests/test_single_end.nf.test.snap
+++ b/tests/test_single_end.nf.test.snap
@@ -1977,7 +1977,7 @@
     },
     "-profile test_single_end": {
         "content": [
-            159,
+            157,
             {
                 "ADAPTERREMOVAL_SE": {
                     "adapterremoval": "2.3.2"
@@ -2156,10 +2156,10 @@
                 }
             }
         ],
-        "timestamp": "2026-05-04T09:02:42.319883678",
+        "timestamp": "2026-06-01T11:04:28.94748105",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.2"
         }
     },
     "multiqc": {


### PR DESCRIPTION
Adds `--gtdbtk_single_job` (default: `false`) to group all bins into a single GTDBTK_CLASSIFYWF job instead of one per sample/assembler/binner group. This is useful when classifying very large numbers of bins, as steps like skani and pplacer run once over the whole dataset rather than being repeated per job.
Enabled in `test_single_end` to exercise the new code path.

Closes #1007.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).