### PR TITLE
Skip fastqc switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- []() - Add skip_fastqc switch (@jorondo1)
+- [#1057](https://github.com/nf-core/mag/pull/1057) - Add skip_fastqc switch (by @jorondo1)
 - [#908](https://github.com/nf-core/mag/pull/908) - Add nf-test snapshot for `test_single_end` profile (by @dialvarezs)
 - [#1028](https://github.com/nf-core/mag/pull/1028) - Add nf-test snapshot for `test_longread_alternatives` profile (by @dialvarezs)
 - [#1037](https://github.com/nf-core/mag/pull/1037) - Complement usage documentation with guidance on pipeline defaults, choices and alternatives (by @d4straub and @jfy133 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- []() - Add skip_fastqc switch (@jorondo1)
 - [#908](https://github.com/nf-core/mag/pull/908) - Add nf-test snapshot for `test_single_end` profile (by @dialvarezs)
 - [#1028](https://github.com/nf-core/mag/pull/1028) - Add nf-test snapshot for `test_longread_alternatives` profile (by @dialvarezs)
 - [#1037](https://github.com/nf-core/mag/pull/1037) - Complement usage documentation with guidance on pipeline defaults, choices and alternatives (by @d4straub and @jfy133 )

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,8 @@ params {
     adapterremoval_trim_quality_stretch  = false
     keep_phix                            = false
     skip_shortread_qc                    = false
+    skip_fastqc                          = false
+
     // long read preprocessing options
     longread_adaptertrimming_tool        = "porechop_abi"
     longread_filtering_tool              = "filtlong"

--- a/nextflow.config
+++ b/nextflow.config
@@ -519,6 +519,14 @@ manifest {
             contribution: ['maintainer'],
             orcid: '0000-0003-0753-274X',
         ],
+        [
+            name: 'Jonathan Rondeau-Leclaire',
+            affiliation: 'Université de Sherbrooke, Québec, Canada',
+            email: '',
+            github: 'jorondo1',
+            contribution: ['contributor'],
+            orcid: '0000-0002-4433-3566',
+        ],
     ]
     homePage        = 'https://github.com/nf-core/mag'
     description     = """Assembly, binning and annotation of metagenomes"""

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -383,7 +383,12 @@
                 "skip_shortread_qc": {
                     "type": "boolean",
                     "description": "Skip all default QC steps for short reads (adapter trimming, phiX removal).",
-                    "help": "Skips clipping and removal of phiX sequences. Does not affect host sequence removal as this is opt in."
+                    "help": "Skips clipping and removal of phiX sequences. Does not affect host sequence removal as this is opt in. Does not prevent FastQC from running if host removal is enabled."
+                },
+                "skip_fastqc": {
+                    "type": "boolean",
+                    "description": "Skip running FastQC on short reads both before and after QC.",
+                    "help": "Skips running FastQC on short reads. Most metrics are redundant with fastp reports, but some metrics are not available in fastp. This option is useful to save time and resources when running the pipeline."
                 },
                 "save_phixremoved_reads": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -388,7 +388,7 @@
                 "skip_fastqc": {
                     "type": "boolean",
                     "description": "Skip running FastQC on short reads both before and after QC.",
-                    "help": "Skips running FastQC on short reads. Most metrics are redundant with fastp reports, but some metrics are not available in fastp. This option is useful to save time and resources when running the pipeline."
+                    "help": "Skips running FastQC on short reads. Most metrics are redundant with reports from adapter clipping tools, but some metrics are not available from adapter clipping tools. This option is useful to save time and resources when running the pipeline."
                 },
                 "save_phixremoved_reads": {
                     "type": "boolean",

--- a/subworkflows/local/preprocessing_shortread/main.nf
+++ b/subworkflows/local/preprocessing_shortread/main.nf
@@ -24,13 +24,16 @@ workflow SHORTREAD_PREPROCESSING {
     ch_host_genome_index // path(fasta)                               (optional)
     ch_phix_db_file      // [val(meta), path(fasta)]                  (optional)
     val_skip_qc          // val(boolean)
+    val_skip_fastqc      // val(boolean)
 
     main:
     ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
 
-    FASTQC_RAW(ch_raw_short_reads)
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC_RAW.out.zip)
+    if (!val_skip_fastqc) {
+        FASTQC_RAW(ch_raw_short_reads)
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_RAW.out.zip)
+    }
 
     if (!params.assembly_input) {
         if (!params.skip_clipping && !val_skip_qc) {
@@ -148,15 +151,18 @@ workflow SHORTREAD_PREPROCESSING {
 
         /**
          * Conditions for *not* running FASTQC_TRIMMED:
+         * - Skip fastqc (params.skip_fastqc)
          * - No host removal and skip_qc (params.skip_shortread_qc)
          * - No host removal and *both* --keep_phix --skip_clipping
          */
-        if (!(val_skip_qc && !(params.host_fasta || params.host_genome))) {
-            if (!(params.keep_phix && params.skip_clipping && !(params.host_genome || params.host_fasta))) {
-                FASTQC_TRIMMED(
-                    ch_short_reads_for_merge
-                )
-                ch_multiqc_files = ch_multiqc_files.mix(FASTQC_TRIMMED.out.zip)
+        if (!val_skip_fastqc) {
+            if (!(val_skip_qc && !(params.host_fasta || params.host_genome))) {
+                if (!(params.keep_phix && params.skip_clipping && !(params.host_genome || params.host_fasta))) {
+                    FASTQC_TRIMMED(
+                        ch_short_reads_for_merge
+                    )
+                    ch_multiqc_files = ch_multiqc_files.mix(FASTQC_TRIMMED.out.zip)
+                }
             }
         }
     }

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -148,6 +148,7 @@ workflow MAG {
         ch_host_bowtie2index,
         ch_phix_db_file,
         params.skip_shortread_qc,
+        params.skip_fastqc,
     )
     ch_versions = ch_versions.mix(SHORTREAD_PREPROCESSING.out.versions)
     ch_multiqc_files = ch_multiqc_files.mix(


### PR DESCRIPTION
Added --skip_fastqc switch (default: false) that skips both FASTQC_RAW and FASTQC_TRIMMED steps in short-read preprocessing. Lot of it is redundant with fastp reports, which is sufficient for me. Parameter is declared in nextflow_schema.json and handled conditionally in subworkflows/local/shortread_preprocessing.nf

This is new to me, and my first real pull request ever. I hope everything is in order! Not sure about the lint, some warnings appeared but seemed not related to my changes.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
