### PR TITLE
feat: rename `--skip_adapter_trimming` and `--skip_deepmased`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Deprecated`
 
+- [#1106](https://github.com/nf-core/mag/pull/1106) - Deprecate `--skip_adapter_trimming` in favor of `--skip_longread_adapter_trimming` (by @dialvarezs)
+
 ## v5.5.0 - Purple Penguin [2026-08-01]
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1104](https://github.com/nf-core/mag/pull/1104) - Updated to nf-core 4.1.0 template (by @dialvarezs)
 - [#1103](https://github.com/nf-core/mag/pull/1103) - Support parameter types (by @dialvarezs)
+- [#1106](https://github.com/nf-core/mag/pull/1106) - Renamed `--skip_adapter_trimming` to `--skip_longread_adapter_trimming` (old name deprecated) and replaced `--skip_deepmased` with `--run_deepmased` (by @dialvarezs)
 
 ### `Fixed`
 

--- a/conf/test_assembly_input.config
+++ b/conf/test_assembly_input.config
@@ -53,7 +53,7 @@ params {
     skip_comebin                    = true
     skip_metabinner                 = true
     skip_ale                        = true
-    skip_deepmased                  = false
+    run_deepmased                   = true
     skip_semibin                    = true
 
     refine_bins_dastool             = true

--- a/conf/test_minimal.config
+++ b/conf/test_minimal.config
@@ -27,7 +27,7 @@ params {
     // Input data
     input                         = params.pipelines_testdata_base_path + 'mag/samplesheets/samplesheet.v4.csv'
     skip_clipping                 = true
-    skip_adapter_trimming         = true
+    skip_longread_adapter_trimming = true
     skip_longread_filtering       = true
     skip_spades                   = true
     skip_spadeshybrid             = true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -590,7 +590,7 @@ When enabled, DeepMAsED performs per-contig assembly error detection on short-re
 
 Useful parameters:
 
-- `--skip_deepmased false` to enable DeepMAsED (it is skipped by default).
+- `--run_deepmased` to enable DeepMAsED (it is not run by default).
 - DeepMAsED prediction is run in CPU-only mode in this pipeline.
 
 ## BIgMAG compatibility

--- a/main.nf
+++ b/main.nf
@@ -53,7 +53,7 @@ params {
 
     // Long read preprocessing options
     skip_longread_adapter_trimming: Boolean
-    // [DEPRECATED] Use `--skip_longread_adapter_trimming` instead. Skip removing adapter sequences from long reads.
+    // [DEPRECATED] Use `--skip_longread_adapter_trimming` instead.
     skip_adapter_trimming: Boolean
     skip_longread_filtering: Boolean
     skip_longread_qc: Boolean

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,8 @@ params {
     skip_fastqc: Boolean
 
     // Long read preprocessing options
-    // TODO: add longread to desambiguate
+    skip_longread_adapter_trimming: Boolean
+    // [DEPRECATED] Use `--skip_longread_adapter_trimming` instead. Skip removing adapter sequences from long reads.
     skip_adapter_trimming: Boolean
     skip_longread_filtering: Boolean
     skip_longread_qc: Boolean
@@ -99,8 +100,7 @@ params {
 
     // Assembly QC and polishing options
     skip_ale: Boolean
-    // TODO: flip this
-    skip_deepmased: Boolean = true
+    run_deepmased: Boolean
     skip_quast: Boolean
     ale_per_base_output: Boolean
     deepmased_features_gzip: Boolean

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -420,9 +420,14 @@
             "description": "",
             "default": "",
             "properties": {
-                "skip_adapter_trimming": {
+                "skip_longread_adapter_trimming": {
                     "type": "boolean",
                     "description": "Skip removing adapter sequences from long reads."
+                },
+                "skip_adapter_trimming": {
+                    "type": "boolean",
+                    "description": "[DEPRECATED] Use `--skip_longread_adapter_trimming` instead. Skip removing adapter sequences from long reads.",
+                    "hidden": true
                 },
                 "skip_longread_filtering": {
                     "type": "boolean",
@@ -646,10 +651,9 @@
                     "type": "boolean",
                     "description": "Skip ALE"
                 },
-                "skip_deepmased": {
+                "run_deepmased": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Skip DeepMAsED assembly error detection (skips both features and predict)"
+                    "description": "Run DeepMAsED assembly error detection (runs both features and predict)"
                 },
                 "deepmased_features_gzip": {
                     "type": "boolean",

--- a/subworkflows/local/preprocessing_longread/main.nf
+++ b/subworkflows/local/preprocessing_longread/main.nf
@@ -33,7 +33,7 @@ workflow LONGREAD_PREPROCESSING {
     ch_versions = ch_versions.mix(NANOPLOT_RAW.out.versions)
 
     if (!params.assembly_input) {
-        if (!params.skip_adapter_trimming && !val_skip_qc) {
+        if (!(params.skip_longread_adapter_trimming || params.skip_adapter_trimming) && !val_skip_qc) {
             ch_long_reads_by_platform = ch_raw_long_reads.branch { meta, _reads ->
                 ont: meta.lr_platform in ['OXFORD_NANOPORE', 'OXFORD_NANOPORE_HQ']
                 pb: meta.lr_platform in ['PACBIO_CLR', 'PACBIO_HIFI']
@@ -131,10 +131,10 @@ workflow LONGREAD_PREPROCESSING {
         /**
          * Conditions for *not* running NANOPLOT_FILTERED:
          * - No host removal and skip_qc (params.skip_longread_qc)
-         * - No host removal and *all* --keep_lambda, --skip_adapter_trimming, --skip_longread_filtering
+         * - No host removal and *all* --keep_lambda, --skip_longread_adapter_trimming, --skip_longread_filtering
          */
         if (!(val_skip_qc && !(params.host_fasta || params.host_genome))) {
-            if (!(params.skip_adapter_trimming && params.skip_longread_filtering && params.keep_lambda && !(params.host_fasta || params.host_genome))) {
+            if (!((params.skip_longread_adapter_trimming || params.skip_adapter_trimming) && params.skip_longread_filtering && params.keep_lambda && !(params.host_fasta || params.host_genome))) {
                 NANOPLOT_FILTERED(ch_long_reads)
                 ch_versions = ch_versions.mix(NANOPLOT_FILTERED.out.versions)
             }

--- a/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mag_pipeline/main.nf
@@ -380,6 +380,10 @@ def validateInputParameters(hybrid) {
         log.warn("[nf-core/mag]: The parameter '--gtdbtk_skip_aniscreen' is deprecated and will be removed in a future release. Please use '--gtdbtk_place_species' instead.")
     }
 
+    if (params.skip_adapter_trimming) {
+        log.warn("[nf-core/mag]: The parameter '--skip_adapter_trimming' is deprecated and will be removed in a future release. Please use '--skip_longread_adapter_trimming' instead.")
+    }
+
     if (params.skip_metaeuk) {
         log.warn("[nf-core/mag]: The parameter '--skip_metaeuk' is deprecated and will be removed in a future release. It no longer has any effect: MetaEuk only runs when '--metaeuk_db' or '--metaeuk_mmseqs_db' is supplied.")
     }
@@ -480,9 +484,10 @@ def toolCitationText() {
     // Note: we don't have a simple way to determine if short or long reads are present, so we add a cite for both Bowtie2 and Minimap2 with a notice to suggest deletion when appropiate.
     def text_mapping = "Read alignment against assemblies was performed with Bowtie2 (Langmead and Salzberg 2012) for short-reads and minimap2 for long-reads (Li 2018) [DELETE AS APPROPRIATE]."
 
+    def skip_longread_adapter_trimming = params.skip_longread_adapter_trimming || params.skip_adapter_trimming
     def longread_qc_tools = [
-        !params.skip_adapter_trimming && params.longread_adaptertrimming_tool == 'porechop' ? "Porechop (Wick et al. 2017)" : "",
-        !params.skip_adapter_trimming && params.longread_adaptertrimming_tool == 'porechop_abi' ? "Porechop ABI (Bonenfant et al. 2022)" : "",
+        !skip_longread_adapter_trimming && params.longread_adaptertrimming_tool == 'porechop' ? "Porechop (Wick et al. 2017)" : "",
+        !skip_longread_adapter_trimming && params.longread_adaptertrimming_tool == 'porechop_abi' ? "Porechop ABI (Bonenfant et al. 2022)" : "",
         !params.skip_longread_filtering && params.longread_filtering_tool == 'filtlong' ? "Filtlong (Wick 2019)" : "",
         !params.skip_longread_filtering && params.longread_filtering_tool == 'nanoq' ? "Nanoq (Steinig et al. 2022)" : "",
         !params.skip_longread_filtering && params.longread_filtering_tool == 'chopper' ? "Chopper (De Coster et al. 2018)" : "",
@@ -503,7 +508,7 @@ def toolCitationText() {
     def assembly_qc_tools = [
         !params.skip_quast ? "metaQUAST (Mikheenko et al. 2016)" : "",
         !params.skip_ale ? "ALE (Clark et al. 2013)" : "",
-        !params.skip_deepmased ? "DeepMAsED (Mineeva et al. 2020)" : "",
+        params.run_deepmased ? "DeepMAsED (Mineeva et al. 2020)" : "",
     ].findAll { tool -> tool != '' }
     def text_assembly_qc = "Assembly quality was assessed with ${assembly_qc_tools.join(', ')}."
 
@@ -593,7 +598,7 @@ def toolBibliographyText() {
         // Note: we don't have a simple way to determine if long reads are present, so we add minimap2 at the same time as Bowtie2
         references << "<li>Li, H. (2018). Minimap2: pairwise alignment for nucleotide sequences. Bioinformatics , 34(18), 3094–3100. doi: 10.1093/bioinformatics/bty191</li>"
     }
-    if (!params.skip_longread_qc && !params.skip_adapter_trimming) {
+    if (!params.skip_longread_qc && !(params.skip_longread_adapter_trimming || params.skip_adapter_trimming)) {
         if (params.longread_adaptertrimming_tool == 'porechop') {
             references << "<li>Wick RR. (2017). Porechop. URL: https://github.com/rrwick/Porechop</li>"
         }
@@ -637,7 +642,7 @@ def toolBibliographyText() {
     if (!params.skip_ale) {
         references << "<li>Clark, S. C., Egan, R., Frazier, P. I., & Wang, Z. (2013). ALE: a generic assembly likelihood evaluation framework for assessing the accuracy of genome and metagenome assemblies. Bioinformatics, 29(4), 435-443. doi: 10.1093/bioinformatics/bts723</li>"
     }
-    if (!params.skip_deepmased) {
+    if (params.run_deepmased) {
         references << "<li>Mineeva, O., Rojas-Carulla, M., Ley, R. E., Schölkopf, B., & Youngblut, N. D. (2020). DeepMAsED: evaluating the quality of metagenomic assemblies. Bioinformatics, 36(10), 3011-3017. doi: 10.1093/bioinformatics/btaa124</li>"
     }
     if (params.run_pypolca) {

--- a/workflows/mag.nf
+++ b/workflows/mag.nf
@@ -294,7 +294,7 @@ workflow MAG {
     ================================================================================
     */
 
-    if (!params.skip_binning || params.ancient_dna || !params.skip_ale || !params.skip_deepmased) {
+    if (!params.skip_binning || params.ancient_dna || !params.skip_ale || params.run_deepmased) {
         BINNING_PREPARATION(
             ch_shortread_assemblies,
             ch_short_reads,
@@ -343,7 +343,7 @@ workflow MAG {
     ================================================================================
     */
 
-    if (!params.skip_deepmased) {
+    if (params.run_deepmased) {
         // DeepMAsED's pre-trained model was only validated on short-read (MEGAHIT/SPAdes) assemblies;
         // long-read (Flye/metaMDBG) and hybrid (SPAdesHybrid) assemblies are excluded, unlike ALE.
         ch_shortread_assemblies_for_deepmased = ch_assemblies.filter { meta, _assembly ->


### PR DESCRIPTION
Resolves the two parameter-naming TODOs left in `main.nf` by the typed-parameters conversion (#1103).

### `--skip_adapter_trimming` → `--skip_longread_adapter_trimming`

The old name was ambiguous, since it only ever applied to long reads. Because it exists in released versions, this is a real deprecation: the old parameter is kept (hidden in the schema, marked `[DEPRECATED]`), still works everywhere via `params.skip_longread_adapter_trimming || params.skip_adapter_trimming`, and emits a warning like the other deprecated parameters (`--gtdbtk_skip_aniscreen`, `--skip_metaeuk`).

### `--skip_deepmased` → `--run_deepmased`

Here no deprecation is needed: DeepMAsED was added in #1051 and only exists on `dev`, never in a release, so no user can have `--skip_deepmased` in a working command. `skip_deepmased` also defaulted to `true`, which is a double negative for an opt-in tool. Renaming to `run_deepmased` (default `false`) preserves the exact same behaviour and matches the `--run_*` convention used by `--run_pypolca`, `--run_busco`, etc.

Also updated: schema, `conf/test_minimal.config`, `conf/test_assembly_input.config`, docs and changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)