### PR TITLE
Fix bin path corruption when a process emits a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#1098](https://github.com/nf-core/mag/issues/1098) - Fix invalid `--gunc_database_type` options to match the values accepted by `gunc download_db` (reported by @cdiener, fix by @dialvarezs)
+- [#1105](https://github.com/nf-core/mag/pull/1105) - Fix corrupted bin paths when a process emits a single file: `java.nio.file.Path` is `Iterable` over its path segments, so list operations on an unwrapped output silently iterated the path components (by @dialvarezs)
 
 ### `Dependencies`
 

--- a/modules/local/dastool_rename_post/main.nf
+++ b/modules/local/dastool_rename_post/main.nf
@@ -11,7 +11,7 @@ process RENAME_POSTDASTOOL {
     tuple val(meta), path(bins)
 
     output:
-    tuple val(meta), path("${meta.assembler}-*Refined-${meta.id}.*.fa.gz"), optional: true, emit: refined_bins
+    tuple val(meta), path("${meta.assembler}-*Refined-${meta.id}.*.fa.gz", arity: '0..*'), optional: true, emit: refined_bins
     tuple val(meta), path("${meta.assembler}-DASToolUnbinned-${meta.id}.fa.gz"), optional: true, emit: refined_unbins
     path "versions.yml", emit: versions
 

--- a/modules/local/dastool_rename_pre/main.nf
+++ b/modules/local/dastool_rename_pre/main.nf
@@ -11,7 +11,7 @@ process RENAME_PREDASTOOL {
     tuple val(meta), path(bins)
 
     output:
-    tuple val(meta), path("${meta.assembler}-${meta.binner}Refined-${meta.id}*"), emit: renamed_bins
+    tuple val(meta), path("${meta.assembler}-${meta.binner}Refined-${meta.id}*", arity: '1..*'), emit: renamed_bins
     path "versions.yml", emit: versions
 
     script:

--- a/modules/local/metabinner_bins/main.nf
+++ b/modules/local/metabinner_bins/main.nf
@@ -13,10 +13,10 @@ process METABINNER_BINS {
     val val_min_contig_size
 
     output:
-    tuple val(meta), path("*.tooShort.fa.gz"), emit: tooshort, optional: true
-    tuple val(meta), path("*.unbinned.fa.gz"), emit: unbinned, optional: true
-    tuple val(meta), path("bins/*.fa.gz")    , emit: bins
-    path "versions.yml"                      , emit: versions
+    tuple val(meta), path("*.tooShort.fa.gz"),            emit: tooshort, optional: true
+    tuple val(meta), path("*.unbinned.fa.gz"),            emit: unbinned, optional: true
+    tuple val(meta), path("bins/*.fa.gz", arity: '1..*'), emit: bins
+    path "versions.yml",                                  emit: versions
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/tiara_classify/main.nf
+++ b/modules/local/tiara_classify/main.nf
@@ -11,14 +11,14 @@ process TIARA_CLASSIFY {
     tuple val(meta), path(classification), path(contig2bin), path(bins)
 
     output:
-    tuple val(meta), path("eukarya/*.fa.gz"),         emit: eukarya_bins, optional: true
-    tuple val(meta), path("prokarya/*.fa.gz"),        emit: prokarya_bins, optional: true
-    tuple val(meta), path("bacteria/*.fa.gz"),        emit: bacteria_bins, optional: true
-    tuple val(meta), path("archaea/*.fa.gz"),         emit: archaea_bins, optional: true
-    tuple val(meta), path("organelle/*.fa.gz"),       emit: organelle_bins, optional: true
-    tuple val(meta), path("unknown/*.fa.gz"),         emit: unknown_bins, optional: true
-    tuple val(meta), path("*.binclassification.tsv"), emit: bin_classifications
-    path 'versions.yml',                              emit: versions
+    tuple val(meta), path("eukarya/*.fa.gz", arity: '0..*'),   emit: eukarya_bins, optional: true
+    tuple val(meta), path("prokarya/*.fa.gz", arity: '0..*'),  emit: prokarya_bins, optional: true
+    tuple val(meta), path("bacteria/*.fa.gz", arity: '0..*'),  emit: bacteria_bins, optional: true
+    tuple val(meta), path("archaea/*.fa.gz", arity: '0..*'),   emit: archaea_bins, optional: true
+    tuple val(meta), path("organelle/*.fa.gz", arity: '0..*'), emit: organelle_bins, optional: true
+    tuple val(meta), path("unknown/*.fa.gz", arity: '0..*'),   emit: unknown_bins, optional: true
+    tuple val(meta), path("*.binclassification.tsv"),          emit: bin_classifications
+    path 'versions.yml',                                       emit: versions
 
     script:
     def args = task.ext.args ?: ""

--- a/subworkflows/local/assembly/main.nf
+++ b/subworkflows/local/assembly/main.nf
@@ -39,10 +39,10 @@ workflow ASSEMBLY {
                     sr_platform: metas.sr_platform[0]
                 ]
                 if (assemble_as_single) {
-                    [meta, reads.toSorted { files -> files[0].getName() }, []]
+                    [meta, reads.toSorted { files -> [files].flatten()[0].getName() }, []]
                 }
                 else {
-                    [meta] + reads.toSorted { files -> files[0].getName() }.transpose()
+                    [meta] + reads.toSorted { files -> [files].flatten()[0].getName() }.transpose()
                 }
             }
 

--- a/subworkflows/local/bin_qc/main.nf
+++ b/subworkflows/local/bin_qc/main.nf
@@ -128,7 +128,7 @@ workflow BIN_QC {
                 meta.domain != "eukarya"
             }
             .map { meta, bins ->
-                [meta, bins.toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
+                [meta, [bins].flatten().toSorted { a, b -> a.getBaseName() <=> b.getBaseName() }]
             }
             .multiMap { meta, fa ->
                 reads: [meta, fa]

--- a/subworkflows/local/gtdbtk/main.nf
+++ b/subworkflows/local/gtdbtk/main.nf
@@ -62,7 +62,8 @@ workflow GTDBTK {
 
             // drop bins with no QC metric, then split the rest:
             // a bin passes if any single tool clears both thresholds together
-            def (passed, discarded) = bins
+            def (passed, discarded) = [bins]
+                .flatten()
                 .findAll { bin -> metrics[bin.getName() - ~/\.gz$/] != null }
                 .split { bin ->
                     metrics[bin.getName() - ~/\.gz$/].any { reading ->

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -224,10 +224,10 @@ workflow MAG {
                     ]
 
                     if (assemble_as_single) {
-                        [meta, reads.toSorted { files -> files[0].getName() }.flatten()]
+                        [meta, reads.toSorted { files -> [files].flatten()[0].getName() }.flatten()]
                     }
                     else {
-                        [meta, reads.toSorted { files -> files[0].getName() }.transpose().flatten()]
+                        [meta, reads.toSorted { files -> [files].flatten()[0].getName() }.transpose().flatten()]
                     }
                 }
         }


### PR DESCRIPTION
## Description

When a `path("dir/*.fa.gz")` output has no `arity` and the glob matches exactly one file, Nextflow emits a bare `Path` instead of a one-element list. `Path` is `Iterable` over its **path segments**, so `findAll`, `toSorted`, `[0]` and friends iterate the directory names instead of the bins. What survives is a relative one-segment path, which resolves against `launchDir` and gives a broken symlink.

This made GTDB-Tk fail with `There are N paths in the batchfile which do not exist` for any group left with a single prokaryotic bin after Tiara. Groups with two or more bins were fine, which is why it went unnoticed.

## Changes

- Added `arity` to the glob bin outputs in `tiara_classify`, `dastool_rename_pre`, `dastool_rename_post` and `metabinner_bins`, so the channel is a list from the start. Optional outputs use `'0..*'`, because `'1..*'` with `optional: true` fails outright when the glob matches nothing.
- Guarded the consumers with the `[bins].flatten()` idiom already used elsewhere in the pipeline, since bins can also come from `modules/nf-core/*`: GTDB-Tk bin filtering (the reported failure) and CheckM v1 bin sorting (same bug, latent because `run_checkm` is off by default).
- Fixed `reads.toSorted { files -> files[0].getName() }` in the co-assembly grouping. With single-end data `files[0]` returned the first path segment, the same for every sample, so the sort key collapsed. Ordering only, no broken paths.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] `CHANGELOG.md` is updated.
