### PR TITLE
fix: change approach to prevent assembly -> binning locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1044](https://github.com/nf-core/mag/pull/1044) - Updated GTDB-Tk to v2.7.2 / GTDB r232 (by @dialvarezs)
 - [#1059](https://github.com/nf-core/mag/pull/1059) - Changed the default long read filtering tool from `filtlong` to `chopper` (by @dialvarezs)
 - [#1060](https://github.com/nf-core/mag/pull/1060) - Updated module tags to make them more specific (by @dialvarezs)
-- [#1061](https://github.com/nf-core/mag/pull/1061) - Speed up binning by not waiting for all mapping jobs to finish before starting (by @dialvarezs)
+- [#1061](https://github.com/nf-core/mag/pull/1061), [#1064](https://github.com/nf-core/mag/pull/1064) - Speed up binning by not waiting for all mapping jobs to finish before starting (by @dialvarezs)
 - [#1063](https://github.com/nf-core/mag/pull/1063) - Run ALE with `--metagenome` and disable its per-base output by default (by @dialvarezs)
 
 ### `Fixed`

--- a/subworkflows/local/binning_preparation_longread/main.nf
+++ b/subworkflows/local/binning_preparation_longread/main.nf
@@ -1,6 +1,16 @@
 include { MINIMAP2_INDEX as MINIMAP2_ASSEMBLY_INDEX } from '../../../modules/nf-core/minimap2/index/main'
 include { MINIMAP2_ALIGN as MINIMAP2_ASSEMBLY_ALIGN } from '../../../modules/nf-core/minimap2/align/main'
 
+def mappingKey(meta) {
+    if (params.binning_map_mode == 'group') {
+        return meta.group
+    }
+    if (params.binning_map_mode == 'own') {
+        return meta.id
+    }
+    return 'all'
+}
+
 workflow LONGREAD_BINNING_PREPARATION {
     take:
     ch_assemblies // [val(meta), path(assembly)]
@@ -11,54 +21,38 @@ workflow LONGREAD_BINNING_PREPARATION {
 
     MINIMAP2_ASSEMBLY_INDEX(ch_assemblies)
 
-    if (params.binning_map_mode == 'all') {
-        ch_minimap2_input = MINIMAP2_ASSEMBLY_INDEX.out.index
-            .combine(ch_reads)
-            .map { meta_idx, idx, meta_reads, reads -> [meta_idx, idx, meta_reads, reads] }
-    }
-    else if (params.binning_map_mode == 'group') {
-        ch_reads_minimap2 = ch_reads.map { meta, reads -> [meta.group, meta, reads] }
-        ch_minimap2_input = MINIMAP2_ASSEMBLY_INDEX.out.index
-            .map { meta_idx, index -> [meta_idx.group, meta_idx, index] }
-            .combine(ch_reads_minimap2, by: 0)
-            .map { _group, meta_idx, idx, meta_reads, reads -> [meta_idx, idx, meta_reads, reads] }
-    }
-    else {
-        ch_reads_minimap2 = ch_reads.map { meta, reads -> [meta.id, meta, reads] }
-        ch_minimap2_input = MINIMAP2_ASSEMBLY_INDEX.out.index
-            .map { meta_idx, index -> [meta_idx.id, meta_idx, index] }
-            .combine(ch_reads_minimap2, by: 0)
-            .map { _id, meta_idx, idx, meta_reads, reads -> [meta_idx, idx, meta_reads, reads] }
-    }
+    // combine assemblies with reads depending on mapping mode
+    ch_reads_minimap2 = ch_reads.map { meta, reads -> [mappingKey(meta), meta, reads] }
+    ch_minimap2_input = MINIMAP2_ASSEMBLY_INDEX.out.index
+        .map { meta_idx, index -> [mappingKey(meta_idx), meta_idx, index] }
+        .combine(ch_reads_minimap2, by: 0)
+        .multiMap { _key, meta_idx, index, meta_reads, reads ->
+            reads: [meta_idx, reads]
+            index: [meta_reads, index]
+        }
 
-    ch_minimap2_input_reads = ch_minimap2_input.map { meta_idx, _index, _meta, reads -> [meta_idx, reads] }
-    ch_minimap2_input_idx = ch_minimap2_input.map { _meta_idx, index, meta, _reads -> [meta, index] }
+    MINIMAP2_ASSEMBLY_ALIGN(ch_minimap2_input.reads, ch_minimap2_input.index, true, 'bai', false, false)
 
-    MINIMAP2_ASSEMBLY_ALIGN(ch_minimap2_input_reads, ch_minimap2_input_idx, true, 'bai', false, false)
-
-    // expected number of mappings (read sets) per assembly, resolved early from
-    // the alignment inputs so groupTuple can release each assembly's group as
-    // soon as it is complete instead of waiting for every MINIMAP2_ASSEMBLY_ALIGN
-    // task to finish
-    ch_mapping_counts = ch_minimap2_input
-        .map { meta_idx, _index, _meta_reads, _reads -> [[meta_idx.assembler, meta_idx.id], 1] }
+    // read sets expected per assembly, counted from the reads so groupTuple can
+    // release each assembly as soon as its own alignments finish instead of
+    // waiting for every MINIMAP2_ASSEMBLY_ALIGN task
+    ch_reads_count = ch_reads
+        .map { meta, _reads -> [mappingKey(meta), 1] }
         .groupTuple()
         .map { key, counts -> [key, counts.size()] }
 
-    ch_grouped_mappings_reads = MINIMAP2_ASSEMBLY_ALIGN.out.bam
-        .map { meta, bam -> [[meta.assembler, meta.id], meta, bam] }
+    ch_mapping_counts = ch_assemblies
+        .map { meta, _assembly -> [mappingKey(meta), meta.assembler, meta.id] }
+        .combine(ch_reads_count, by: 0)
+        .map { _key, assembler, id, count -> [[assembler, id], count] }
+
+    ch_grouped_mappings = MINIMAP2_ASSEMBLY_ALIGN.out.bam
+        .join(MINIMAP2_ASSEMBLY_ALIGN.out.index)
+        .map { meta, bam, bai -> [[meta.assembler, meta.id], meta, bam, bai] }
         .combine(ch_mapping_counts, by: 0)
-        .map { key, meta, bam, count -> [groupKey(key, count), meta, bam] }
+        .map { key, meta, bam, bai, count -> [groupKey(key, count), meta, bam, bai] }
         .groupTuple()
-        .map { _key, metas, bams -> [metas[0], bams] }
-    ch_grouped_mappings_index = MINIMAP2_ASSEMBLY_ALIGN.out.index
-        .map { meta, bai -> [[meta.assembler, meta.id], meta, bai] }
-        .combine(ch_mapping_counts, by: 0)
-        .map { key, meta, bai, count -> [groupKey(key, count), meta, bai] }
-        .groupTuple()
-        .map { _key, metas, bais -> [metas[0], bais] }
-    ch_grouped_mappings = ch_grouped_mappings_reads
-        .combine(ch_grouped_mappings_index, by: 0)
+        .map { _key, metas, bams, bais -> [metas[0], bams, bais] }
         .combine(ch_assemblies, by: 0)
         .map { meta, bams, bais, assembly -> [meta, assembly, bams, bais] }
 

--- a/subworkflows/local/binning_preparation_shortread/main.nf
+++ b/subworkflows/local/binning_preparation_shortread/main.nf
@@ -5,6 +5,16 @@
 include { BOWTIE2_ASSEMBLY_BUILD } from '../../../modules/local/bowtie2_assembly_build/main'
 include { BOWTIE2_ASSEMBLY_ALIGN } from '../../../modules/local/bowtie2_assembly_align/main'
 
+def mappingKey(meta) {
+    if (params.binning_map_mode == 'group') {
+        return meta.group
+    }
+    if (params.binning_map_mode == 'own') {
+        return meta.id
+    }
+    return 'all'
+}
+
 workflow SHORTREAD_BINNING_PREPARATION {
     take:
     ch_assemblies // [val(meta), path(assembly)]
@@ -17,46 +27,30 @@ workflow SHORTREAD_BINNING_PREPARATION {
     BOWTIE2_ASSEMBLY_BUILD(ch_assemblies)
     ch_versions = ch_versions.mix(BOWTIE2_ASSEMBLY_BUILD.out.versions)
 
-    // combine assemblies with sample reads for binning depending on specified mapping mode
-    if (params.binning_map_mode == 'all') {
-        // combine assemblies with reads of all samples
-        ch_bowtie2_input = BOWTIE2_ASSEMBLY_BUILD.out.assembly_index.combine(ch_reads)
-    }
-    else if (params.binning_map_mode == 'group') {
-        // combine assemblies with reads of samples from same group
-        ch_reads_bowtie2 = ch_reads.map { meta, sample_reads -> [meta.group, meta, sample_reads] }
-        ch_bowtie2_input = BOWTIE2_ASSEMBLY_BUILD.out.assembly_index
-            .map { meta, assembly, index -> [meta.group, meta, assembly, index] }
-            .combine(ch_reads_bowtie2, by: 0)
-            .map { _group, assembly_meta, assembly, index, reads_meta, sample_reads ->
-                [assembly_meta, assembly, index, reads_meta, sample_reads]
-            }
-    }
-    else {
-        // i.e. --binning_map_mode 'own'
-        // combine assemblies (not co-assembled) with reads from own sample
-        ch_reads_bowtie2 = ch_reads.map { meta, sample_reads -> [meta.id, meta, sample_reads] }
-        ch_bowtie2_input = BOWTIE2_ASSEMBLY_BUILD.out.assembly_index
-            .map { meta, assembly, index -> [meta.id, meta, assembly, index] }
-            .combine(ch_reads_bowtie2, by: 0)
-            .map { _id, assembly_meta, assembly, index, reads_meta, sample_reads ->
-                [assembly_meta, assembly, index, reads_meta, sample_reads]
-            }
-    }
+    // combine assemblies with sample reads depending on mapping mode
+    ch_reads_bowtie2 = ch_reads.map { meta, sample_reads -> [mappingKey(meta), meta, sample_reads] }
+    ch_bowtie2_input = BOWTIE2_ASSEMBLY_BUILD.out.assembly_index
+        .map { meta, assembly, index -> [mappingKey(meta), meta, assembly, index] }
+        .combine(ch_reads_bowtie2, by: 0)
+        .map { _key, assembly_meta, assembly, index, reads_meta, sample_reads ->
+            [assembly_meta, assembly, index, reads_meta, sample_reads]
+        }
 
     BOWTIE2_ASSEMBLY_ALIGN(ch_bowtie2_input)
     ch_versions = ch_versions.mix(BOWTIE2_ASSEMBLY_ALIGN.out.versions)
 
-    // expected number of mappings (read sets) per assembly, resolved early from
-    // the alignment inputs so groupTuple can release each assembly's group as
-    // soon as it is complete instead of waiting for every BOWTIE2_ASSEMBLY_ALIGN
-    // task to finish
-    ch_mapping_counts = ch_bowtie2_input
-        .map { assembly_meta, _assembly, _index, _reads_meta, _reads ->
-            [[assembly_meta.assembler, assembly_meta.id], 1]
-        }
+    // read sets expected per assembly, counted from the reads so groupTuple can
+    // release each assembly as soon as its own alignments finish instead of
+    // waiting for every BOWTIE2_ASSEMBLY_ALIGN task
+    ch_reads_count = ch_reads
+        .map { meta, _reads -> [mappingKey(meta), 1] }
         .groupTuple()
         .map { key, counts -> [key, counts.size()] }
+
+    ch_mapping_counts = ch_assemblies
+        .map { meta, _assembly -> [mappingKey(meta), meta.assembler, meta.id] }
+        .combine(ch_reads_count, by: 0)
+        .map { _key, assembler, id, count -> [[assembler, id], count] }
 
     // group mappings for one assembly
     ch_grouped_mappings = BOWTIE2_ASSEMBLY_ALIGN.out.mappings


### PR DESCRIPTION
This is a follow-up on #1061.
It turns out that the approach implemented there didn't work as expected because it depended on the channels.
This new approach uses the `params.binning_map_mode` directly. I simplified the workflows, and now it's easier to read and follow. This was validated on a real run.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
