### PR TITLE
fix(tests): set 1 CPUs to Flye to ensure stable results

### DIFF
--- a/conf/test_longreadonly.config
+++ b/conf/test_longreadonly.config
@@ -19,8 +19,12 @@ process {
     ]
 }
 
+// needed for result stability
 process {
     withName: METAMDBG_ASM {
+        cpus = 1
+    }
+    withName: FLYE {
         cpus = 1
     }
 }

--- a/conf/test_longreadonly_alternatives.config
+++ b/conf/test_longreadonly_alternatives.config
@@ -19,6 +19,7 @@ process {
     ]
 }
 
+// needed for result stability
 process {
     withName: FLYE {
         cpus = 1


### PR DESCRIPTION
In my desktop PC I get a different snapshot around 1 of 5 times. This is because Flye is not deterministic with multicore.
This was set already in `longreadonly_alternatives`, this PR adds it to `longreadonly`.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
