### PR TITLE
reafactor: deprecate skip_metaeuk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#908](https://github.com/nf-core/mag/pull/908) - Removed local `quast_bins_summary` in favor of `csvtk/concat` (by @dialvarezs)
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Remove `mag_depths_plot` local module (by @dialvarezs)
 - [#1018](https://github.com/nf-core/mag/pull/1018) - Deprecated `--gtdbtk_skip_aniscreen` in favor of `--gtdbtk_place_species` (by @dialvarezs)
+- [#1067](https://github.com/nf-core/mag/pull/1066) - Deprecated `--skip_metaeuk` as it has no effect, MetaEuk is gated by `--metaeuk_db` / `--metaeuk_mmseqs_db` (by @dialvarezs)
 
 ## 5.4.2 Yellow Frog patch [2026-03-31]
 

--- a/conf/test_alternatives.config
+++ b/conf/test_alternatives.config
@@ -50,6 +50,5 @@ params {
     skip_comebin               = true
     skip_metabinner            = true
     skip_semibin               = true
-    skip_metaeuk               = true
     megahit_fix_cpu_1          = true
 }

--- a/conf/test_assembly_input.config
+++ b/conf/test_assembly_input.config
@@ -58,7 +58,6 @@ params {
     run_gunc                        = true
     gunc_db                         = params.pipelines_testdata_base_path + 'mag/databases/gunc/ci_test.dmnd'
 
-    skip_metaeuk                    = false
     metaeuk_mmseqs_db               = 'Kalamari'
 }
 

--- a/conf/test_longreadonly_alternatives.config
+++ b/conf/test_longreadonly_alternatives.config
@@ -53,5 +53,4 @@ params {
     skip_comebin                  = true
     skip_metabinner               = true
     skip_semibin                  = true
-    skip_metaeuk                  = true
 }

--- a/conf/test_minimal.config
+++ b/conf/test_minimal.config
@@ -52,6 +52,5 @@ params {
     skip_gtdbtk                   = true
     gtdbtk_min_completeness       = 0.01
     gtdbtk_place_species          = true
-    skip_metaeuk                  = true
     skip_ancient_damagecorrection = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -186,7 +186,7 @@ params {
     metabat_rng_seed                     = 1
 
     // Annotation options
-    skip_metaeuk                         = false
+    skip_metaeuk                         = false // DEPRECATED: no longer has any effect, MetaEuk is gated by --metaeuk_db / --metaeuk_mmseqs_db
     metaeuk_mmseqs_db                    = null
     metaeuk_db                           = null
     save_mmseqs_db                       = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -698,7 +698,7 @@
                 },
                 "skip_metaeuk": {
                     "type": "boolean",
-                    "description": "Skip MetaEuk gene prediction and annotation"
+                    "description": "[DEPRECATED] This parameter no longer has any effect and will be removed in a future release. MetaEuk only runs when `--metaeuk_db` or `--metaeuk_mmseqs_db` is supplied."
                 },
                 "metaeuk_mmseqs_db": {
                     "type": "string",

--- a/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
@@ -380,6 +380,10 @@ def validateInputParameters(hybrid) {
         log.warn("[nf-core/mag]: The parameter '--gtdbtk_skip_aniscreen' is deprecated and will be removed in a future release. Please use '--gtdbtk_place_species' instead.")
     }
 
+    if (params.skip_metaeuk) {
+        log.warn("[nf-core/mag]: The parameter '--skip_metaeuk' is deprecated and will be removed in a future release. It no longer has any effect: MetaEuk only runs when '--metaeuk_db' or '--metaeuk_mmseqs_db' is supplied.")
+    }
+
     if (!params.skip_gtdbtk) {
         if (params.skip_binqc) {
             log.warn('[nf-core/mag]: --skip_binqc is specified, but --skip_gtdbtk is explicitly set to run! GTDB-tk will be omitted because GTDB-tk bin classification requires bin filtering based on BUSCO or CheckM QC results to avoid GTDB-tk errors.')

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -122,7 +122,7 @@ workflow MAG {
         gtdb = []
     }
 
-    if (params.metaeuk_db && !params.skip_metaeuk) {
+    if (params.metaeuk_db) {
         ch_metaeuk_db = channel.value(file("${params.metaeuk_db}", checkIfExists: true))
     }
     else {
@@ -130,7 +130,7 @@ workflow MAG {
     }
 
     // Get mmseqs db for MetaEuk if requested
-    if (!params.skip_metaeuk && params.metaeuk_mmseqs_db) {
+    if (params.metaeuk_mmseqs_db) {
         MMSEQS_DATABASES(params.metaeuk_mmseqs_db)
         ch_versions = ch_versions.mix(MMSEQS_DATABASES.out.versions)
         ch_metaeuk_db = MMSEQS_DATABASES.out.database
@@ -593,7 +593,7 @@ workflow MAG {
             ch_versions = ch_versions.mix(PROKKA.out.versions)
         }
 
-        if (!params.skip_metaeuk && (params.metaeuk_db || params.metaeuk_mmseqs_db)) {
+        if (params.metaeuk_db || params.metaeuk_mmseqs_db) {
             ch_bins_for_metaeuk = ch_input_for_postbinning
                 .transpose()
                 .filter { meta, _bin ->


### PR DESCRIPTION
Even if `skip_metaeuk` was `false` by default, it is really gated by the database parameter, so it's redundant and confusing.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
