### PR TITLE
Convert depths in a single streaming pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
-- [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
+- [#1092](https://github.com/nf-core/mag/pull/1092) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
 - [#1093](https://github.com/nf-core/mag/pull/1093) - Ignore CheckM `storage/` subdirectories in nf-test snapshots, whose contents vary between runs and machines (by @dialvarezs)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
-- [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
 - [#1093](https://github.com/nf-core/mag/pull/1093) - Ignore CheckM `storage/` subdirectories in nf-test snapshots, whose contents vary between runs and machines (by @dialvarezs)
 - [#1094](https://github.com/nf-core/mag/pull/1094) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
 - [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
-- [#1094](https://github.com/nf-core/mag/pull/1094) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
 - [#1093](https://github.com/nf-core/mag/pull/1093) - Ignore CheckM `storage/` subdirectories in nf-test snapshots, whose contents vary between runs and machines (by @dialvarezs)
+- [#1094](https://github.com/nf-core/mag/pull/1094) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Copy instead of move staged bins in `TIARA_CLASSIFY`, which emitted dangling symlinks rather than bin contents on remote filesystems (by @dialvarezs)
 - [#1086](https://github.com/nf-core/mag/pull/1086) - Match bin filenames exactly in `TIARA_CLASSIFY` so that e.g. bin `.1` no longer also picks up bin `.10` (by @dialvarezs)
 - [#1087](https://github.com/nf-core/mag/pull/1087) - Use non-mutating `toSorted` instead of in-place `sort` on shared channel items, which could cause `ConcurrentModificationException` failures (by @dialvarezs)
-- [#1092](https://github.com/nf-core/mag/pull/1092) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
+- [#1089](https://github.com/nf-core/mag/pull/1089) - Give `CONVERT_DEPTHS` 2 GB instead of 1 GB in the full-size test config (by @dialvarezs)
+- [#1094](https://github.com/nf-core/mag/pull/1094) - Convert depths in a single streaming pass, so `CONVERT_DEPTHS` no longer writes a decompressed copy of the depth file to the work directory and re-reads it once per read set, which stalled short-read assemblies for hours on object-backed work directories (by @dialvarezs)
 - [#1093](https://github.com/nf-core/mag/pull/1093) - Ignore CheckM `storage/` subdirectories in nf-test snapshots, whose contents vary between runs and machines (by @dialvarezs)
 
 ### `Dependencies`

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -83,7 +83,7 @@ process {
     }
     withName: 'NFCORE_MAG:MAG:BINNING:CONVERT_DEPTHS' {
         cpus   = { 1 * task.attempt }
-        memory = { 2.GB * task.attempt }
+        memory = { 1.GB * task.attempt }
     }
     withName: 'NFCORE_MAG:MAG:BINNING:MAXBIN2' {
         cpus          = { 2 * task.attempt }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -83,7 +83,7 @@ process {
     }
     withName: 'NFCORE_MAG:MAG:BINNING:CONVERT_DEPTHS' {
         cpus   = { 1 * task.attempt }
-        memory = { 1.GB * task.attempt }
+        memory = { 2.GB * task.attempt }
     }
     withName: 'NFCORE_MAG:MAG:BINNING:MAXBIN2' {
         cpus          = { 2 * task.attempt }

--- a/modules/local/mag_depths_convert/main.nf
+++ b/modules/local/mag_depths_convert/main.nf
@@ -16,21 +16,25 @@ process CONVERT_DEPTHS {
 
     script:
     """
-    gunzip -f ${depth}
-
-    # Determine the number of abundance columns
-    n_abund=\$(awk 'NR==1 {print int((NF-3)/2)}' ${depth.toString() - '.gz'})
-
-    # Get column names
-    read -r header<${depth.toString() - '.gz'}
-    header=(\$header)
-
-    # Generate abundance files for each read set
-    for i in \$(seq 1 \$n_abund); do
-        col=\$((i*2+2))
-        name=\$( echo \${header[\$col-1]} | sed s/\\.bam\$// )
-        bioawk -t '{if (NR > 1) {print \$1, \$'"\$col"'}}' ${depth.toString() - '.gz'} > \${name}.abund
-    done
+    # Write one abundance file per read set in a single streaming pass. The depth
+    # file is never decompressed to disk: on shared/object-backed work dirs the
+    # plaintext copy and one full read per column are prohibitively slow.
+    gzip -cd ${depth} | bioawk -t '
+        NR == 1 {
+            n_abund = int((NF - 3) / 2)
+            for (i = 1; i <= n_abund; i++) {
+                name = \$(i * 2 + 2)
+                sub(/\\.bam\$/, "", name)
+                abund[i] = name ".abund"
+            }
+            next
+        }
+        {
+            for (i = 1; i <= n_abund; i++) {
+                print \$1, \$(i * 2 + 2) > (abund[i])
+            }
+        }
+    '
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
## Problem

`CONVERT_DEPTHS` decompressed the depth file into the work directory and then re-read it once per read set:

```bash
gunzip -f ${depth}
...
for i in $(seq 1 $n_abund); do
    bioawk -t '...' ${depth - '.gz'} > ${name}.abund
done
```

Under Fusion the work directory *is* the S3-backed FUSE mount, so this writes a multi-GB plaintext file to S3 and streams it back N times. Small long-read depth files fit in Fusion's cache and cost nothing; larger short-read ones do not, so every pass re-streams from S3.

This aborted two AWS full-size runs. Long-read assemblies finished in ~20 s, while short-read ones stalled for up to two hours and failed with Fusion I/O errors (174) and checkpoint dump failures (175). #1089 raised the memory to 2 GB on the assumption this was resource starvation; the second run had that change and failed anyway.

## Changes

Pipe `gzip -cd` straight into `bioawk` and emit every `.abund` file in a single pass. No plaintext intermediate, one read instead of N, and the staged input is no longer mutated in place.

The 2 GB from #1089 is left in place as a safety margin.

## Verification

Ran the module in the `bioawk:1.0--hed695b0_5` container against a synthetic three-BAM depth file, and the previous implementation over the same input. The `.abund` files are byte-identical and `versions.yml` is unchanged, so existing snapshots should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)