### PR TITLE
perf: unflatten dastool_fasta2contig input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1065](https://github.com/nf-core/mag/pull/1065) - Improved efficiency by removing usage of per-bin GUNZIP module for bins and unbinned contigs and allowing gzip support for all modules (by @dialvarezs)
 - [#1066](https://github.com/nf-core/mag/pull/1066) - Improved efficiency by removing channel "locks" on Seqkit, QUAST, and GTDB-Tk (by @dialvarezs)
 - [#1070](https://github.com/nf-core/mag/pull/1070) - Update BUSCO nf-core module (by @dialvarezs)
+- [#1071](https://github.com/nf-core/mag/pull/1071) - Improved efficiency by batching `DASTOOL_FASTATOCONTIG2BIN` per binner instead of per bin (by @dialvarezs)
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1060,8 +1060,8 @@ process {
     }
 
     withName: DASTOOL_FASTATOCONTIG2BIN {
-        tag        = { "${fasta.baseName}" }
-        ext.prefix = { "${fasta.baseName}_contiglist" }
+        tag        = { "${meta.assembler}-${meta.binner}-${meta.id}" }
+        ext.prefix = { "${meta.assembler}-${meta.binner}-${meta.id}_contiglist" }
         publishDir = [
             path: { "${params.outdir}/GenomeBinning/DASTool/fastatocontig2bin/" },
             mode: params.publish_dir_mode,

--- a/subworkflows/local/binning_refinement/main.nf
+++ b/subworkflows/local/binning_refinement/main.nf
@@ -35,10 +35,9 @@ workflow BINNING_REFINEMENT {
     // prepare bins
     RENAME_PREDASTOOL(ch_bins)
     ch_bins_for_fastatocontig2bin = RENAME_PREDASTOOL.out.renamed_bins
-        .transpose()
-        .multiMap { meta, bin ->
-            bins: [meta, bin]
-            ext: bin.extension
+        .multiMap { meta, bins ->
+            bins: [meta, bins]
+            ext: 'fa'
         }
     ch_versions = ch_versions.mix(RENAME_PREDASTOOL.out.versions)
 

--- a/tests/test_assembly_input.nf.test.snap
+++ b/tests/test_assembly_input.nf.test.snap
@@ -65,7 +65,7 @@
     },
     "-profile assembly_input": {
         "content": [
-            194,
+            105,
             {
                 "ADJUST_MAXBIN2_EXT": {
                     "coreutils": 9.5
@@ -169,7 +169,7 @@
                 }
             }
         ],
-        "timestamp": "2026-07-09T14:19:50.581085946",
+        "timestamp": "2026-07-10T01:50:53.792824455",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -495,12 +495,12 @@
                 "SPAdes-CONCOCT-test_minigut_sample2_clustering_gt1000.csv:md5,4bbba6a0ba80b107ef2b13b7089e2156",
                 "MEGAHIT-DASTool-test_minigut.seqlength:md5,f154f9ef4a4c0adb8d8f9ebb8163df93",
                 "MEGAHIT-DASTool-test_minigut_DASTool_contig2bin.tsv:md5,6add6f39f4fd9c31ff9f58df5f28fcdf",
-                "MEGAHIT-DASTool-test_minigut_DASTool_summary.tsv:md5,33aee7453e0ee3bd84b4d911e0419032",
-                "MEGAHIT-DASTool-test_minigut_allBins.eval:md5,48415e0a36f6cb05fc36ea64d9394b1f",
+                "MEGAHIT-DASTool-test_minigut_DASTool_summary.tsv:md5,05dd33082bed2dbab635ba2e32774d84",
+                "MEGAHIT-DASTool-test_minigut_allBins.eval:md5,1d74311761c9134be3d71ebe8d4da3b8",
                 "SPAdes-DASTool-test_minigut.seqlength:md5,4860a5cb7b0bf2e78e959111b5619006",
                 "SPAdes-DASTool-test_minigut_DASTool_contig2bin.tsv:md5,07c1af95dd0da4c11de390c2f188fe6c",
-                "SPAdes-DASTool-test_minigut_DASTool_summary.tsv:md5,29dcb8c0665f0b129f6fd66a83112380",
-                "SPAdes-DASTool-test_minigut_allBins.eval:md5,966f10c283df77494d43ed7ce5106a03",
+                "SPAdes-DASTool-test_minigut_DASTool_summary.tsv:md5,d25af93947d8690dc4979d42a6845151",
+                "SPAdes-DASTool-test_minigut_allBins.eval:md5,25311a65a614b4e2998bf8641c8d84e0",
                 "MEGAHIT-MetaBAT2Refined-test_minigut.1.fa.gz:md5,489a5f7ba3795477e09d2d396fe535c3",
                 "MEGAHIT-MetaBAT2Refined-test_minigut.2.fa.gz:md5,1addf634bca82af85d36621585f93f52",
                 "SPAdes-CONCOCTRefined-test_minigut.7.fa.gz:md5,4be1cc2c06f329e0102cb27b03e30624",
@@ -557,7 +557,7 @@
                 "bin_depths_summary.tsv:md5,7153f759db72abb02e2ee3c2ab1b5e56"
             ]
         ],
-        "timestamp": "2026-07-09T14:19:50.913600634",
+        "timestamp": "2026-07-10T01:50:53.97279516",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"


### PR DESCRIPTION
`DASTOOL_FASTATOCONTIG2BIN` was running once per bin, spawning a large number of jobs.
But this isn't necessary: `Fasta_to_Contig2Bin.sh` takes a directory (`-i`) and processes all FASTA files in it at once, producing the same contig2bin table.
This PR removes `.transpose()` so each binner's bins are passed as a single batch.

Notes:
- The fa extension is hardcoded instead of read per-file, since RENAME_PREDASTOOL guarantees every bin is renamed to .fa (it errors out otherwise). This matches how the TIARA subworkflow already calls the same module.
- Snapshot changes are limited to:
  - Fewer succeeded jobs, the direct benefit of this change.
  - `_DASTool_summary.tsv` / `_allBins.eval checksums`, only the source-filename column changes (now the per-binner contig2bin file rather than the per-bin one). All bin scores, sizes, and completeness values are identical.
  - No change to the refined bins (`.fa.gz`) or `_DASTool_contig2bin.tsv`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
