### PR TITLE
Increase CONVERT_DEPTHS memory in the full test config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
-- [#1088](https://github.com/nf-core/mag/pull/1088) - Retry on exit status 174, which was missing from the retriable Fusion exit codes and aborted full-size runs on Spot reclamation (by @dialvarezs)
+- [#1089](https://github.com/nf-core/mag/pull/1089) - Retry on exit status 174, which was missing from the retriable Fusion exit codes and aborted full-size runs on Spot reclamation (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
 - [#1089](https://github.com/nf-core/mag/pull/1089) - Retry on exit status 174, which was missing from the retriable Fusion exit codes and aborted full-size runs on Spot reclamation (by @dialvarezs)
+- [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
-- [#1089](https://github.com/nf-core/mag/pull/1089) - Retry on exit status 174, which was missing from the retriable Fusion exit codes and aborted full-size runs on Spot reclamation (by @dialvarezs)
 - [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
+- [#1088](https://github.com/nf-core/mag/pull/1088) - Retry on exit status 174, which was missing from the retriable Fusion exit codes and aborted full-size runs on Spot reclamation (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
     memory        = { 7.GB * task.attempt }
     time          = { 4.h * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + [104] + (174..177)) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + [104] + (175..177)) ? 'retry' : 'finish' }
     maxRetries    = 3
     maxErrors     = -1
 
@@ -113,7 +113,7 @@ process {
         cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
         memory        = { 40.GB * task.attempt }
         time          = { 16.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
     }
     //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
     //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
@@ -121,14 +121,14 @@ process {
         cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 64.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     withName: METASPADESHYBRID {
         cpus          = { params.spadeshybrid_fix_cpus as Integer != -1 ? params.spadeshybrid_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 64.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
     }
 
@@ -153,7 +153,7 @@ process {
         cpus          = { 2 * task.attempt }
         memory        = { 8.GB * task.attempt }
         time          = { 8.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
     }
     withName: METABAT2_METABAT2 {
         cpus   = { 8 * task.attempt }
@@ -165,12 +165,12 @@ process {
     }
     // CAT_pack summarise fails when there are multiple taxonomic classifications for a bin: https://github.com/MGXlab/CAT_pack/issues/125
     withName: 'CATPACK_SUMMARISE_BINS|CATPACK_SUMMARISE_UNBINS' {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: BUSCO_BUSCO {
         cpus          = { 10 * task.attempt }
         memory        = { 12.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : 'ignore' }
     }
     withName: MAXBIN2 {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
@@ -182,7 +182,7 @@ process {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
     }
     withName: DASTOOL_DASTOOL {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     //as per https://github.com/Ecogenomics/CheckM/wiki/Installation#system-requirements
     withName: CHECKM_LINEAGEWF {
@@ -190,7 +190,7 @@ process {
     }
     //CheckM2 returns exit code 1 when Diamond doesn't find any hits
     withName: CHECKM2_PREDICT {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'CONCAT_BUSCO_TSV|CONCAT_CHECKM_TSV|CONCAT_CHECKM2_TSV|CONCAT_GUNC_TSV|CONCAT_GUNC_CHECKM_TSV' {
         cpus   = 1

--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
     memory        = { 7.GB * task.attempt }
     time          = { 4.h * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + [104] + (175..177)) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + [104] + (174..177)) ? 'retry' : 'finish' }
     maxRetries    = 3
     maxErrors     = -1
 
@@ -113,7 +113,7 @@ process {
         cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
         memory        = { 40.GB * task.attempt }
         time          = { 16.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247, 250]) ? 'retry' : 'finish' }
     }
     //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
     //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
@@ -121,14 +121,14 @@ process {
         cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 64.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     withName: METASPADESHYBRID {
         cpus          = { params.spadeshybrid_fix_cpus as Integer != -1 ? params.spadeshybrid_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 64.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
     }
 
@@ -153,7 +153,7 @@ process {
         cpus          = { 2 * task.attempt }
         memory        = { 8.GB * task.attempt }
         time          = { 8.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247]) ? 'retry' : 'finish' }
     }
     withName: METABAT2_METABAT2 {
         cpus   = { 8 * task.attempt }
@@ -165,12 +165,12 @@ process {
     }
     // CAT_pack summarise fails when there are multiple taxonomic classifications for a bin: https://github.com/MGXlab/CAT_pack/issues/125
     withName: 'CATPACK_SUMMARISE_BINS|CATPACK_SUMMARISE_UNBINS' {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: BUSCO_BUSCO {
         cpus          = { 10 * task.attempt }
         memory        = { 12.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : 'ignore' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : 'ignore' }
     }
     withName: MAXBIN2 {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
@@ -182,7 +182,7 @@ process {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
     }
     withName: DASTOOL_DASTOOL {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     //as per https://github.com/Ecogenomics/CheckM/wiki/Installation#system-requirements
     withName: CHECKM_LINEAGEWF {
@@ -190,7 +190,7 @@ process {
     }
     //CheckM2 returns exit code 1 when Diamond doesn't find any hits
     withName: CHECKM2_PREDICT {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'CONCAT_BUSCO_TSV|CONCAT_CHECKM_TSV|CONCAT_CHECKM2_TSV|CONCAT_GUNC_TSV|CONCAT_GUNC_CHECKM_TSV' {
         cpus   = 1

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -73,13 +73,13 @@ process {
     withName: 'NFCORE_MAG:MAG:ASSEMBLY:SHORTREAD_ASSEMBLY:MEGAHIT' {
         cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
         memory        = { 4.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 250]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:ASSEMBLY:SHORTREAD_ASSEMBLY:METASPADES' {
         cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 24.GB * task.attempt }
         scratch       = true
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BINNING:CONVERT_DEPTHS' {
         cpus   = { 1 * task.attempt }
@@ -121,7 +121,7 @@ process {
     withName: 'NFCORE_MAG:MAG:BINNING_PREPARATION:SHORTREAD_BINNING_PREPARATION:BOWTIE2_ASSEMBLY_ALIGN' {
         cpus          = { 3 * task.attempt }
         memory        = { 6.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BINNING_PREPARATION:SHORTREAD_BINNING_PREPARATION:BOWTIE2_ASSEMBLY_BUILD' {
         cpus   = { 1 * task.attempt }
@@ -134,7 +134,7 @@ process {
     withName: 'NFCORE_MAG:MAG:BIN_QC:CHECKM2_PREDICT' {
         cpus          = { 5 * task.attempt }
         memory        = { 13.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BIN_QC:CONCAT_BINQC_TSV' {
         cpus   = { 1 * task.attempt }
@@ -155,7 +155,7 @@ process {
     withName: 'NFCORE_MAG:MAG:GTDBTK:GTDBTK_CLASSIFYWF' {
         cpus          = { 1 * task.attempt }
         memory        = { 128.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:GTDBTK:GTDBTK_SUMMARY' {
         cpus   = { 9 * task.attempt }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -83,7 +83,7 @@ process {
     }
     withName: 'NFCORE_MAG:MAG:BINNING:CONVERT_DEPTHS' {
         cpus   = { 1 * task.attempt }
-        memory = { 1.GB * task.attempt }
+        memory = { 2.GB * task.attempt }
     }
     withName: 'NFCORE_MAG:MAG:BINNING:MAXBIN2' {
         cpus          = { 2 * task.attempt }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -73,13 +73,13 @@ process {
     withName: 'NFCORE_MAG:MAG:ASSEMBLY:SHORTREAD_ASSEMBLY:MEGAHIT' {
         cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
         memory        = { 4.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 250]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 250]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:ASSEMBLY:SHORTREAD_ASSEMBLY:METASPADES' {
         cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
         memory        = { 24.GB * task.attempt }
         scratch       = true
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BINNING:CONVERT_DEPTHS' {
         cpus   = { 1 * task.attempt }
@@ -121,7 +121,7 @@ process {
     withName: 'NFCORE_MAG:MAG:BINNING_PREPARATION:SHORTREAD_BINNING_PREPARATION:BOWTIE2_ASSEMBLY_ALIGN' {
         cpus          = { 3 * task.attempt }
         memory        = { 6.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175, 247]) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BINNING_PREPARATION:SHORTREAD_BINNING_PREPARATION:BOWTIE2_ASSEMBLY_BUILD' {
         cpus   = { 1 * task.attempt }
@@ -134,7 +134,7 @@ process {
     withName: 'NFCORE_MAG:MAG:BIN_QC:CHECKM2_PREDICT' {
         cpus          = { 5 * task.attempt }
         memory        = { 13.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:BIN_QC:CONCAT_BINQC_TSV' {
         cpus   = { 1 * task.attempt }
@@ -155,7 +155,7 @@ process {
     withName: 'NFCORE_MAG:MAG:GTDBTK:GTDBTK_CLASSIFYWF' {
         cpus          = { 1 * task.attempt }
         memory        = { 128.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 174, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
     }
     withName: 'NFCORE_MAG:MAG:GTDBTK:GTDBTK_SUMMARY' {
         cpus   = { 9 * task.attempt }


### PR DESCRIPTION
## Problem

The AWS full-size test run `1VGAEYl9hrOScI` aborted on a `CONVERT_DEPTHS` task that exited with status 174 after sitting in `RUNNING` for 2h04:

```
Caused by:
  Essential container in task exited
Command exit status:
  174
Command output:
  (empty)
```

`.command.out` was never written and `.command.err` contained only the Fusion startup banner, so the script produced nothing. The five sibling `CONVERT_DEPTHS` tasks were also still running when the session aborted.

## Changes

Raise `CONVERT_DEPTHS` from 1 GB to 2 GB in `conf/test_full.config`, so the starting allocation has headroom rather than relying on retry escalation.

The script only streams (`gunzip`, a one-line `awk`, then `bioawk` passes), so peak RSS is small, but the container also hosts the Fusion client and 1 GB left nothing spare. 2 GB matches the tier already used by the other small processes in this config.

## On exit code 174

This PR originally also added 174 to the retriable exit-code lists. Dropped per review — and the docs confirm that was the right call. Seqera documents 174 as `ErrorExitCode`, *"Fusion I/O error, application-level input/output error"*, explicitly not an out-of-memory condition:

> The `sysexits.h` standard uses exit code 74 for "input/output error" and reserves 150-199 for application use. In Fusion's context, 174 means "application input/output error".

The listed causes are all FUSE/mount-level — failing to start or stop the FUSE process, errors during filesystem shutdown or unmount. The OOM codes inherited from the nf-core template are a different category, so 174 does not belong there, in this pipeline or upstream.

That does mean this PR does not address the two-hour stall itself, which still looks like a Fusion or Spot issue worth tracking separately.

Source: [Fusion error codes and exit messages](https://docs.seqera.io/fusion/troubleshooting/error-codes-exit-messages#exit-codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)