### PR TITLE
fix: address v5.5.0 review 2 comments

### DIFF
--- a/docs/usage/new_to_mag.md
+++ b/docs/usage/new_to_mag.md
@@ -30,7 +30,7 @@ This page is split into four specific sections:
 > - **Already have assemblies?** Use the `--assembly_input` flag to start from binning
 > - **Assemble or co-assemble?** It's complicated! Check our advice below.
 > - **Which assembler to use?** Use as many as you can.
-> - **Can I polish my assemblies?** No, but it is being considered.
+> - **Can I polish my assemblies?** Long-read assemblies can be short-read polished with `--run_pypolca`, but check our advice below.
 > - **Which binner to use?** Use as many as you can.
 > - **Should I refine my bins?** It depends on your context.
 > - **Which bin QC tool to use?** CheckM/CheckM2 for prokaryote only projects, BUSCO for projects with wider taxonomic targets.
@@ -184,11 +184,13 @@ Short-read-first assembly performs better with high-depth short reads or low-qua
 
 Polishing of long-read assemblies involves using high-quality short reads to 'repair' mistakes in lower-quality long reads.
 
-Polishing of assemblies with short or long reads is _not_ currently implemented in the pipeline.
+Short-read polishing of long-read assemblies is available with `--run_pypolca`, which runs `Pypolca` on each long-read assembly using the short reads of the same sample (or the same group, when co-assembling).
+It is turned off by default, and long-read assemblies of samples without short reads are passed on unpolished.
+Long-read polishing (for example, with `Medaka`) is _not_ implemented in the pipeline.
 
 For metagenomes, polishing can harm assembly quality by erroneously modifying low-abundance genomes using high-abundance data.
-High-quality Nanopore data (10.4) may not benefit substantially from long-read polishing (for example, with `Medaka`).
-Polishing long-read assemblies with short-read data might be beneficial but remains debated and is not currently available in the pipeline (for example, `Polypolish` and `Pypolca`).
+High-quality Nanopore data (10.4) may not benefit substantially from long-read polishing.
+Polishing long-read assemblies with short-read data might be beneficial but remains debated, so evaluate the results (for example, with `QUAST`) before relying on them.
 
 ### What binning tool should I select?
 

--- a/docs/usage/new_to_mag.md
+++ b/docs/usage/new_to_mag.md
@@ -49,7 +49,7 @@ A run of nf-core/mag without any customisation or additional parameters will:
 
 - Preprocess input reads to
   - Remove adapters (short reads: `fastp`, long reads: `porechop_ABI`)
-  - FASTQ-level quality filtering (long reads: `Filtlong`)
+  - FASTQ-level quality filtering (long reads: `Chopper`)
   - Remove Phi X (short-read) or lambda (long-read) sequences
   - Quality control reads (short reads: FastQC, long reads: `Nanoplot`)
 - Assemble reads into contigs with

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -233,20 +233,32 @@ workflow MAG {
             ch_short_reads_pypolca = ch_short_reads
         }
 
-        // Join reads and assemblies by sample id so PYPOLCA pairs them correctly
-        ch_pypolca_input = ch_longread_raw_assemblies
-            .map { meta, assembly -> [meta.id, meta, assembly] }
-            .combine(
-                ch_short_reads_pypolca.map { meta, reads -> [meta.id, reads] },
-                by: 0
-            )
-            .map { _id, assembly_meta, assembly, reads ->
-                [assembly_meta, assembly, reads]
+        // Collect short reads in a map keyed by id, so assemblies can be paired with
+        // the corresponding reads without dropping the ones that have no short reads
+        ch_short_reads_pypolca_by_id = ch_short_reads_pypolca
+            .toList()
+            .map { short_reads ->
+                short_reads.collectEntries { meta, reads ->
+                    [(meta.id): reads]
+                }
             }
 
-        PYPOLCA_RUN(ch_pypolca_input)
-        ch_longread_assemblies = PYPOLCA_RUN.out.polished
-    } else {
+        // Split long read assemblies depending on whether they can be polished
+        ch_longread_assemblies_branched = ch_longread_raw_assemblies
+            .combine(ch_short_reads_pypolca_by_id)
+            .branch { meta, assembly, short_reads_by_id ->
+                polish: short_reads_by_id.containsKey(meta.id)
+                return [meta, assembly, short_reads_by_id[meta.id]]
+                no_short_reads: true
+                log.warn("[nf-core/mag]: No short reads found for '${meta.id}', skipping PYPOLCA polishing of its ${meta.assembler} assembly.")
+                return [meta, assembly]
+            }
+
+        PYPOLCA_RUN(ch_longread_assemblies_branched.polish)
+
+        ch_longread_assemblies = PYPOLCA_RUN.out.polished.mix(ch_longread_assemblies_branched.no_short_reads)
+    }
+    else {
         ch_longread_assemblies = ch_longread_raw_assemblies
     }
 
@@ -482,10 +494,9 @@ workflow MAG {
 
         ch_quast_bins_summary = channel.empty()
         if (!params.skip_quast) {
-            ch_input_for_quast_bins = ch_input_for_postbinning
-                .map { meta, bins ->
-                    [meta, [bins].flatten().toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
-                }
+            ch_input_for_quast_bins = ch_input_for_postbinning.map { meta, bins ->
+                [meta, [bins].flatten().toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
+            }
 
             QUAST_BINS(ch_input_for_quast_bins)
             ch_versions = ch_versions.mix(QUAST_BINS.out.versions)


### PR DESCRIPTION
- Updated docs regarding chopper and pypolca
- Added a fix to prevent Pypolca dropping long read assemblies without short reads available

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mag/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mag _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
