### PR TITLE
chore: tweak process resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1084](https://github.com/nf-core/mag/pull/1084) - Disable NanoPlot static plot image files by default, since it depends on Chrome installed (by @dialvarezs)
 - [#1088](https://github.com/nf-core/mag/pull/1088) - Update Prokka (to v1.15.6), Prodigal and PyDamage modules, fixing conda/container output mismatches (by @dialvarezs)
 - [#1088](https://github.com/nf-core/mag/pull/1088) - Run GTDB-Tk with a single CPU on the `test_single_end` profile, so its outputs no longer depend on the machine running the test (by @dialvarezs)
+- [#1091](https://github.com/nf-core/mag/pull/1091) - Optimize process resource configs (by @dialvarezs)
 
 ### `Fixed`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -222,7 +222,7 @@ process {
 
     withName: MINIMAP2_ASSEMBLY_ALIGN {
         cpus   = { 8 * task.attempt }
-        memory = { 24.GB * task.attempt }
+        memory = { 32.GB * task.attempt }
     }
 
     withName: MULTIQC {

--- a/conf/base.config
+++ b/conf/base.config
@@ -206,7 +206,7 @@ process {
     //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
     withName: METASPADES {
         cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
-        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
+        memory        = { 72.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
         errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
@@ -214,7 +214,7 @@ process {
 
     withName: METASPADESHYBRID {
         cpus          = { params.spadeshybrid_fix_cpus as Integer != -1 ? params.spadeshybrid_fix_cpus as Integer : (10 * task.attempt) }
-        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
+        memory        = { 72.GB * (2 ** (task.attempt - 1)) }
         time          = { 24.h * (2 ** (task.attempt - 1)) }
         errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
         maxRetries    = 5
@@ -223,6 +223,11 @@ process {
     withName: MINIMAP2_ASSEMBLY_ALIGN {
         cpus   = { 8 * task.attempt }
         memory = { 24.GB * task.attempt }
+    }
+
+    withName: MULTIQC {
+        memory = { 16.GB * task.attempt }
+        time   = { 8.h * task.attempt }
     }
 
     withName: NANOLYSE {

--- a/conf/base.config
+++ b/conf/base.config
@@ -62,79 +62,99 @@ process {
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
 
-    withName: BOWTIE2_HOST_REMOVAL_BUILD {
-        cpus   = { 10 * task.attempt }
-        memory = { 20.GB * task.attempt }
-        time   = { 4.h * task.attempt }
+    // Named customisations, kept in alphabetical order by process name.
+    // Please keep it that way when adding new ones, and remember to update the table in
+    // `docs/usage/resource_guidance.md`.
+    withName: ALE {
+        memory = { params.coassemble_group ? 30.GB * task.attempt : 18.GB * task.attempt }
     }
+
+    //returns exit code 247 when running out of memory
+    withName: BOWTIE2_ASSEMBLY_ALIGN {
+        cpus          = { 8 * task.attempt }
+        memory        = { 8.GB * task.attempt }
+        time          = { 8.h * task.attempt }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
+    }
+
     withName: BOWTIE2_HOST_REMOVAL_ALIGN {
         cpus   = { 10 * task.attempt }
         memory = { 10.GB * task.attempt }
         time   = { 6.h * task.attempt }
     }
-    withName: BOWTIE2_PHIX_REMOVAL_ALIGN {
-        cpus   = { 4 * task.attempt }
-        memory = { 4.GB * task.attempt }
-        time   = { 6.h * task.attempt }
-    }
-    withName: PORECHOP_PORECHOP {
-        cpus   = { 4 * task.attempt }
-        memory = { 30.GB * task.attempt }
+
+    withName: BOWTIE2_HOST_REMOVAL_BUILD {
+        cpus   = { 10 * task.attempt }
+        memory = { 20.GB * task.attempt }
         time   = { 4.h * task.attempt }
     }
-    withName: NANOLYSE {
+
+    withName: BOWTIE2_PHIX_REMOVAL_ALIGN {
+        cpus   = { 8 * task.attempt }
+        memory = { 2.GB * task.attempt }
+        time   = { 6.h * task.attempt }
+    }
+
+    withName: BUSCO_BUSCO {
+        cpus          = { 6 * task.attempt }
+        memory        = { 16.GB * task.attempt }
+        time          = { 12.h * task.attempt }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : 'ignore' }
+    }
+
+    withName: CATPACK_BINS {
+        memory = { 120.GB * task.attempt }
+    }
+
+    withName: CATPACK_CONTIGS {
+        memory = { 60.GB * task.attempt }
+    }
+
+    // CAT_pack summarise fails when there are multiple taxonomic classifications for a bin: https://github.com/MGXlab/CAT_pack/issues/125
+    withName: 'CATPACK_SUMMARISE_BINS|CATPACK_SUMMARISE_UNBINS' {
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+    }
+
+    //CheckM2 returns exit code 1 when Diamond doesn't find any hits
+    withName: CHECKM2_PREDICT {
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+    }
+
+    //as per https://github.com/Ecogenomics/CheckM/wiki/Installation#system-requirements
+    withName: CHECKM_LINEAGEWF {
+        memory = 42.GB
+    }
+
+    withName: CHOPPER {
         cpus   = { 2 * task.attempt }
-        memory = { 10.GB * task.attempt }
-        time   = { 3.h * task.attempt }
+        memory = { 4.GB * task.attempt }
     }
-    withName: PORECHOP_ABI {
-        cpus   = 4
-        memory = { 64.GB * task.attempt }
+
+    withName: COMEBIN_RUNCOMEBIN {
+        errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
     }
+
+    withName: 'CONCAT_BUSCO_TSV|CONCAT_CHECKM_TSV|CONCAT_CHECKM2_TSV|CONCAT_GUNC_TSV|CONCAT_GUNC_CHECKM_TSV' {
+        cpus   = 1
+        memory = { 1.GB * task.attempt }
+    }
+
+    withName: CONCOCT_CONCOCT {
+        memory = { 24.GB * task.attempt }
+    }
+
+    withName: DASTOOL_DASTOOL {
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+    }
+
+    withName: FASTP {
+        memory = { 8.GB * task.attempt }
+    }
+
     //filtlong: exponential increase of memory and time with attempts
     withName: FILTLONG {
         cpus   = { 8 * task.attempt }
         memory = { 64.GB * (2 ** (task.attempt - 1)) }
-        time   = { 24.h * (2 ** (task.attempt - 1)) }
-    }
-    withName: CATPACK_BINS {
-        memory = { 120.GB * task.attempt }
-    }
-    withName: CATPACK_CONTIGS {
-        memory = { 60.GB * task.attempt }
-    }
-    withName: GTDBTK_CLASSIFYWF {
-        cpus   = { 10 * task.attempt }
-        memory = { 140.GB * task.attempt }
-        time   = { 12.h * task.attempt }
-    }
-    //MEGAHIT returns exit code 250 when running out of memory
-    withName: MEGAHIT {
-        cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
-        memory        = { 40.GB * task.attempt }
-        time          = { 16.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
-    }
-    //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
-    //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
-    withName: METASPADES {
-        cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
-        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
-        time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
-        maxRetries    = 5
-    }
-    withName: METASPADESHYBRID {
-        cpus          = { params.spadeshybrid_fix_cpus as Integer != -1 ? params.spadeshybrid_fix_cpus as Integer : (10 * task.attempt) }
-        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
-        time          = { 24.h * (2 ** (task.attempt - 1)) }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
-        maxRetries    = 5
-    }
-
-    withName: METAMDBG_ASM {
-        cpus   = { 12 * task.attempt }
-        memory = { 72.GB * (2 ** (task.attempt - 1)) }
         time   = { 24.h * (2 ** (task.attempt - 1)) }
     }
 
@@ -144,63 +164,106 @@ process {
         time   = { 24.h * (2 ** (task.attempt - 1)) }
     }
 
-    withName: ALE {
-        memory = { params.coassemble_group ? 30.GB * task.attempt : 18.GB * task.attempt }
+    withName: GTDBTK_CLASSIFYWF {
+        cpus   = { params.gtdbtk_single_job ? 10 * task.attempt : 2 * task.attempt }
+        memory = { 140.GB * task.attempt }
+        time   = { 12.h * task.attempt }
     }
 
-    //returns exit code 247 when running out of memory
-    withName: BOWTIE2_ASSEMBLY_ALIGN {
-        cpus          = { 2 * task.attempt }
-        memory        = { 8.GB * task.attempt }
-        time          = { 8.h * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247]) ? 'retry' : 'finish' }
+    withName: MAG_DEPTHS {
+        memory = { 16.GB * task.attempt }
     }
+
+    withName: MAXBIN2 {
+        errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
+    }
+
+    //MEGAHIT returns exit code 250 when running out of memory
+    withName: MEGAHIT {
+        cpus          = { params.megahit_fix_cpu_1 ? 1 : (8 * task.attempt) }
+        memory        = { 40.GB * task.attempt }
+        time          = { 16.h * task.attempt }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 247, 250]) ? 'retry' : 'finish' }
+    }
+
     withName: METABAT2_METABAT2 {
         cpus   = { 8 * task.attempt }
         memory = { 20.GB * task.attempt }
         time   = { 8.h * task.attempt }
     }
-    withName: MAG_DEPTHS {
-        memory = { 16.GB * task.attempt }
-    }
-    // CAT_pack summarise fails when there are multiple taxonomic classifications for a bin: https://github.com/MGXlab/CAT_pack/issues/125
-    withName: 'CATPACK_SUMMARISE_BINS|CATPACK_SUMMARISE_UNBINS' {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
-    }
-    withName: BUSCO_BUSCO {
-        cpus          = { 10 * task.attempt }
-        memory        = { 12.GB * task.attempt }
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : 'ignore' }
-    }
-    withName: MAXBIN2 {
-        errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
-    }
-    withName: COMEBIN_RUNCOMEBIN {
-        errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
-    }
+
     withName: METABINNER_METABINNER {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
     }
-    withName: DASTOOL_DASTOOL {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+
+    withName: METAMDBG_ASM {
+        cpus   = { 12 * task.attempt }
+        memory = { 64.GB * (2 ** (task.attempt - 1)) }
+        time   = { 24.h * (2 ** (task.attempt - 1)) }
     }
-    //as per https://github.com/Ecogenomics/CheckM/wiki/Installation#system-requirements
-    withName: CHECKM_LINEAGEWF {
-        memory = 42.GB
+
+    //SPAdes returns error(1) if it runs out of memory (and for other reasons as well...)!
+    //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
+    withName: METASPADES {
+        cpus          = { params.spades_fix_cpus as Integer != -1 ? params.spades_fix_cpus as Integer : (10 * task.attempt) }
+        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
+        time          = { 24.h * (2 ** (task.attempt - 1)) }
+        errorStrategy = { task.exitStatus in ((130..145) + [250, 104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        maxRetries    = 5
     }
-    //CheckM2 returns exit code 1 when Diamond doesn't find any hits
-    withName: CHECKM2_PREDICT {
-        errorStrategy = { task.exitStatus in ((130..145) + [104, 175]) ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
+
+    withName: METASPADESHYBRID {
+        cpus          = { params.spadeshybrid_fix_cpus as Integer != -1 ? params.spadeshybrid_fix_cpus as Integer : (10 * task.attempt) }
+        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
+        time          = { 24.h * (2 ** (task.attempt - 1)) }
+        errorStrategy = { task.exitStatus in ((130..145) + [104, 175, 21, 12, 1]) ? 'retry' : 'finish' }
+        maxRetries    = 5
     }
-    withName: 'CONCAT_BUSCO_TSV|CONCAT_CHECKM_TSV|CONCAT_CHECKM2_TSV|CONCAT_GUNC_TSV|CONCAT_GUNC_CHECKM_TSV' {
-        cpus   = 1
-        memory = { 1.GB * task.attempt }
+
+    withName: MINIMAP2_ASSEMBLY_ALIGN {
+        cpus   = { 8 * task.attempt }
+        memory = { 24.GB * task.attempt }
     }
-    withName: SEQKIT_STATS {
-        cpus   = 1
-        memory = { 1.GB * task.attempt }
+
+    withName: NANOLYSE {
+        cpus   = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time   = { 3.h * task.attempt }
     }
+
+    withName: PORECHOP_ABI {
+        cpus   = 4
+        memory = { 64.GB * task.attempt }
+    }
+
+    withName: PORECHOP_PORECHOP {
+        cpus   = { 4 * task.attempt }
+        memory = { 30.GB * task.attempt }
+        time   = { 4.h * task.attempt }
+    }
+
+    withName: PRODIGAL {
+        memory = { 4.GB * task.attempt }
+    }
+
+    withName: PROKKA {
+        memory = { 4.GB * task.attempt }
+    }
+
+    withName: PYPOLCA_RUN {
+        time = { 8.h * task.attempt }
+    }
+
+    withName: QUAST_BINS {
+        memory = { 2.GB * task.attempt }
+    }
+
     withName: 'RENAME_PREDASTOOL|RENAME_POSTDASTOOL' {
+        cpus   = 1
+        memory = { 1.GB * task.attempt }
+    }
+
+    withName: SEQKIT_STATS {
         cpus   = 1
         memory = { 1.GB * task.attempt }
     }

--- a/docs/usage/resource_guidance.md
+++ b/docs/usage/resource_guidance.md
@@ -51,7 +51,7 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | MEGAHIT                              | 8   | 40.GB  | 16.h | Named customisation   |
 | PORECHOP_PORECHOP                    | 4   | 30.GB  | 4.h  | Named customisation   |
 | CONCOCT_CONCOCT                      | 12  | 24.GB  | 16.h | Named customisation   |
-| MINIMAP2_ASSEMBLY_ALIGN              | 8   | 24.GB  | 16.h | Named customisation   |
+| MINIMAP2_ASSEMBLY_ALIGN              | 8   | 32.GB  | 16.h | Named customisation   |
 | BOWTIE2_HOST_REMOVAL_BUILD           | 10  | 20.GB  | 4.h  | Named customisation   |
 | METABAT2_METABAT2                    | 8   | 20.GB  | 8.h  | Named customisation   |
 | ALE                                  | 1   | 18.GB  | 4.h  | Named customisation   |

--- a/docs/usage/resource_guidance.md
+++ b/docs/usage/resource_guidance.md
@@ -41,8 +41,8 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | GTDBTK_CLASSIFYWF                    | 10  | 140.GB | 12.h | Named customisation   |
 | CATPACK_BINS                         | 6   | 120.GB | 8.h  | Named customisation   |
 | FLYE                                 | 12  | 72.GB  | 24.h | Named customisation   |
-| METAMDBG_ASM                         | 12  | 72.GB  | 24.h | Named customisation   |
 | FILTLONG                             | 8   | 64.GB  | 24.h | Named customisation   |
+| METAMDBG_ASM                         | 12  | 64.GB  | 24.h | Named customisation   |
 | METASPADES                           | 10  | 64.GB  | 24.h | Named customisation   |
 | METASPADESHYBRID                     | 10  | 64.GB  | 24.h | Named customisation   |
 | PORECHOP_ABI                         | 4   | 64.GB  | 8.h  | Named customisation   |
@@ -50,15 +50,23 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | CHECKM_LINEAGEWF                     | 6   | 42.GB  | 8.h  | Named customisation   |
 | MEGAHIT                              | 8   | 40.GB  | 16.h | Named customisation   |
 | PORECHOP_PORECHOP                    | 4   | 30.GB  | 4.h  | Named customisation   |
+| CONCOCT_CONCOCT                      | 12  | 24.GB  | 16.h | Named customisation   |
+| MINIMAP2_ASSEMBLY_ALIGN              | 8   | 24.GB  | 16.h | Named customisation   |
 | BOWTIE2_HOST_REMOVAL_BUILD           | 10  | 20.GB  | 4.h  | Named customisation   |
 | METABAT2_METABAT2                    | 8   | 20.GB  | 8.h  | Named customisation   |
 | ALE                                  | 1   | 18.GB  | 4.h  | Named customisation   |
+| BUSCO_BUSCO                          | 6   | 16.GB  | 12.h | Named customisation   |
 | MAG_DEPTHS                           | 1   | 16.GB  | 4.h  | Named customisation   |
-| BUSCO_BUSCO                          | 10  | 12.GB  | 8.h  | Named customisation   |
+| PYPOLCA_RUN                          | 2   | 12.GB  | 8.h  | Named customisation   |
 | BOWTIE2_HOST_REMOVAL_ALIGN           | 10  | 10.GB  | 6.h  | Named customisation   |
 | NANOLYSE                             | 2   | 10.GB  | 3.h  | Named customisation   |
-| BOWTIE2_ASSEMBLY_ALIGN               | 2   | 8.GB   | 8.h  | Named customisation   |
-| BOWTIE2_PHIX_REMOVAL_ALIGN           | 4   | 4.GB   | 6.h  | Named customisation   |
+| BOWTIE2_ASSEMBLY_ALIGN               | 8   | 8.GB   | 8.h  | Named customisation   |
+| FASTP                                | 6   | 8.GB   | 8.h  | Named customisation   |
+| CHOPPER                              | 2   | 4.GB   | 8.h  | Named customisation   |
+| PRODIGAL                             | 1   | 4.GB   | 4.h  | Named customisation   |
+| PROKKA                               | 2   | 4.GB   | 4.h  | Named customisation   |
+| BOWTIE2_PHIX_REMOVAL_ALIGN           | 8   | 2.GB   | 6.h  | Named customisation   |
+| QUAST_BINS                           | 1   | 2.GB   | 4.h  | Named customisation   |
 | CONCAT_BUSCO_TSV                     | 1   | 1.GB   | 4.h  | Named customisation   |
 | CONCAT_CHECKM_TSV                    | 1   | 1.GB   | 4.h  | Named customisation   |
 | CONCAT_CHECKM2_TSV                   | 1   | 1.GB   | 4.h  | Named customisation   |
@@ -68,18 +76,15 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | RENAME_PREDASTOOL                    | 1   | 1.GB   | 4.h  | Named customisation   |
 | SEQKIT_STATS                         | 1   | 1.GB   | 4.h  | Named customisation   |
 | COMEBIN_RUNCOMEBIN                   | 12  | 72.GB  | 16.h | Label: process_high   |
-| CONCOCT_CONCOCT                      | 12  | 72.GB  | 16.h | Label: process_high   |
 | GENOMAD_ENDTOEND                     | 12  | 72.GB  | 16.h | Label: process_high   |
-| MINIMAP2_ALIGN                       | 12  | 72.GB  | 16.h | Label: process_high   |
+| MINIMAP2_HOST_ALIGN                  | 12  | 72.GB  | 16.h | Label: process_high   |
 | ADAPTERREMOVAL                       | 6   | 36.GB  | 8.h  | Label: process_medium |
 | BBMAP_BBNORM                         | 6   | 36.GB  | 8.h  | Label: process_medium |
 | BCFTOOLS_CONSENSUS                   | 6   | 36.GB  | 8.h  | Label: process_medium |
 | BCFTOOLS_VIEW                        | 6   | 36.GB  | 8.h  | Label: process_medium |
 | CATPACK_PREPARE                      | 6   | 36.GB  | 8.h  | Label: process_medium |
 | CHECKM2_PREDICT                      | 6   | 36.GB  | 8.h  | Label: process_medium |
-| CHOPPER                              | 6   | 36.GB  | 8.h  | Label: process_medium |
 | DASTOOL_DASTOOL                      | 6   | 36.GB  | 8.h  | Label: process_medium |
-| FASTP                                | 6   | 36.GB  | 8.h  | Label: process_medium |
 | GUNC_RUN                             | 6   | 36.GB  | 8.h  | Label: process_medium |
 | MAXBIN2                              | 6   | 36.GB  | 8.h  | Label: process_medium |
 | METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS | 6   | 36.GB  | 8.h  | Label: process_medium |
@@ -100,8 +105,6 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | MINIMAP2_INDEX                       | 2   | 12.GB  | 4.h  | Label: process_low    |
 | NANOPLOT                             | 2   | 12.GB  | 4.h  | Label: process_low    |
 | NANOQ                                | 2   | 12.GB  | 4.h  | Label: process_low    |
-| PROKKA                               | 2   | 12.GB  | 4.h  | Label: process_low    |
-| PYPOLCA_RUN                          | 2   | 12.GB  | 4.h  | Label: process_low    |
 | SAMTOOLS_INDEX                       | 2   | 12.GB  | 4.h  | Label: process_low    |
 | SAMTOOLS_UNMAPPED                    | 2   | 12.GB  | 4.h  | Label: process_low    |
 | SPLIT_FASTA                          | 2   | 12.GB  | 4.h  | Label: process_low    |
@@ -122,7 +125,6 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | GUNC_MERGECHECKM                     | 1   | 6.GB   | 4.h  | Label: process_single |
 | GUNZIP                               | 1   | 6.GB   | 4.h  | Label: process_single |
 | MULTIQC                              | 1   | 6.GB   | 4.h  | Label: process_single |
-| PRODIGAL                             | 1   | 6.GB   | 4.h  | Label: process_single |
 | PYDAMAGE_FILTER                      | 1   | 6.GB   | 4.h  | Label: process_single |
 | QSV_CAT                              | 1   | 6.GB   | 4.h  | Label: process_single |
 | SAMTOOLS_FAIDX                       | 1   | 6.GB   | 4.h  | Label: process_single |
@@ -139,7 +141,6 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | MAG_DEPTHS_SUMMARY                   | 1   | 7.GB   | 4.h  | Default               |
 | PREPARE_BIGMAG_SUMMARY               | 1   | 7.GB   | 4.h  | Default               |
 | QUAST                                | 1   | 7.GB   | 4.h  | Default               |
-| QUAST_BINS                           | 1   | 7.GB   | 4.h  | Default               |
 
 _Table generated for nf-core/mag v5.5, using Claude Haiku 4.5, and corrected for accuracy by a human._
 

--- a/docs/usage/resource_guidance.md
+++ b/docs/usage/resource_guidance.md
@@ -43,8 +43,8 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | FLYE                                 | 12  | 72.GB  | 24.h | Named customisation   |
 | FILTLONG                             | 8   | 64.GB  | 24.h | Named customisation   |
 | METAMDBG_ASM                         | 12  | 64.GB  | 24.h | Named customisation   |
-| METASPADES                           | 10  | 64.GB  | 24.h | Named customisation   |
-| METASPADESHYBRID                     | 10  | 64.GB  | 24.h | Named customisation   |
+| METASPADES                           | 10  | 72.GB  | 24.h | Named customisation   |
+| METASPADESHYBRID                     | 10  | 72.GB  | 24.h | Named customisation   |
 | PORECHOP_ABI                         | 4   | 64.GB  | 8.h  | Named customisation   |
 | CATPACK_CONTIGS                      | 6   | 60.GB  | 8.h  | Named customisation   |
 | CHECKM_LINEAGEWF                     | 6   | 42.GB  | 8.h  | Named customisation   |
@@ -57,6 +57,7 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | ALE                                  | 1   | 18.GB  | 4.h  | Named customisation   |
 | BUSCO_BUSCO                          | 6   | 16.GB  | 12.h | Named customisation   |
 | MAG_DEPTHS                           | 1   | 16.GB  | 4.h  | Named customisation   |
+| MULTIQC                              | 1   | 16.GB  | 8.h  | Named customisation   |
 | PYPOLCA_RUN                          | 2   | 12.GB  | 8.h  | Named customisation   |
 | BOWTIE2_HOST_REMOVAL_ALIGN           | 10  | 10.GB  | 6.h  | Named customisation   |
 | NANOLYSE                             | 2   | 10.GB  | 3.h  | Named customisation   |
@@ -124,7 +125,6 @@ The table is ordered first by 'Source' of defaults by specificity of definition,
 | GUNC_DOWNLOADDB                      | 1   | 6.GB   | 4.h  | Label: process_single |
 | GUNC_MERGECHECKM                     | 1   | 6.GB   | 4.h  | Label: process_single |
 | GUNZIP                               | 1   | 6.GB   | 4.h  | Label: process_single |
-| MULTIQC                              | 1   | 6.GB   | 4.h  | Label: process_single |
 | PYDAMAGE_FILTER                      | 1   | 6.GB   | 4.h  | Label: process_single |
 | QSV_CAT                              | 1   | 6.GB   | 4.h  | Label: process_single |
 | SAMTOOLS_FAIDX                       | 1   | 6.GB   | 4.h  | Label: process_single |


### PR DESCRIPTION
Update process resources based on four benchmark runs of the pipeline, comparing measured usage from the Nextflow traces and execution reports against what each process reserves.

## Resource change reasoning

### Walltime increases to avoid known retries

`PYPOLCA_RUN`, `BUSCO_BUSCO` and `MULTIQC` each had tasks killed at exactly their time limit and then succeed on retry, so the first attempt was pure waste.

### CPU increases where the tool was saturating its allocation

`BOWTIE2_ASSEMBLY_ALIGN` and `BOWTIE2_PHIX_REMOVAL_ALIGN` both ran at essentially 100% CPU efficiency, meaning they were CPU-bound. Assembly align was also the largest wall-clock consumer among the aligners, so it benefits most.

### CPU reductions where the cores were never used

`GTDBTK_CLASSIFYWF`, `BUSCO_BUSCO`, `MINIMAP2_ASSEMBLY_ALIGN` and `CHOPPER` all reserved more cores than any task ever used. GTDB-Tk is the extreme case effectively single-threaded, consistent with `--gtdbtk_pplacer_cpus 1`, so its 10-core path is kept only for `single_job` mode, which the benchmark did not test.

### Memory reductions where the reservation was far above the peak

Several processes reserved one to two orders of magnitude more than they ever touched. Reductions keep clear headroom over the observed peak. Most of these tools are expected to have low memory footprint: `PROKKA`, `PRODIGAL`, etc.

### Memory increases where the peak met or exceeded the reservation

`BUSCO_BUSCO` and `MULTIQC` were both running at or above their limit; MULTIQC in particular spent four hours thrashing before being killed and then finished in minutes once the retry gave it more.

## Resource customization reordering

Named customisations are now sorted alphabetically with a comment recording the convention, and `docs/usage/resource_guidance.md` is regenerated to match.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
