### PR TITLE
fix: sort GTDB-Tk input bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1049](https://github.com/nf-core/mag/pull/1049) - Fix publishing issue with `gtdbtk/classifywf` (by @dialvarezs)
 - [#1058](https://github.com/nf-core/mag/pull/1058) - Make `create_metabinner_bins.py` save gzipped bin files to prevent NFS race condition (by @dialvarezs)
 - [#1069](https://github.com/nf-core/mag/pull/1069) - Exclude eukaryotic bins from CheckM2, which only supports bacterial and archaeal genomes (by @dialvarezs)
+- [#1078](https://github.com/nf-core/mag/pull/1078) - Sort bins before GTDB-Tk classification so order-sensitive outputs are reproducible across environments (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -94,7 +94,7 @@ workflow GTDBTK {
         }
 
     ch_passed_bins = ch_filtered_bins
-        .map { meta, passed, _discarded -> [meta, passed] }
+        .map { meta, passed, _discarded -> [meta, passed.sort { bin -> bin.name }] }
         .filter { _meta, passed -> passed }
     ch_passed_flat = ch_passed_bins.flatMap { _meta, passed -> passed }
     ch_discarded_bins = ch_filtered_bins.flatMap { _meta, _passed, discarded -> discarded }
@@ -110,6 +110,8 @@ workflow GTDBTK {
                 ]
             }
             .groupTuple()
+            // Sort bins by name so GTDB-Tk receives a deterministic input order.
+            .map { meta, bins -> [meta, bins.sort { bin -> bin.name }] }
     }
     else {
         ch_bins_for_classifywf = ch_passed_bins


### PR DESCRIPTION
One of the GTDB-Tk tsv output fails checksum sometimes, this should cover it.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
