### PR TITLE
Fix invalid `--gunc_database_type` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#1098](https://github.com/nf-core/mag/issues/1098) - Fix invalid `--gunc_database_type` options to match the values accepted by `gunc download_db` (reported by @cdiener, fix by @dialvarezs)
+
 ### `Dependencies`
 
 | Tool | Previous version | New version |

--- a/nextflow.config
+++ b/nextflow.config
@@ -175,7 +175,7 @@ params {
     // corresponds to Zenodo record  ID
     save_checkm2_data                    = false
     run_gunc                             = false
-    gunc_database_type                   = 'progenomes'
+    gunc_database_type                   = 'progenomes_2.1'
     gunc_db                              = null
     gunc_save_db                         = false
     generate_bigmag_file                 = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1055,9 +1055,9 @@
                 },
                 "gunc_database_type": {
                     "type": "string",
-                    "default": "progenomes",
+                    "default": "progenomes_2.1",
                     "description": "Specify which database to auto-download if not supplying own",
-                    "enum": ["progenomes", "gtdb", "test_data"]
+                    "enum": ["progenomes_2.1", "progenomes_3", "gtdb_95", "gtdb_214", "test_data"]
                 },
                 "gunc_save_db": {
                     "type": "boolean",


### PR DESCRIPTION
Closes #1098 — updates the `--gunc_database_type` enum and default to the database names actually accepted by `gunc download_db` (`progenomes_2.1`, `progenomes_3`, `gtdb_95`, `gtdb_214`, `test_data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)