### PR TITLE
perf: speed up binning by not waiting for all mapping jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1044](https://github.com/nf-core/mag/pull/1044) - Updated GTDB-Tk to v2.7.2 / GTDB r232 (by @dialvarezs)
 - [#1059](https://github.com/nf-core/mag/pull/1059) - Changed the default long read filtering tool from `filtlong` to `chopper` (by @dialvarezs)
 - [#1060](https://github.com/nf-core/mag/pull/1060) - Updated module tags to make them more specific (by @dialvarezs)
+- [#1061](https://github.com/nf-core/mag/pull/1061) - Speed up binning by not waiting for all mapping jobs to finish before starting (by @dialvarezs)
 
 ### `Fixed`
 

--- a/subworkflows/local/binning_preparation_longread/main.nf
+++ b/subworkflows/local/binning_preparation_longread/main.nf
@@ -36,8 +36,27 @@ workflow LONGREAD_BINNING_PREPARATION {
 
     MINIMAP2_ASSEMBLY_ALIGN(ch_minimap2_input_reads, ch_minimap2_input_idx, true, 'bai', false, false)
 
-    ch_grouped_mappings_reads = MINIMAP2_ASSEMBLY_ALIGN.out.bam.groupTuple(by: 0)
-    ch_grouped_mappings_index = MINIMAP2_ASSEMBLY_ALIGN.out.index.groupTuple(by: 0)
+    // expected number of mappings (read sets) per assembly, resolved early from
+    // the alignment inputs so groupTuple can release each assembly's group as
+    // soon as it is complete instead of waiting for every MINIMAP2_ASSEMBLY_ALIGN
+    // task to finish
+    ch_mapping_counts = ch_minimap2_input
+        .map { meta_idx, _index, _meta_reads, _reads -> [[meta_idx.assembler, meta_idx.id], 1] }
+        .groupTuple()
+        .map { key, counts -> [key, counts.size()] }
+
+    ch_grouped_mappings_reads = MINIMAP2_ASSEMBLY_ALIGN.out.bam
+        .map { meta, bam -> [[meta.assembler, meta.id], meta, bam] }
+        .combine(ch_mapping_counts, by: 0)
+        .map { key, meta, bam, count -> [groupKey(key, count), meta, bam] }
+        .groupTuple()
+        .map { _key, metas, bams -> [metas[0], bams] }
+    ch_grouped_mappings_index = MINIMAP2_ASSEMBLY_ALIGN.out.index
+        .map { meta, bai -> [[meta.assembler, meta.id], meta, bai] }
+        .combine(ch_mapping_counts, by: 0)
+        .map { key, meta, bai, count -> [groupKey(key, count), meta, bai] }
+        .groupTuple()
+        .map { _key, metas, bais -> [metas[0], bais] }
     ch_grouped_mappings = ch_grouped_mappings_reads
         .combine(ch_grouped_mappings_index, by: 0)
         .combine(ch_assemblies, by: 0)

--- a/subworkflows/local/binning_preparation_shortread/main.nf
+++ b/subworkflows/local/binning_preparation_shortread/main.nf
@@ -47,10 +47,24 @@ workflow SHORTREAD_BINNING_PREPARATION {
     BOWTIE2_ASSEMBLY_ALIGN(ch_bowtie2_input)
     ch_versions = ch_versions.mix(BOWTIE2_ASSEMBLY_ALIGN.out.versions)
 
+    // expected number of mappings (read sets) per assembly, resolved early from
+    // the alignment inputs so groupTuple can release each assembly's group as
+    // soon as it is complete instead of waiting for every BOWTIE2_ASSEMBLY_ALIGN
+    // task to finish
+    ch_mapping_counts = ch_bowtie2_input
+        .map { assembly_meta, _assembly, _index, _reads_meta, _reads ->
+            [[assembly_meta.assembler, assembly_meta.id], 1]
+        }
+        .groupTuple()
+        .map { key, counts -> [key, counts.size()] }
+
     // group mappings for one assembly
     ch_grouped_mappings = BOWTIE2_ASSEMBLY_ALIGN.out.mappings
-        .groupTuple(by: 0)
-        .map { meta, assembly, bams, bais -> [meta, assembly.sort()[0], bams, bais] }
+        .map { meta, assembly, bam, bai -> [[meta.assembler, meta.id], meta, assembly, bam, bai] }
+        .combine(ch_mapping_counts, by: 0)
+        .map { key, meta, assembly, bam, bai, count -> [groupKey(key, count), meta, assembly, bam, bai] }
+        .groupTuple()
+        .map { _key, metas, assemblies, bams, bais -> [metas[0], assemblies.sort()[0], bams, bais] }
 
     emit:
     bowtie2_assembly_multiqc = BOWTIE2_ASSEMBLY_ALIGN.out.log.map { _assembly_meta, _reads_meta, log -> [log] }


### PR DESCRIPTION
This is performance/QoL improvement.

Right now, binners have to wait for every `BOWTIE2_ASSEMBLY_ALIGN / MINIMAP2_ASSEMBLY_ALIGN` to finish, because `groupTuple(by:0)` doesn't know how many elements will be in the tuple.

In practice this means a couple of straggler alignment jobs stall the entire shortread (or longread) binning path, even for assemblies whose mappings already completed. This inflates runtimes and makes resource usage suboptimal.

Fix: the mappings per assembly are predictable from `binning_map_mode` (own -> 1, group -> samples in group, all -> total samples). We compute that count and wrap the key with `groupKey(key, count)`, so each group is released as soon as it's complete.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
