### PR TITLE
Fix ConcurrentModificationException from in-place sorting of shared channel items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Rename MaxBin2 bins inside the `MAXBIN2` module via a patch instead of the `ADJUST_MAXBIN2_EXT` local module, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
+- [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/subworkflows/local/assembly/main.nf
+++ b/subworkflows/local/assembly/main.nf
@@ -39,10 +39,10 @@ workflow ASSEMBLY {
                     sr_platform: metas.sr_platform[0]
                 ]
                 if (assemble_as_single) {
-                    [meta, reads.sort { files -> files[0].getName() }, []]
+                    [meta, reads.toSorted { files -> files[0].getName() }, []]
                 }
                 else {
-                    [meta] + reads.sort { files -> files[0].getName() }.transpose()
+                    [meta] + reads.toSorted { files -> files[0].getName() }.transpose()
                 }
             }
 

--- a/subworkflows/local/bin_qc/main.nf
+++ b/subworkflows/local/bin_qc/main.nf
@@ -128,7 +128,7 @@ workflow BIN_QC {
                 meta.domain != "eukarya"
             }
             .map { meta, bins ->
-                [meta, bins.sort { a, b -> a.getBaseName() <=> b.getBaseName() }]
+                [meta, bins.toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
             }
             .multiMap { meta, fa ->
                 reads: [meta, fa]
@@ -149,7 +149,7 @@ workflow BIN_QC {
             .map { _meta, summary -> [[id: 'checkm'], summary] }
             .groupTuple()
             .map { meta, summaries ->
-                [meta, summaries.sort { a, b -> a.getBaseName() <=> b.getBaseName() }]
+                [meta, summaries.toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
             }
         ch_multiqc_files = ch_multiqc_files.mix(
             CHECKM_QA.out.output.map { _meta, summary -> summary }.flatten()

--- a/subworkflows/local/binning_preparation_shortread/main.nf
+++ b/subworkflows/local/binning_preparation_shortread/main.nf
@@ -58,7 +58,7 @@ workflow SHORTREAD_BINNING_PREPARATION {
         .combine(ch_mapping_counts, by: 0)
         .map { key, meta, assembly, bam, bai, count -> [groupKey(key, count), meta, assembly, bam, bai] }
         .groupTuple()
-        .map { _key, metas, assemblies, bams, bais -> [metas[0], assemblies.sort()[0], bams, bais] }
+        .map { _key, metas, assemblies, bams, bais -> [metas[0], assemblies.toSorted()[0], bams, bais] }
 
     emit:
     bowtie2_assembly_multiqc = BOWTIE2_ASSEMBLY_ALIGN.out.log.map { _assembly_meta, _reads_meta, log -> [log] }

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -94,7 +94,7 @@ workflow GTDBTK {
         }
 
     ch_passed_bins = ch_filtered_bins
-        .map { meta, passed, _discarded -> [meta, passed.sort { bin -> bin.name }] }
+        .map { meta, passed, _discarded -> [meta, passed.toSorted { bin -> bin.name }] }
         .filter { _meta, passed -> passed }
     ch_passed_flat = ch_passed_bins.flatMap { _meta, passed -> passed }
     ch_discarded_bins = ch_filtered_bins.flatMap { _meta, _passed, discarded -> discarded }
@@ -111,7 +111,7 @@ workflow GTDBTK {
             }
             .groupTuple()
             // Sort bins by name so GTDB-Tk receives a deterministic input order.
-            .map { meta, bins -> [meta, bins.sort { bin -> bin.name }] }
+            .map { meta, bins -> [meta, bins.toSorted { bin -> bin.name }] }
     }
     else {
         ch_bins_for_classifywf = ch_passed_bins

--- a/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
@@ -219,7 +219,7 @@ workflow PIPELINE_INITIALISATION {
             .concat(ch_assembly_ids)
             .collect(flat: false)
             .map { ids1, ids2 ->
-                if (ids1.sort() != ids2.sort()) {
+                if (ids1.toSorted() != ids2.toSorted()) {
                     exit(1, "[nf-core/mag] ERROR: supplied IDs or Groups in read and assembly CSV files do not match!")
                 }
             }

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -222,10 +222,10 @@ workflow MAG {
                     ]
 
                     if (assemble_as_single) {
-                        [meta, reads.sort { files -> files[0].getName() }.flatten()]
+                        [meta, reads.toSorted { files -> files[0].getName() }.flatten()]
                     }
                     else {
-                        [meta, reads.sort { files -> files[0].getName() }.transpose().flatten()]
+                        [meta, reads.toSorted { files -> files[0].getName() }.transpose().flatten()]
                     }
                 }
         }
@@ -322,7 +322,7 @@ workflow MAG {
                 // Try to find the BAM where reads came from the same sample as the assembly (co-binning may include multiple BAMs)
                 // If none matches (coassembly), take the first one after sorting for determinism
                 def own_bam = bams.find { bam -> bam.name.endsWith("-${meta.id}.bam") }
-                def bam = own_bam ?: bams.sort()[0]
+                def bam = own_bam ?: bams.toSorted()[0]
 
                 [meta, assembly, bam]
             }
@@ -485,7 +485,7 @@ workflow MAG {
         if (!params.skip_quast) {
             ch_input_for_quast_bins = ch_input_for_postbinning
                 .map { meta, bins ->
-                    [meta, [bins].flatten().sort { a, b -> a.getBaseName() <=> b.getBaseName() }]
+                    [meta, [bins].flatten().toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
                 }
 
             QUAST_BINS(ch_input_for_quast_bins)
@@ -493,7 +493,7 @@ workflow MAG {
 
             ch_quast_bin_summaries = QUAST_BINS.out.quast_bin_summaries
                 .collect { _meta, summary -> summary }
-                .map { summaries -> [[id: 'quast_bin_summary'], summaries.sort { a, b -> a.getBaseName() <=> b.getBaseName() }] }
+                .map { summaries -> [[id: 'quast_bin_summary'], summaries.toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }] }
 
             CONCAT_QUAST_SUMMARY(ch_quast_bin_summaries, 'rowskey', 'tsv', true)
 


### PR DESCRIPTION
## Problem

Conda jobs on the 5.5.0 release PR (#1083) fail intermittently with `java.util.ConcurrentModificationException` on `CATPACK_BINS`. 4 of 8 shards failed — a data race, not a determinism bug.

## Cause

Groovy's `List.sort(Closure)` sorts **in place**. Used inside a `map` operator on a list that came straight from a channel, it mutates the object every other consumer of that channel also holds — and a consumer iterating it concurrently throws.

`BIN_QC` used to re-group its input with `groupTuple()`, which allocates a fresh list, so sorting it was harmless. #1066 removed that roundtrip, so the CheckM branch now sorts the list emitted by `ch_input_for_postbinning` while `DEPTHS`, `QUAST_BINS`, `CATPACK`, `PROKKA` and `GTDBTK` hold the same object.

Same failure mode as nextflow-io/nextflow#6589.

Only visible under conda because (a) the conda profile is excluded on `dev` PRs, so #1066 got its first conda run on the release PR, and (b) blocking conda env creation widens the race window. Docker can hit it too, just far more rarely.

## Fix

Every operator-level in-place sort becomes `toSorted`, which returns a new list. Ordering is unchanged, so no snapshots move.

#1066 made the same `groupTuple` removal for QUAST but wrote `[bins].flatten().sort { ... }` — `flatten()` allocates, so that one was accidentally safe. Converted here for consistency.

The remaining conda failures on #1083 are unrelated (Prokka md5 drift between the conda solve and the Wave container) and are being handled separately.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile +docker`). Not run locally — relying on CI.
- [x] `CHANGELOG.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
