### PR TITLE
Add exit code 247 to MEGAHIT retry error strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1070](https://github.com/nf-core/mag/pull/1070) - Update BUSCO nf-core module (by @dialvarezs)
 - [#1071](https://github.com/nf-core/mag/pull/1071) - Improved efficiency by batching `DASTOOL_FASTATOCONTIG2BIN` per binner instead of per bin (by @dialvarezs)
 - [#1074](https://github.com/nf-core/mag/pull/1074) - Exclude BUSCO output directories to reduce storage usage in output dir (by @dialvarezs)
+- [#1079](https://github.com/nf-core/mag/pull/1079) - Add exit code 247 to the MEGAHIT retry error strategy (by @dialvarezs)
 - [#1075](https://github.com/nf-core/mag/pull/1075) - Update output documentation to reflect BUSCO complete directory no longer being published (by @dialvarezs)
 
 ### `Fixed`

--- a/conf/base.config
+++ b/conf/base.config
@@ -113,7 +113,7 @@ process {
         cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
         memory        = { 40.GB * task.attempt }
         time          = { 16.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
     }
     //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
     //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility


### PR DESCRIPTION
## Description

MEGAHIT can exit with code `247` when it runs out of memory (alongside the already-handled `250`). Previously this exit code caused the task to `finish` instead of `retry`, so out-of-memory runs failed permanently rather than getting a fresh attempt with more memory.

This PR adds `247` to the MEGAHIT `errorStrategy` retry list in `conf/base.config`.

```diff
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)