### PR TITLE
fix: conda-related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1069](https://github.com/nf-core/mag/pull/1069) - Exclude eukaryotic bins from CheckM2, which only supports bacterial and archaeal genomes (by @dialvarezs)
 - [#1076](https://github.com/nf-core/mag/pull/1076) - Add missing PyPOLCA citations to README, `CITATIONS.md` and the pipeline citation/bibliography text (by @dialvarezs)
 - [#1078](https://github.com/nf-core/mag/pull/1078) - Sort bins before GTDB-Tk classification so order-sensitive outputs are reproducible across environments (by @dialvarezs)
+- [#1084](https://github.com/nf-core/mag/pull/1084) - Update Prokka nf-core module, which pins GNU parallel to fix Prokka failures with Conda (by @dialvarezs)
+- [#1084](https://github.com/nf-core/mag/pull/1084) - Disable NanoPlot static plot export in the nf-test config, as it only works where a Chrome installation is available and made outputs differ between profiles (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1079](https://github.com/nf-core/mag/pull/1079) - Add exit code 247 to the MEGAHIT retry error strategy (by @dialvarezs)
 - [#1080](https://github.com/nf-core/mag/pull/1080) - Updated to nf-core 4.0.3 `TEMPLATE` (by @dialvarezs)
 - [#1081](https://github.com/nf-core/mag/pull/1081) - Use subset database for geNomad (by @dialvarezs)
+- [#1084](https://github.com/nf-core/mag/pull/1084) - Disable NanoPlot static plot image files by default, since it depends on Chrome installed (by @dialvarezs)
 
 ### `Fixed`
 
@@ -60,7 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1076](https://github.com/nf-core/mag/pull/1076) - Add missing PyPOLCA citations to README, `CITATIONS.md` and the pipeline citation/bibliography text (by @dialvarezs)
 - [#1078](https://github.com/nf-core/mag/pull/1078) - Sort bins before GTDB-Tk classification so order-sensitive outputs are reproducible across environments (by @dialvarezs)
 - [#1084](https://github.com/nf-core/mag/pull/1084) - Update Prokka nf-core module, which pins GNU parallel to fix Prokka failures with Conda (by @dialvarezs)
-- [#1084](https://github.com/nf-core/mag/pull/1084) - Disable NanoPlot static plot export in the nf-test config, as it only works where a Chrome installation is available and made outputs differ between profiles (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -289,6 +289,7 @@ process {
                 "-p raw_",
                 "--title ${meta.id}_raw",
                 "-c darkblue",
+                "-f",
             ].join(' ').trim()
         }
         publishDir = [
@@ -304,6 +305,7 @@ process {
                 "-p filtered_",
                 "--title ${meta.id}_filtered",
                 "-c darkblue",
+                "-f",
             ].join(' ').trim()
         }
         publishDir = [

--- a/docs/output.md
+++ b/docs/output.md
@@ -169,8 +169,8 @@ NanoPlot is used to calculate various metrics and plots about the quality and le
 <summary>Output files</summary>
 
 - `QC_longreads/NanoPlot/[sample]/`
-  - `raw_*.[png/html/txt]`: Plots and reports for raw data
-  - `filtered_*.[png/html/txt]`: Plots and reports for filtered data
+  - `raw_*.[html/txt]`: Plots and reports for raw data
+  - `filtered_*.[html/txt]`: Plots and reports for filtered data
 
 </details>
 

--- a/modules.json
+++ b/modules.json
@@ -288,7 +288,7 @@
                     },
                     "prokka": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "2dc23692bd1c3a23a12cfd959808a8fe7e3c6557",
                         "installed_by": ["modules"]
                     },
                     "pydamage/analyze": {

--- a/modules/nf-core/prokka/environment.yml
+++ b/modules/nf-core/prokka/environment.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::prokka=1.14.6
   - conda-forge::openjdk=8.0.412
+  - conda-forge::parallel=20241122

--- a/modules/nf-core/prokka/main.nf
+++ b/modules/nf-core/prokka/main.nf
@@ -3,7 +3,7 @@ process PROKKA {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3a/3af46b047c8fe84112adeaecf300878217c629b97f111f923ecf327656ddd141/data' :
         'community.wave.seqera.io/library/prokka_openjdk:10546cadeef11472' }"
 
@@ -25,7 +25,7 @@ process PROKKA {
     tuple val(meta), path("${prefix}/*.log"), emit: log
     tuple val(meta), path("${prefix}/*.txt"), emit: txt
     tuple val(meta), path("${prefix}/*.tsv"), emit: tsv
-    path "versions.yml" , emit: versions
+    tuple val("${task.process}"), val('prokka'), eval("prokka --version 2>&1 | sed 's/^.*prokka //'"), topic: versions, emit: versions_prokka
 
     when:
     task.ext.when == null || task.ext.when
@@ -50,11 +50,6 @@ process PROKKA {
         ${input}
 
     ${cleanup}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        prokka: \$(echo \$(prokka --version 2>&1) | sed 's/^.*prokka //')
-    END_VERSIONS
     """
 
     stub:
@@ -74,10 +69,5 @@ process PROKKA {
     touch ${prefix}/${prefix}.txt
     touch ${prefix}/${prefix}.tsv
     touch ${prefix}/${prefix}.gff
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        prokka: \$(echo \$(prokka --version 2>&1) | sed 's/^.*prokka //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/prokka/meta.yml
+++ b/modules/nf-core/prokka/meta.yml
@@ -1,5 +1,6 @@
 name: prokka
-description: Whole genome annotation of small genomes (bacterial, archeal, viral)
+description: Whole genome annotation of small genomes (bacterial, archeal,
+  viral)
 keywords:
   - annotation
   - fasta
@@ -9,7 +10,8 @@ tools:
       description: Rapid annotation of prokaryotic genomes
       homepage: https://github.com/tseemann/prokka
       doi: "10.1093/bioinformatics/btu153"
-      licence: ["GPL v2"]
+      licence:
+        - "GPL v2"
       identifier: biotools:prokka
 input:
   - - meta:
@@ -24,7 +26,8 @@ input:
         ontologies: []
   - proteins:
       type: file
-      description: FASTA file of trusted proteins to first annotate from (optional)
+      description: FASTA file of trusted proteins to first annotate from
+        (optional)
       ontologies: []
   - prodigal_tf:
       type: file
@@ -39,7 +42,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.gff:
           type: file
-          description: annotation in GFF3 format, containing both sequences and annotations
+          description: annotation in GFF3 format, containing both sequences and
+            annotations
           pattern: "*.{gff}"
           ontologies: []
   gbk:
@@ -50,7 +54,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.gbk:
           type: file
-          description: annotation in GenBank format, containing both sequences and annotations
+          description: annotation in GenBank format, containing both sequences and
+            annotations
           pattern: "*.{gbk}"
           ontologies: []
   fna:
@@ -83,8 +88,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.ffn:
           type: file
-          description: nucleotide FASTA file of all the prediction transcripts (CDS,
-            rRNA, tRNA, tmRNA, misc_RNA)
+          description: nucleotide FASTA file of all the prediction transcripts
+            (CDS, rRNA, tRNA, tmRNA, misc_RNA)
           pattern: "*.{ffn}"
           ontologies: []
   sqn:
@@ -106,8 +111,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.fsa:
           type: file
-          description: nucleotide FASTA file of the input contig sequences, used by
-            "tbl2asn" to create the .sqn file
+          description: nucleotide FASTA file of the input contig sequences, used
+            by "tbl2asn" to create the .sqn file
           pattern: "*.{fsa}"
           ontologies: []
   tbl:
@@ -118,7 +123,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.tbl:
           type: file
-          description: feature Table file, used by "tbl2asn" to create the .sqn file
+          description: feature Table file, used by "tbl2asn" to create the .sqn
+            file
           pattern: "*.{tbl}"
           ontologies: []
   err:
@@ -162,17 +168,32 @@ output:
             e.g. [ id:'test', single_end:false ]
       - ${prefix}/*.tsv:
           type: file
-          description: tab-separated file of all features (locus_tag,ftype,len_bp,gene,EC_number,COG,product)
+          description: tab-separated file of all features
+            (locus_tag,ftype,len_bp,gene,EC_number,COG,product)
           pattern: "*.{tsv}"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
+  versions_prokka:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - prokka:
+          type: string
+          description: The name of the tool
+      - prokka --version 2>&1 | sed 's/^.*prokka //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - prokka:
+          type: string
+          description: The name of the tool
+      - prokka --version 2>&1 | sed 's/^.*prokka //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/prokka/tests/main.nf.test
+++ b/modules/nf-core/prokka/tests/main.nf.test
@@ -26,22 +26,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert path(process.out.gbk.get(0).get(1)).exists() },
-                { assert path(process.out.log.get(0).get(1)).exists() },
-                { assert path(process.out.sqn.get(0).get(1)).exists() },
-                { assert snapshot(
-                    process.out.gff,
-                    process.out.fna,
-                    process.out.faa,
-                    process.out.ffn,
-                    process.out.fsa,
-                    process.out.tbl,
-                    process.out.err,
-                    process.out.txt,
-                    process.out.tsv,
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["gbk", "log", "sqn"])).match()}
             )
         }
 
@@ -65,22 +50,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert path(process.out.gbk.get(0).get(1)).exists() },
-                { assert path(process.out.log.get(0).get(1)).exists() },
-                { assert path(process.out.sqn.get(0).get(1)).exists() },
-                { assert snapshot(
-                    process.out.gff,
-                    process.out.fna,
-                    process.out.faa,
-                    process.out.ffn,
-                    process.out.fsa,
-                    process.out.tbl,
-                    process.out.err,
-                    process.out.txt,
-                    process.out.tsv,
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["gbk", "log", "sqn"])).match()}
             )
         }
 
@@ -106,7 +76,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/prokka/tests/main.nf.test.snap
+++ b/modules/nf-core/prokka/tests/main.nf.test.snap
@@ -1,304 +1,259 @@
 {
     "Prokka - sarscov2 - genome.fasta": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.gff:md5,5dbfb8fcf2db020564c16045976a0933"
+            {
+                "err": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.err:md5,b3daedc646fddd422824e2b3e5e9229d"
+                    ]
+                ],
+                "faa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa:md5,a4ceda83262b3c222a6b1f508fb9e24b"
+                    ]
+                ],
+                "ffn": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.ffn:md5,80f474b5367b7ea5ed23791935f65e34"
+                    ]
+                ],
+                "fna": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna:md5,787307f29a263e5657cc276ebbf7e2b3"
+                    ]
+                ],
+                "fsa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fsa:md5,71bbefcb7f12046bcd3263f58cfd5404"
+                    ]
+                ],
+                "gbk": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk"
+                    ]
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff:md5,5dbfb8fcf2db020564c16045976a0933"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log"
+                    ]
+                ],
+                "sqn": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.sqn"
+                    ]
+                ],
+                "tbl": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tbl:md5,d8f816a066ced94b62d9618b13fb8add"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,da7c720c3018c5081d6a70b517b7d450"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt:md5,b40e485ffc8eaf1feacf8d79d9751a33"
+                    ]
+                ],
+                "versions_prokka": [
+                    [
+                        "PROKKA",
+                        "prokka",
+                        "1.14.6"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.fna:md5,787307f29a263e5657cc276ebbf7e2b3"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.faa:md5,a4ceda83262b3c222a6b1f508fb9e24b"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.ffn:md5,80f474b5367b7ea5ed23791935f65e34"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.fsa:md5,71bbefcb7f12046bcd3263f58cfd5404"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.tbl:md5,d8f816a066ced94b62d9618b13fb8add"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.err:md5,b3daedc646fddd422824e2b3e5e9229d"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.txt:md5,b40e485ffc8eaf1feacf8d79d9751a33"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.tsv:md5,da7c720c3018c5081d6a70b517b7d450"
-                ]
-            ],
-            [
-                "versions.yml:md5,e83a22fe02167e290d90853b45650db9"
-            ]
+            }
         ],
+        "timestamp": "2026-05-23T16:24:30.853426",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-30T12:34:20.447734"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "Prokka - sarscov2 - genome.fasta.gz": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.gff:md5,5dbfb8fcf2db020564c16045976a0933"
+            {
+                "err": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.err:md5,b3daedc646fddd422824e2b3e5e9229d"
+                    ]
+                ],
+                "faa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa:md5,a4ceda83262b3c222a6b1f508fb9e24b"
+                    ]
+                ],
+                "ffn": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.ffn:md5,80f474b5367b7ea5ed23791935f65e34"
+                    ]
+                ],
+                "fna": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna:md5,787307f29a263e5657cc276ebbf7e2b3"
+                    ]
+                ],
+                "fsa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fsa:md5,71bbefcb7f12046bcd3263f58cfd5404"
+                    ]
+                ],
+                "gbk": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk"
+                    ]
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff:md5,5dbfb8fcf2db020564c16045976a0933"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log"
+                    ]
+                ],
+                "sqn": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.sqn"
+                    ]
+                ],
+                "tbl": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tbl:md5,d8f816a066ced94b62d9618b13fb8add"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,da7c720c3018c5081d6a70b517b7d450"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt:md5,b40e485ffc8eaf1feacf8d79d9751a33"
+                    ]
+                ],
+                "versions_prokka": [
+                    [
+                        "PROKKA",
+                        "prokka",
+                        "1.14.6"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.fna:md5,787307f29a263e5657cc276ebbf7e2b3"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.faa:md5,a4ceda83262b3c222a6b1f508fb9e24b"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.ffn:md5,80f474b5367b7ea5ed23791935f65e34"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.fsa:md5,71bbefcb7f12046bcd3263f58cfd5404"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.tbl:md5,d8f816a066ced94b62d9618b13fb8add"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.err:md5,b3daedc646fddd422824e2b3e5e9229d"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.txt:md5,b40e485ffc8eaf1feacf8d79d9751a33"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.tsv:md5,da7c720c3018c5081d6a70b517b7d450"
-                ]
-            ],
-            [
-                "versions.yml:md5,e83a22fe02167e290d90853b45650db9"
-            ]
+            }
         ],
+        "timestamp": "2026-05-23T16:24:46.194236",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2024-12-19T09:48:05.110188714"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "Prokka - sarscov2 - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.gbk:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "10": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "11": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "12": [
-                    "versions.yml:md5,e83a22fe02167e290d90853b45650db9"
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.fna:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.ffn:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.sqn:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.fsa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "7": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tbl:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "8": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.err:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "9": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
                 "err": [
                     [
                         {
@@ -407,15 +362,19 @@
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e83a22fe02167e290d90853b45650db9"
+                "versions_prokka": [
+                    [
+                        "PROKKA",
+                        "prokka",
+                        "1.14.6"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-05-23T16:24:51.703195",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T10:51:57.362187225"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -10,16 +10,3 @@ params {
 }
 
 aws.client.anonymous = true // fixes S3 access issues on self-hosted runners
-
-// NanoPlot only exports static (PNG) plots when a Chrome installation is available to Kaleido,
-// which is the case for Conda (host Chrome) but not for the containers, so the published files
-// differ between profiles. Passing an empty `-f` skips them and keeps the output reproducible.
-process {
-    withName: NANOPLOT_RAW {
-        ext.args = { "-p raw_ --title ${meta.id}_raw -c darkblue -f" }
-    }
-
-    withName: NANOPLOT_FILTERED {
-        ext.args = { "-p filtered_ --title ${meta.id}_filtered -c darkblue -f" }
-    }
-}

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -10,3 +10,16 @@ params {
 }
 
 aws.client.anonymous = true // fixes S3 access issues on self-hosted runners
+
+// NanoPlot only exports static (PNG) plots when a Chrome installation is available to Kaleido,
+// which is the case for Conda (host Chrome) but not for the containers, so the published files
+// differ between profiles. Passing an empty `-f` skips them and keeps the output reproducible.
+process {
+    withName: NANOPLOT_RAW {
+        ext.args = { "-p raw_ --title ${meta.id}_raw -c darkblue -f" }
+    }
+
+    withName: NANOPLOT_FILTERED {
+        ext.args = { "-p filtered_ --title ${meta.id}_filtered -c darkblue -f" }
+    }
+}

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -589,7 +589,6 @@ workflow MAG {
                 [],
                 [],
             )
-            ch_versions = ch_versions.mix(PROKKA.out.versions)
         }
 
         if (params.metaeuk_db || params.metaeuk_mmseqs_db) {


### PR DESCRIPTION
Two changes to address the Conda failures / snapshot mismatches seen in #1083.
1. **Update the Prokka module.** GNU parallel `20260422+` fails every local job when `SHELL` isn't exported (`exec failed:No such file or directory`), which makes Prokka exit 2. The current module version pins `parallel=20241122` (nf-core/modules#11754). Containers ship an older parallel, hence Conda-only.
2. **Explicitly disable NanoPlot static images** (empty `-f`) in `tests/nextflow.config`. NanoPlot defaults to `--format png`, rendered via Kaleido, which needs Chrome. The runners have it, so Conda runs emit PNGs and container runs don't, causing snapshot drift.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
